### PR TITLE
Function output returns

### DIFF
--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -89,7 +89,7 @@ Functions
 ---------
 ::
 
-    function sum a:int b:int -> int
+    function sum a:int b:int returns int
         x = a + b
         return x
 

--- a/storyscript/parser/grammar.py
+++ b/storyscript/parser/grammar.py
@@ -80,9 +80,8 @@ class Grammar:
         self.ebnf.rule('function_argument', ('ws', 'typed_argument'))
 
     def function_output(self):
-        self.ebnf.token('arrow', 'DASH GREATER', regexp=True, inline=True,
-                        priority=2)
-        self.ebnf.rule('function_output', ('ws', 'arrow', 'ws', 'types'))
+        self.ebnf.token('returns', 'returns', inline=True)
+        self.ebnf.rule('function_output', ('ws', 'returns', 'ws', 'types'))
 
     def function_statement(self):
         self.function_argument()

--- a/tests/integration/parser.py
+++ b/tests/integration/parser.py
@@ -186,7 +186,7 @@ def test_parser_function_arguments(parser):
 
 
 def test_parser_function_output(parser):
-    result = parser.parse('function test n:string -> int\n\tvar = 1\n')
+    result = parser.parse('function test n:string returns int\n\tvar = 1\n')
     statement = result.node('block.function_block.function_statement')
     node = statement.node('function_output.types')
     assert node.child(0) == Token('INT_TYPE', 'int')

--- a/tests/unittests/parser/grammar.py
+++ b/tests/unittests/parser/grammar.py
@@ -105,9 +105,8 @@ def test_grammar_function_argument(patch, grammar, ebnf):
 
 def test_grammar_function_output(grammar, ebnf):
     grammar.function_output()
-    ebnf.token.assert_called_with('arrow', 'DASH GREATER', regexp=True,
-                                  inline=True, priority=2)
-    rule = ('ws', 'arrow', 'ws', 'types')
+    ebnf.token.assert_called_with('returns', 'returns', inline=True)
+    rule = ('ws', 'returns', 'ws', 'types')
     ebnf.rule.assert_called_with('function_output', rule)
 
 


### PR DESCRIPTION
closes #217 

**- What I did**
Functions output use "returns" instead of "->"

**- Description for the changelog**
Functions output use "returns" instead of "->"
