### PR TITLE
Paths and whitespaces in objects

### DIFF
--- a/storyscript/parser/grammar.py
+++ b/storyscript/parser/grammar.py
@@ -167,7 +167,7 @@ class Grammar:
 
     def key_value(self):
         self.ebnf.token('colon', ':', inline=True)
-        self.ebnf.rule('key_value', ('string', 'colon', 'values'))
+        self.ebnf.rule('key_value', 'string _COLON (values|path)', raw=True)
 
     def objects(self):
         self.key_value()

--- a/storyscript/parser/grammar.py
+++ b/storyscript/parser/grammar.py
@@ -167,7 +167,8 @@ class Grammar:
 
     def key_value(self):
         self.ebnf.token('colon', ':', inline=True)
-        self.ebnf.rule('key_value', 'string _COLON (values|path)', raw=True)
+        rule = 'string _COLON _WS? (values|path)'
+        self.ebnf.rule('key_value', rule, raw=True)
 
     def objects(self):
         self.key_value()

--- a/storyscript/parser/grammar.py
+++ b/storyscript/parser/grammar.py
@@ -173,7 +173,7 @@ class Grammar:
     def objects(self):
         self.key_value()
         self.ebnf.tokens(('ocb', '{'), ('ccb', '}'), inline=True)
-        rule = '_OCB (key_value (_COMMA key_value)*)? _CCB'
+        rule = '_OCB (key_value (_COMMA _WS? key_value)*)? _CCB'
         self.ebnf.rule('objects', rule, raw=True)
 
     def values(self):

--- a/tests/unittests/parser/grammar.py
+++ b/tests/unittests/parser/grammar.py
@@ -262,7 +262,7 @@ def test_grammar_list(grammar, ebnf):
 def test_grammar_key_value(grammar, ebnf):
     grammar.key_value()
     ebnf.token.assert_called_with('colon', ':', inline=True)
-    rule = 'string _COLON (values|path)'
+    rule = 'string _COLON _WS? (values|path)'
     ebnf.rule.assert_called_with('key_value', rule, raw=True)
 
 

--- a/tests/unittests/parser/grammar.py
+++ b/tests/unittests/parser/grammar.py
@@ -271,7 +271,7 @@ def test_grammar_objects(patch, grammar, ebnf):
     grammar.objects()
     assert Grammar.key_value.call_count == 1
     ebnf.tokens.assert_called_with(('ocb', '{'), ('ccb', '}'), inline=True)
-    rule = '_OCB (key_value (_COMMA key_value)*)? _CCB'
+    rule = '_OCB (key_value (_COMMA _WS? key_value)*)? _CCB'
     ebnf.rule.assert_called_with('objects', rule, raw=True)
 
 

--- a/tests/unittests/parser/grammar.py
+++ b/tests/unittests/parser/grammar.py
@@ -262,7 +262,8 @@ def test_grammar_list(grammar, ebnf):
 def test_grammar_key_value(grammar, ebnf):
     grammar.key_value()
     ebnf.token.assert_called_with('colon', ':', inline=True)
-    ebnf.rule.assert_called_with('key_value', ('string', 'colon', 'values'))
+    rule = 'string _COLON (values|path)'
+    ebnf.rule.assert_called_with('key_value', rule, raw=True)
 
 
 def test_grammar_objects(patch, grammar, ebnf):


### PR DESCRIPTION
closes #267, closes #268

**- What I did**
Objects support paths as values and allow whitespace after column and  comma

**- Description for the changelog**
Objects support paths as values and allow whitespace after column and  comma
