### PR TITLE
Mutations miscompiled as services

### DIFF
--- a/docs/compiler.rst
+++ b/docs/compiler.rst
@@ -201,31 +201,6 @@ to declare arguments:
     }
 
 
-Method
-######
-Method objects is used when it's not possible to compile a tree that would
-normally be a line as a proper line. For example, in `x = alpine echo`
-the `alpine echo` bit would be compiled as method object::
-
-
-    {
-      "$OBJECT": "method",
-      "method": "execute",
-      "service": "alpine",
-      "output": null,
-      "args": [
-        {
-          "$OBJECT": "argument",
-          "name": "pizza",
-          "argument": {
-            "$OBJECT": "string",
-            "string": "please"
-          }
-        }
-      ],
-      "command": "echo"
-    }
-
 Methods
 -------
 

--- a/docs/compiler.rst
+++ b/docs/compiler.rst
@@ -201,17 +201,48 @@ to declare arguments:
     }
 
 
+Mutation
+########
+Mutation objects are used for mutations on values, and are found only as
+arguments in expression methods. They are always preceded by another object,
+that can be any kind of value or a path::
+
+    {
+      "$OBJECT": "string",
+      "string": "hello"
+    },
+    {
+      "$OBJECT": "mutation",
+      "mutation": "uppercase",
+      "arguments": []
+    }
+
+
+Mutations arguments follow the same syntax for service arguments and can be
+found in the arguments list::
+
+    {
+      "$OBJECT": "mutation",
+      "mutation": "slice",
+      "arguments": [
+        {
+          "$OBJECT": "argument",
+          "name": "at",
+          "argument": 2
+        }
+      ]
+    }
+
 Methods
 -------
 
 Expression
 ##########
-Used for expression lines, like sums, multiplications and so on. For example,
-the line::
+Used for expression lines, like sums, multiplications and so on. For example::
 
     1 + 1
 
