### PR TITLE
Fix multiline comments

### DIFF
--- a/storyscript/Story.py
+++ b/storyscript/Story.py
@@ -21,12 +21,18 @@ class Story:
         self.path = path
 
     @staticmethod
-    def clean_source(source):
+    def remove_comments(source):
         """
-        Cleans a story by removing comments.
+        Removes inline comments from source.
         """
-        expression = r'(?<=###)\s(.*|\\n)+(?=\s###)|#(.*)'
-        return re.sub(expression, '', source)
+        return re.sub(r'#[^#\n]+', '', source)
+
+    @classmethod
+    def clean_source(cls, source):
+        """
+        Cleans a story by removing all comments.
+        """
+        return re.sub(r'###[^#]+###', '', cls.remove_comments(source))
 
     @classmethod
     def read(cls, path):

--- a/storyscript/Story.py
+++ b/storyscript/Story.py
@@ -48,12 +48,12 @@ class Story:
         """
         return Story(cls.read(path), path=path)
 
-    @staticmethod
-    def from_stream(stream):
+    @classmethod
+    def from_stream(cls, stream):
         """
         Creates a story from a stream source
         """
-        return Story(stream.read())
+        return Story(cls.clean_source(stream.read()))
 
     def error(self, error, debug=False):
         """

--- a/tests/integration/Story.py
+++ b/tests/integration/Story.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from io import StringIO
+
+from storyscript.Story import Story
+
+
+def test_story_from_stream():
+    stream = StringIO('x = 0')
+    story = Story.from_stream(stream)
+    assert story.story == 'x = 0'
+
+
+def test_story_comments():
+    stream = StringIO('# comment')
+    story = Story.from_stream(stream)
+    assert story.story == ''
+
+
+def test_story_comments_indented():
+    stream = StringIO('function test\n\t# comment\n\tx = 0')
+    story = Story.from_stream(stream)
+    assert story.story == 'function test\n\t\n\tx = 0'
+
+
+def test_story_comments_multiline():
+    stream = StringIO('###\nmultiline\n###')
+    story = Story.from_stream(stream)
+    assert story.story == ''
+
+
+def test_story_comments_multiline_idented():
+    stream = StringIO('function test\n\t###\nmultiline\n\t###\n\tx = 0')
+    story = Story.from_stream(stream)
+    assert story.story == 'function test\n\t\n\tx = 0'
+
+
+def test_story_comments_multiline_catastrophic():
+    """
+    Certain regular expressions will work correctly on short comments, but
+    fail on longer ones because of backtracking.
+    """
+    stream = StringIO('###\nFiller filler filler filler\n\n###\nx = 0')
+    story = Story.from_stream(stream)
+    assert story.story == '\nx = 0'
+
+
+def test_story_comments_nested():
+    stream = StringIO('###\nmultiline\n# nested\n###')
+    story = Story.from_stream(stream)
+    assert story.story == ''

--- a/tests/unittests/Story.py
+++ b/tests/unittests/Story.py
@@ -83,9 +83,11 @@ def test_story_from_file(patch):
 
 def test_story_from_stream(patch, magic):
     patch.init(Story)
+    patch.object(Story, 'clean_source')
     stream = magic()
     result = Story.from_stream(stream)
-    Story.__init__.assert_called_with(stream.read())
+    Story.clean_source.assert_called_with(stream.read())
+    Story.__init__.assert_called_with(Story.clean_source())
     assert isinstance(result, Story)
 
 

--- a/tests/unittests/Story.py
+++ b/tests/unittests/Story.py
@@ -40,14 +40,24 @@ def test_story_init_path():
     assert story.path == 'path'
 
 
+def test_story_remove_comments(patch):
+    """
+    Ensures that remove_comments can remove inline comments.
+    """
+    patch.object(re, 'sub')
+    result = Story.remove_comments('source')
+    re.sub.assert_called_with(r'#[^#\n]+', '', 'source')
+    assert result == re.sub()
+
+
 def test_story_clean_source(patch):
     """
     Ensures that a story is cleaned correctly
     """
     patch.object(re, 'sub')
+    patch.object(Story, 'remove_comments')
     result = Story.clean_source('source')
-    expression = r'(?<=###)\s(.*|\\n)+(?=\s###)|#(.*)'
-    re.sub.assert_called_with(expression, '', 'source')
+    re.sub.assert_called_with(r'###[^#]+###', '', Story.remove_comments())
     assert result == re.sub()
 
 


### PR DESCRIPTION
closes #369 

**- What I did**
Change the regular expression that strips comments to a backtracking-free one
