### PR TITLE
fix(story): Story.modules appends '.story' when missing

### DIFF
--- a/storyscript/story.py
+++ b/storyscript/story.py
@@ -46,7 +46,10 @@ class Story:
         """
         modules = []
         for module in self.tree.find_data('imports'):
-            modules.append(module.string.child(0).value[1:-1])
+            path = module.string.child(0).value[1:-1]
+            if path.endswith('.story') is False:
+                path = '{}.story'.format(path)
+            modules.append(path)
         return modules
 
     def compile(self, debug=False):

--- a/tests/unittests/story.py
+++ b/tests/unittests/story.py
@@ -94,6 +94,15 @@ def test_story_modules(magic, story):
     assert result == [import_tree.string.child().value[1:-1]]
 
 
+def test_story_modules_no_extension(magic, story):
+    import_tree = magic()
+    import_tree.string.child.return_value = magic(value='"hello"')
+    story.tree = magic()
+    story.tree.find_data.return_value = [import_tree]
+    result = story.modules()
+    assert result == ['hello.story']
+
+
 def test_story_debug(patch, story):
     patch.init(Parser)
     patch.object(Parser, 'parse')


### PR DESCRIPTION
closes #277 

**- What I did**
Imports declared without '.story' are compiled correctly

**- Description for the changelog**
Imports declared without '.story' are compiled correctly