-Should produce the following tree::
+Compiles to::
 
     {
         "method": "expression",

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -71,10 +71,17 @@ class Compiler:
         Compiles an assignment tree
         """
         name = Objects.names(tree.path)
-        if tree.assignment_fragment.service:
-            self.service(tree.assignment_fragment.service, None, parent)
-            self.lines.set_name(name)
-            return
+        service = tree.assignment_fragment.service
+        if service:
+            path = Objects.names(service.path)
+            if path not in self.lines.variables:
+                self.service(service, None, parent)
+                self.lines.set_name(name)
+                return
+            else:
+                self.expression(service, parent)
+                self.lines.set_name(name)
+                return
         line = tree.line()
         args = self.extract_values(tree.assignment_fragment)
         self.lines.append('set', line, name=name, args=args, parent=parent)

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -34,6 +34,14 @@ class Compiler:
         module = tree.child(1).value
         self.lines.modules[module] = tree.string.child(0).value[1:-1]
 
+    def expression(self, tree, parent):
+        """
+        Compiles an expression
+        """
+        mutation = Objects.mutation(tree.service_fragment.command)
+        args = [Objects.path(tree.path), mutation]
+        self.lines.append('expression', tree.line(), args=args, parent=parent)
+
     def absolute_expression(self, tree, parent):
         """
         Compiles an absolute expression

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -38,7 +38,7 @@ class Compiler:
         """
         Compiles an expression
         """
-        mutation = Objects.mutation(tree.service_fragment.command)
+        mutation = Objects.mutation(tree.service_fragment)
         args = [Objects.path(tree.path), mutation]
         self.lines.append('expression', tree.line(), args=args, parent=parent)
 

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -38,21 +38,26 @@ class Compiler:
         """
         Compiles an expression
         """
-        mutation = Objects.mutation(tree.service_fragment)
-        args = [Objects.path(tree.path), mutation]
+        mutation = None
+        if tree.expression:
+            if tree.expression.mutation:
+                value = Objects.values(tree.expression.values)
+                mutation = Objects.mutation(tree.expression.mutation)
+            else:
+                value = Objects.expression(tree.expression)
+        elif tree.service_fragment:
+            value = Objects.path(tree.path)
+            mutation = Objects.mutation(tree.service_fragment)
+        args = [value]
+        if mutation:
+            args.append(mutation)
         self.lines.append('expression', tree.line(), args=args, parent=parent)
 
     def absolute_expression(self, tree, parent):
         """
-        Compiles an absolute expression
+        Compiles an absolute expression using Compiler.expression
         """
-        mutation = tree.expression.mutation
-        if mutation:
-            args = [Objects.values(tree.expression.values),
-                    Objects.mutation(mutation)]
-        else:
-            args = [Objects.expression(tree.expression)]
-        self.lines.append('expression', tree.line(), args=args, parent=parent)
+        self.expression(tree, parent)
 
     def extract_values(self, fragment):
         """

--- a/storyscript/compiler/lines.py
+++ b/storyscript/compiler/lines.py
@@ -8,6 +8,7 @@ class Lines:
     """
     def __init__(self):
         self.lines = {}
+        self.variables = []
         self.services = []
         self.functions = {}
         self.outputs = {}
@@ -111,6 +112,8 @@ class Lines:
 
         if method == 'function':
             self.functions[kwargs['function']] = line
+        elif method == 'set':
+            self.variables.append(kwargs['name'])
         elif method == 'execute':
             if self.is_output(kwargs['parent'], kwargs['service']) is False:
                 self.services.append(kwargs['service'])

--- a/storyscript/compiler/objects.py
+++ b/storyscript/compiler/objects.py
@@ -106,23 +106,6 @@ class Objects:
         return {'$OBJECT': 'type', 'type': tree.child(0).value}
 
     @classmethod
-    def method(cls, tree):
-        """
-        Produces a method object. This is used when it's not possible to
-        compile something that would normally be a line as a line.
-        For example, in `x = alpine echo` the `alpine echo` bit would be
-        compiled as method object.
-        """
-        service = tree.child(0).child(0).value
-        args = cls.arguments(tree.node('service_fragment'))
-        object = {'$OBJECT': 'method', 'method': 'execute', 'service': service,
-                  'output': None, 'args': args}
-        command = tree.node('service_fragment.command')
-        if command:
-            object['command'] = command.child(0).value
-        return object
-
-    @classmethod
     def values(cls, tree):
         """
         Parses a values subtree
@@ -141,11 +124,6 @@ class Objects:
                 return cls.objects(subtree)
             elif subtree.data == 'types':
                 return cls.types(subtree)
-            elif subtree.data == 'path':
-                # NOTE(vesuvium): path trees are sent to Objects.values only
-                # when they are in a service tree. Objects.method however takes
-                # the whole tree.
-                return cls.method(tree)
         if subtree.type == 'NAME':
             return cls.path(tree)
 

--- a/storyscript/compiler/objects.py
+++ b/storyscript/compiler/objects.py
@@ -32,12 +32,16 @@ class Objects:
     @classmethod
     def mutation(cls, tree):
         """
-        Compiles a mutation tree.
+        Compiles a mutation object, either from a mutation or a
+        service_fragment tree.
         """
+        mutation = tree.child(0).value
         arguments = []
         if tree.arguments:
             arguments = cls.arguments(tree.arguments)
-        return {'$OBJECT': 'mutation', 'mutation': tree.child(0).value,
+        if tree.command:
+            mutation = tree.command.child(0).value
+        return {'$OBJECT': 'mutation', 'mutation': mutation,
                 'arguments': arguments}
 
     @staticmethod

--- a/storyscript/compiler/objects.py
+++ b/storyscript/compiler/objects.py
@@ -81,10 +81,6 @@ class Objects:
             return True
         return False
 
-    @staticmethod
-    def file(token):
-        return {'$OBJECT': 'file', 'string': token.value[1:-1]}
-
     @classmethod
     def list(cls, tree):
         items = []
@@ -150,9 +146,7 @@ class Objects:
                 # when they are in a service tree. Objects.method however takes
                 # the whole tree.
                 return cls.method(tree)
-        if subtree.type == 'FILEPATH':
-            return cls.file(subtree)
-        elif subtree.type == 'NAME':
+        if subtree.type == 'NAME':
             return cls.path(tree)
 
     @classmethod

--- a/storyscript/compiler/preprocessor.py
+++ b/storyscript/compiler/preprocessor.py
@@ -35,7 +35,7 @@ class Preprocessor:
         """
         fake_tree = cls.fake_tree(block)
         for argument in service.find_data('arguments'):
-            expression = argument.values.inline_expression
+            expression = argument.node('values.inline_expression')
             if expression:
                 cls.replace_expression(fake_tree, argument, expression)
 

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -52,7 +52,11 @@ def test_compiler_imports(patch, compiler, lines, tree):
 
 
 def test_compiler_expression(patch, compiler, lines, tree):
+    """
+    Ensures that expressions are compiled correctly
+    """
     patch.many(Objects, ['mutation', 'path'])
+    tree.expression = None
     compiler.expression(tree, '1')
     Objects.mutation.assert_called_with(tree.service_fragment)
     Objects.path.assert_called_with(tree.path)
@@ -61,23 +65,36 @@ def test_compiler_expression(patch, compiler, lines, tree):
                                     parent='1')
 
 
