### PR TITLE
 Spaces between an arg name and an inline expression

### DIFF
--- a/storyscript/parser/grammar.py
+++ b/storyscript/parser/grammar.py
@@ -101,7 +101,7 @@ class Grammar:
 
     def arguments(self):
         self.inline_expression()
-        rule = '_WS? NAME? _COLON (values|path|inline_expression)'
+        rule = '_WS? NAME? _COLON _WS? (values|path|inline_expression)'
         self.ebnf.rule('arguments', rule, raw=True)
 
     def command(self):

--- a/tests/unittests/parser/grammar.py
+++ b/tests/unittests/parser/grammar.py
@@ -131,7 +131,7 @@ def test_grammar_arguments(patch, grammar, ebnf):
     patch.object(Grammar, 'inline_expression')
     grammar.arguments()
     assert Grammar.inline_expression.call_count == 1
-    rule = '_WS? NAME? _COLON (values|path|inline_expression)'
+    rule = '_WS? NAME? _COLON _WS? (values|path|inline_expression)'
     ebnf.rule.assert_called_with('arguments', rule, raw=True)
 
 


### PR DESCRIPTION
closes #273

**- What I did**
Allow whitespace between column and value in services

**- Description for the changelog**
Allow whitespace between column and value in services

