### PR TITLE
Fix escape sequences

### DIFF
--- a/storyscript/compiler/objects.py
+++ b/storyscript/compiler/objects.py
@@ -55,9 +55,9 @@ class Objects:
         return int(token.value)
 
     @staticmethod
-    def replace_placeholders(string, matches):
+    def replace_fillers(string, matches):
         """
-        Replaces placeholder values with '{}'
+        Replaces filler values with '{}'
         """
         for match in matches:
             placeholder = '{}{}{}'.format('{', match, '}')

--- a/storyscript/compiler/objects.py
+++ b/storyscript/compiler/objects.py
@@ -65,7 +65,7 @@ class Objects:
         return string
 
     @classmethod
-    def placeholders_values(cls, matches):
+    def fillers_values(cls, matches):
         values = []
         for match in matches:
             values.append(cls.path(Tree('path', [Token('WORD', match)])))

--- a/storyscript/compiler/objects.py
+++ b/storyscript/compiler/objects.py
@@ -71,18 +71,27 @@ class Objects:
             values.append(cls.path(Tree('path', [Token('WORD', match)])))
         return values
 
+    @staticmethod
+    def unescape_string(tree):
+        """
+        Unescapes a string tree, returning the real string.
+        """
+        string = tree.child(0).value[1:-1]
+        unescaped = string.encode('utf-8').decode('unicode_escape')
+        return unescaped.encode('latin1').decode()
+
     @classmethod
     def string(cls, tree):
         """
         Compiles a string tree. If the string has templated values, they
         are processed and compiled.
         """
-        item = {'$OBJECT': 'string', 'string': tree.child(0).value[1:-1]}
+        item = {'$OBJECT': 'string', 'string': cls.unescape_string(tree)}
         matches = re.findall(r'{([^}]*)}', item['string'])
         if matches == []:
             return item
-        item['values'] = cls.placeholders_values(matches)
-        item['string'] = cls.replace_placeholders(item['string'], matches)
+        item['values'] = cls.fillers_values(matches)
+        item['string'] = cls.replace_fillers(item['string'], matches)
         return item
 
     @staticmethod

--- a/tests/unittests/compiler/objects.py
+++ b/tests/unittests/compiler/objects.py
@@ -112,9 +112,9 @@ def test_objects_replace_fillers():
     assert result == 'hello, {}'
 
 
-def test_objects_placeholders_values(patch):
+def test_objects_fillers_values(patch):
     patch.object(Objects, 'path')
-    result = Objects.placeholders_values(['one'])
+    result = Objects.fillers_values(['one'])
     Objects.path.assert_called_with(Tree('path', [Token('WORD', 'one')]))
     assert result == [Objects.path()]
 

--- a/tests/unittests/compiler/objects.py
+++ b/tests/unittests/compiler/objects.py
@@ -107,8 +107,8 @@ def test_objects_number_float():
     assert Objects.number(tree) == 1.2
 
 
-def test_objects_replace_placeholders():
-    result = Objects.replace_placeholders('hello, {world}', ['world'])
+def test_objects_replace_fillers():
+    result = Objects.replace_fillers('hello, {world}', ['world'])
     assert result == 'hello, {}'
 
 


### PR DESCRIPTION
closes #290

**- What I did**
Unescape Python-escaped sequences when compiling string objects

**- Description for the changelog**
Unescape Python-escaped sequences when compiling string objects