-def test_compiler_absolute_expression(patch, compiler, lines, tree):
+def test_compiler_expression_absolute(patch, compiler, lines, tree):
+    """
+    Ensures that absolute expressions are compiled correctly
+    """
     patch.object(Objects, 'expression')
     tree.expression.mutation = None
-    compiler.absolute_expression(tree, '1')
+    compiler.expression(tree, '1')
     Objects.expression.assert_called_with(tree.expression)
-    lines.append.assert_called_with('expression', tree.line(),
-                                    args=[Objects.expression()], parent='1')
+    args = [Objects.expression()]
+    lines.append.assert_called_with('expression', tree.line(), args=args,
+                                    parent='1')
 
 
-def test_compiler_absolute_expression_mutation(patch, compiler, lines, tree):
+def test_compiler_expression_absolute_mutation(patch, compiler, lines, tree):
+    """
+    Ensures that absolute expressions with mutations are compiled correctly
+    """
     patch.many(Objects, ['mutation', 'values'])
-    compiler.absolute_expression(tree, '1')
+    compiler.expression(tree, '1')
     Objects.mutation.assert_called_with(tree.expression.mutation)
     Objects.values.assert_called_with(tree.expression.values)
     args = [Objects.values(), Objects.mutation()]
     lines.append.assert_called_with('expression', tree.line(), args=args,
                                     parent='1')
+
+
+def test_compiler_absolute_expression(patch, compiler, lines, tree):
+    patch.object(Compiler, 'expression')
+    compiler.absolute_expression(tree, '1')
+    Compiler.expression.assert_called_with(tree, '1')
 
 
 def test_compiler_extract_values(patch, compiler, tree):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -54,7 +54,7 @@ def test_compiler_imports(patch, compiler, lines, tree):
 def test_compiler_expression(patch, compiler, lines, tree):
     patch.many(Objects, ['mutation', 'path'])
     compiler.expression(tree, '1')
