### PR TITLE
Fix return empty list

### DIFF
--- a/storyscript/compiler/objects.py
+++ b/storyscript/compiler/objects.py
@@ -95,7 +95,8 @@ class Objects:
     def list(cls, tree):
         items = []
         for value in tree.children:
-            items.append(cls.values(value))
+            if isinstance(value, Tree):
+                items.append(cls.values(value))
         return {'$OBJECT': 'list', 'items': items}
 
     @classmethod

--- a/storyscript/parser/grammar.py
+++ b/storyscript/parser/grammar.py
@@ -162,7 +162,7 @@ class Grammar:
                          inline=True)
         definition = ('_OSB (_NL _INDENT)? (values (_COMMA (_WS|_NL)? '
                       'values)*)? (_NL _DEDENT)? _CSB')
-        self.ebnf.rule('list', definition, raw=True)
+        self.ebnf.rule('!list', definition, raw=True)
 
     def key_value(self):
         self.ebnf.token('colon', ':', inline=True)

--- a/tests/integration/compiler.py
+++ b/tests/integration/compiler.py
@@ -86,12 +86,33 @@ def test_compiler_foreach_key_value(parser):
 
 def test_compiler_set(parser):
     """
-    Ensures that assignments are compiled correctly
+    Ensures that assignments to integers are compiled correctly
     """
     tree = parser.parse('a = 0')
     result = Compiler.compile(tree)
     assert result['tree']['1']['method'] == 'set'
     assert result['tree']['1']['args'] == [0]
+
+
+def test_compiler_set_list(parser):
+    """
+    Ensures that assignments to lists are compiled correctly
+    """
+    tree = parser.parse('a = [1, 2]')
+    result = Compiler.compile(tree)
+    args = [{'$OBJECT': 'list', 'items': [1, 2]}]
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['args'] == args
+
+
+def test_compiler_set_empty(parser):
+    """
+    Ensures that assignments to empty lists are compiled correctly
+    """
+    tree = parser.parse('a = []')
+    result = Compiler.compile(tree)
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['args'] == [{'$OBJECT': 'list', 'items': []}]
 
 
 def test_compiler_set_service(parser):

--- a/tests/integration/parser.py
+++ b/tests/integration/parser.py
@@ -59,12 +59,13 @@ def test_parser_list(parser, int_token):
     result = parser.parse('[3,4]\n')
     list = result.block.rules.values.list
     assert list.values.number.child(0) == int_token
-    assert list.child(1).number.child(0) == Token('INT', 4)
+    assert list.child(3).number.child(0) == Token('INT', 4)
 
 
 def test_parser_list_empty(parser):
     result = parser.parse('[]\n')
-    assert result.block.rules.values.list == Tree('list', [])
+    expected = Tree('list', [Token('_OSB', '['), Token('_CSB', ']')])
+    assert result.block.rules.values.list == expected
 
 
 def test_parser_object(parser):

--- a/tests/unittests/compiler/objects.py
+++ b/tests/unittests/compiler/objects.py
@@ -148,9 +148,9 @@ def test_objects_boolean_false():
 
 def test_objects_list(patch, tree):
     patch.object(Objects, 'values')
-    tree.children = ['value']
+    tree.children = [Tree('value', 'value'), 'token']
     result = Objects.list(tree)
-    Objects.values.assert_called_with('value')
+    Objects.values.assert_called_with(Tree('value', 'value'))
     assert result == {'$OBJECT': 'list', 'items': [Objects.values()]}
 
 

--- a/tests/unittests/parser/grammar.py
+++ b/tests/unittests/parser/grammar.py
@@ -256,7 +256,7 @@ def test_grammar_list(grammar, ebnf):
     ebnf.tokens.assert_called_with(*tokens, inline=True)
     definition = ('_OSB (_NL _INDENT)? (values (_COMMA (_WS|_NL)? '
                   'values)*)? (_NL _DEDENT)? _CSB')
-    ebnf.rule.assert_called_with('list', definition, raw=True)
+    ebnf.rule.assert_called_with('!list', definition, raw=True)
 
 
 def test_grammar_key_value(grammar, ebnf):


### PR DESCRIPTION
closes #298 

**- What I did**
Fix empty list compilation by setting Grammar.list to not drop inlined tokens

**- Description for the changelog**
Fix empty list compilation