-    Objects.mutation.assert_called_with(tree.service_fragment.command)
+    Objects.mutation.assert_called_with(tree.service_fragment)
     Objects.path.assert_called_with(tree.path)
     args = [Objects.path(), Objects.mutation()]
     lines.append.assert_called_with('expression', tree.line(), args=args,

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -129,6 +129,21 @@ def test_compiler_assignment_service(patch, compiler, lines, tree):
     lines.set_name.assert_called_with(Objects.names())
 
 
+def test_compiler_assignment_expression(patch, compiler, lines, tree):
+    """
+    Ensures that assignments like 'x = a mutation' are compiled correctly.
+    This works by checking that 'a' was infact previously assigned, thus
+    it's not a service but a variable.
+    """
+    patch.object(Objects, 'names', return_value='name')
+    patch.object(Compiler, 'expression')
+    lines.variables = ['name']
+    compiler.assignment(tree, '1')
+    service = tree.assignment_fragment.service
+    Compiler.expression.assert_called_with(service, '1')
+    lines.set_name.assert_called_with(Objects.names())
+
+
 def test_compiler_arguments(patch, compiler, lines, tree):
     patch.object(Objects, 'arguments')
     lines.last.return_value = '1'

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -51,6 +51,16 @@ def test_compiler_imports(patch, compiler, lines, tree):
     assert lines.modules[module] == tree.string.child(0).value[1:-1]
 
 
+def test_compiler_expression(patch, compiler, lines, tree):
+    patch.many(Objects, ['mutation', 'path'])
+    compiler.expression(tree, '1')
+    Objects.mutation.assert_called_with(tree.service_fragment.command)
+    Objects.path.assert_called_with(tree.path)
+    args = [Objects.path(), Objects.mutation()]
+    lines.append.assert_called_with('expression', tree.line(), args=args,
+                                    parent='1')
+
+
 def test_compiler_absolute_expression(patch, compiler, lines, tree):
     patch.object(Objects, 'expression')
     tree.expression.mutation = None

--- a/tests/unittests/compiler/lines.py
+++ b/tests/unittests/compiler/lines.py
@@ -12,6 +12,7 @@ def lines():
 
 def test_lines_init(lines):
     assert lines.lines == {}
+    assert lines.variables == []
     assert lines.services == []
     assert lines.functions == {}
     assert lines.outputs == {}
@@ -134,6 +135,15 @@ def test_lines_append_function(patch, lines):
     patch.many(Lines, ['make', 'set_next'])
     lines.append('function', 'line', function='function')
     assert lines.functions['function'] == 'line'
+
+
+def test_lines_append_set(patch, lines):
+    """
+    Ensures that a variable is registered properly
+    """
+    patch.many(Lines, ['make', 'set_next'])
+    lines.append('set', 'line', name=['name'])
+    assert lines.variables[-1] == ['name']
 
 
 def test_compiler_append_service(patch, lines):

--- a/tests/unittests/compiler/objects.py
+++ b/tests/unittests/compiler/objects.py
@@ -152,17 +152,6 @@ def test_objects_types(tree):
     assert Objects.types(tree) == {'$OBJECT': 'type', 'type': token.value}
 
 
-def test_objects_method(patch, tree):
-    patch.object(Objects, 'arguments')
-    result = Objects.method(tree)
-    Objects.arguments.assert_called_with(tree.node())
-    expected = {'$OBJECT': 'method', 'method': 'execute',
-                'service': tree.child().child().value,
-                'command': tree.node().child().value,
-                'output': None, 'args': Objects.arguments()}
-    assert result == expected
-
-
 @mark.parametrize('value_type', [
     'string', 'boolean', 'list', 'number', 'objects', 'types'
 ])
@@ -173,15 +162,6 @@ def test_objects_values(patch, magic, value_type):
     result = Objects.values(tree)
     getattr(Objects, value_type).assert_called_with(item)
     assert result == getattr(Objects, value_type)()
-
-
-def test_objects_values_method(patch, magic):
-    patch.object(Objects, 'method')
-    item = magic(data='path')
-    tree = magic(child=lambda x: item)
-    result = Objects.values(tree)
-    Objects.method.assert_called_with(tree)
-    assert result == Objects.method()
 
 
 def test_objects_values_path(patch, magic):

--- a/tests/unittests/compiler/objects.py
+++ b/tests/unittests/compiler/objects.py
@@ -116,11 +116,6 @@ def test_objects_boolean_false():
     assert Objects.boolean(tree) is False
 
 
-def test_objects_file():
-    token = Token('FILEPATH', '`path`')
-    assert Objects.file(token) == {'$OBJECT': 'file', 'string': 'path'}
-
-
 def test_objects_list(patch, tree):
     patch.object(Objects, 'values')
     tree.children = ['value']
@@ -187,15 +182,6 @@ def test_objects_values_method(patch, magic):
     result = Objects.values(tree)
     Objects.method.assert_called_with(tree)
     assert result == Objects.method()
-
-
-def test_objects_values_filepath(patch, magic):
-    patch.object(Objects, 'file')
-    item = magic(type='FILEPATH')
-    tree = magic(child=lambda x: item)
-    result = Objects.values(tree)
-    Objects.file.assert_called_with(item)
-    assert result == Objects.file()
 
 
 def test_objects_values_path(patch, magic):

--- a/tests/unittests/compiler/objects.py
+++ b/tests/unittests/compiler/objects.py
@@ -61,6 +61,16 @@ def test_objects_mutation(token):
     assert Objects.mutation(tree) == expected
 
 
+def test_objects_mutation_from_service(token):
+    """
+    Ensures that mutations objects from service trees are compiled correctly.
+    """
+    tree = Tree('service_fragment', [Tree('command', [token])])
+    expected = {'$OBJECT': 'mutation', 'mutation': token.value,
+                'arguments': []}
+    assert Objects.mutation(tree) == expected
+
+
 def test_objects_mutation_arguments(patch, magic):
     """
     Ensures that mutations objects with arguments are compiled correctly.

--- a/tests/unittests/compiler/objects.py
+++ b/tests/unittests/compiler/objects.py
@@ -52,13 +52,19 @@ def test_objects_path(patch):
 
 
 def test_objects_mutation(token):
+    """
+    Ensures that mutations objects are compiled correctly.
+    """
     tree = Tree('mutation', [token])
     expected = {'$OBJECT': 'mutation', 'mutation': token.value,
                 'arguments': []}
     assert Objects.mutation(tree) == expected
 
 
-def test_objects_mutation_argument(patch, magic):
+def test_objects_mutation_arguments(patch, magic):
+    """
+    Ensures that mutations objects with arguments are compiled correctly.
+    """
     patch.object(Objects, 'arguments')
     tree = magic()
     result = Objects.mutation(tree)

--- a/tests/unittests/compiler/preprocessor.py
+++ b/tests/unittests/compiler/preprocessor.py
@@ -29,8 +29,8 @@ def test_preprocessor_service_arguments(patch, magic, tree):
     Preprocessor.service_arguments('block', tree)
     Preprocessor.fake_tree.assert_called_with('block')
     tree.find_data.assert_called_with('arguments')
-    args = (Preprocessor.fake_tree(), argument,
-            argument.values.inline_expression)
+    argument.node.assert_called_with('values.inline_expression')
+    args = (Preprocessor.fake_tree(), argument, argument.node())
     Preprocessor.replace_expression.assert_called_with(*args)
 
 


### PR DESCRIPTION
closes #274 

**- What I did**
The compiler now registers used variables and checks that whether a service tree is a mutation on a variable or a regular service call