### PR TITLE
fix(grammar): allow functions without arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ jobs:
             - image: circleci/python:3.6.1
         steps:
             - checkout
-            - restore_cache:
-                keys:
-                    - v1-dependencies-{{ checksum "setup.py" }}
-                    - v1-dependencies-
+            #- restore_cache:
+                #keys:
+                    #- v1-dependencies-{{ checksum "setup.py" }}
+                    #- v1-dependencies-
 
             - run:
                 name: install dependencies
@@ -19,10 +19,10 @@ jobs:
                     python3 setup.py install
                     pip install tox
 
-            - save_cache:
-                paths:
-                    - ./venv
-                key: v1-dependencies-{{ checksum "setup.py" }}
+            #- save_cache:
+                #paths:
+                    #- ./venv
+                #key: v1-dependencies-{{ checksum "setup.py" }}
 
             - run:
                 name: run unit tests

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -34,7 +34,7 @@ class Compiler:
                 return [Objects.values(fragment.expression.values),
                         Objects.mutation(fragment.expression.mutation)]
             return [Objects.expression(fragment.expression)]
-        return [Objects.entity(fragment.child(1))]
+        return [Objects.values(fragment.child(1))]
 
     @classmethod
     def function_output(cls, tree):
@@ -160,7 +160,7 @@ class Compiler:
         if parent is None:
             raise CompilerError('return_outside', tree=tree)
         line = tree.line()
-        args = [Objects.entity(tree.child(0))]
+        args = [Objects.values(tree.child(0))]
         self.lines.append('return', line, args=args, parent=parent)
 
     def if_block(self, tree, parent):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -122,12 +122,18 @@ class Compiler:
             self.expression(tree, parent)
             return
         line = tree.line()
-        command = tree.service_fragment.command
+        command = None
+        if tree.service_fragment:
+            command = tree.service_fragment.command
         if command:
             command = command.child(0)
-        arguments = Objects.arguments(tree.service_fragment)
+        arguments = []
+        if tree.service_fragment:
+            arguments = Objects.arguments(tree.service_fragment)
         service = tree.path.extract_path()
-        output = self.output(tree.service_fragment.output)
+        output = []
+        if tree.service_fragment:
+            output = self.output(tree.service_fragment.output)
         if output:
             self.lines.set_output(line, output)
         enter = None

--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -118,7 +118,7 @@ class Objects:
         items = []
         for value in tree.children:
             if isinstance(value, Tree):
-                items.append(cls.entity(value))
+                items.append(cls.values(value))
         return {'$OBJECT': 'list', 'items': items}
 
     @classmethod
@@ -130,7 +130,7 @@ class Objects:
                 key = cls.string(child)
             elif child.data == 'path':
                 key = cls.path(child)
-            value = cls.entity(item.child(1))
+            value = cls.values(item.child(1))
             items.append([key, value])
         return {'$OBJECT': 'dict', 'items': items}
 
@@ -148,10 +148,6 @@ class Objects:
     @staticmethod
     def types(tree):
         return {'$OBJECT': 'type', 'type': tree.child(0).value}
-
-    @classmethod
-    def entity(cls, tree):
-        return cls.values(tree.child(0))
 
     @classmethod
     def values(cls, tree):
@@ -183,7 +179,7 @@ class Objects:
         Compiles an argument tree to the corresponding object.
         """
         name = tree.child(0).value
-        value = cls.entity(tree.child(1))
+        value = cls.values(tree.child(1))
         return {'$OBJECT': 'argument', 'name': name, 'argument': value}
 
     @classmethod
@@ -225,10 +221,13 @@ class Objects:
         """
         operator = tree.expression_fragment.operator.child(0).value
         expression_type = Objects.expression_type(operator)
-        rhs = tree.expression_fragment.entity.values
+        rhs = tree.expression_fragment.values
         if rhs is None:
             rhs = tree.expression_fragment.path
-        values = [cls.entity(tree.entity), cls.values(rhs)]
+        lhs = tree.values
+        if lhs is None:
+            lhs = tree.path
+        values = [cls.values(lhs), cls.values(rhs)]
         return {'$OBJECT': 'expression', 'expression': expression_type,
                 'values': values}
 
@@ -237,7 +236,7 @@ class Objects:
         """
         Compiles an assertion object.
         """
-        lhs = cls.entity(tree.entity)
+        lhs = cls.values(tree.path_value.child(0))
         operator = tree.child(1)
         if operator is None:
             return [lhs]

--- a/storyscript/compiler/Preprocessor.py
+++ b/storyscript/compiler/Preprocessor.py
@@ -21,19 +21,19 @@ class Preprocessor:
         Replaces an inline expression with a fake assignment
         """
         assignment = fake_tree.add_assignment(inline_expression.service)
-        parent.child(1).child(0).replace(0, assignment.path.child(0))
+        parent.child(1).replace(0, assignment.path.child(0))
 
     @classmethod
-    def replace_in_entity(cls, block, statement, entity):
+    def replace_pathvalue(cls, block, statement, path_value):
         """
-        Replaces an inline expression inside an entity branch.
+        Replaces an inline expression inside a path_value branch.
         """
         fake_tree = cls.fake_tree(block)
         line = statement.line()
-        service = entity.path.inline_expression.service
+        service = path_value.path.inline_expression.service
         assignment = fake_tree.add_assignment(service)
-        entity.replace(0, assignment.path)
-        entity.path.children[0].line = line
+        path_value.replace(0, assignment.path)
+        path_value.path.children[0].line = line
 
     @classmethod
     def service_arguments(cls, block, service):
@@ -42,7 +42,7 @@ class Preprocessor:
         """
         fake_tree = cls.fake_tree(block)
         for argument in service.find_data('arguments'):
-            expression = argument.node('entity.path.inline_expression')
+            expression = argument.node('path.inline_expression')
             if expression:
                 cls.replace_expression(fake_tree, argument, expression)
 
@@ -65,9 +65,9 @@ class Preprocessor:
             fragment = assignment.assignment_fragment
             if fragment.service:
                 cls.service_arguments(block, fragment.service)
-            elif fragment.entity.path:
-                if fragment.entity.path.inline_expression:
-                    cls.assignment_expression(block, fragment.entity.path)
+            elif fragment.path:
+                if fragment.path.inline_expression:
+                    cls.assignment_expression(block, fragment.path)
 
     @classmethod
     def service(cls, tree):
@@ -129,12 +129,13 @@ class Preprocessor:
         Processes if statements, looking inline expressions.
         """
         for statement in block.find_data(name):
-            if statement.node('entity.path.inline_expression'):
-                cls.replace_in_entity(block, statement, statement.entity)
+            print(statement.pretty())
+            if statement.node('path_value.path.inline_expression'):
+                cls.replace_pathvalue(block, statement, statement.path_value)
 
             if statement.child(2):
-                if statement.child(2).node('entitypath.inline_expression'):
-                    cls.replace_in_entity(block, statement, statement.child(2))
+                if statement.child(2).node('path.inline_expression'):
+                    cls.replace_pathvalue(block, statement, statement.child(2))
 
     @classmethod
     def process(cls, tree):

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -62,9 +62,10 @@ class Grammar:
         self.ebnf.void = 'null'
         self.ebnf.number = 'int, float'
         self.ebnf.string = 'single_quoted, double_quoted'
-        list = self.ebnf.collection('osb', 'entity', 'entity', 'csb')
+        values_path = '(values, path)'
+        list = self.ebnf.collection('osb', values_path, values_path, 'csb')
         self.ebnf.set_rule('!list', list)
-        self.ebnf.key_value = '(string, path) colon entity'
+        self.ebnf.key_value = '(string, path) colon {}'.format(values_path)
         objects = ('ocb', 'key_value', 'key_value', 'ccb')
         self.ebnf.objects = self.ebnf.collection(*objects)
         self.ebnf.regular_expression = 'regexp name?'
@@ -80,7 +81,7 @@ class Grammar:
         self.ebnf.path_fragment = path_fragment
         self.ebnf.path = ('name (path_fragment)* | '
                           'inline_expression (path_fragment)*')
-        assignment_fragment = 'equals (entity, expression, service)'
+        assignment_fragment = 'equals (values, expression, path, service)'
         self.ebnf.assignment_fragment = assignment_fragment
         self.ebnf.assignment = 'path assignment_fragment'
 
@@ -91,7 +92,7 @@ class Grammar:
 
     def service(self):
         self.ebnf.command = 'name'
-        self.ebnf.arguments = 'name? colon entity'
+        self.ebnf.arguments = 'name? colon (values, path)'
         self.ebnf.output = '(as name (comma name)*)'
         self.ebnf.service_fragment = '(command arguments*|arguments+) output?'
         self.ebnf.service = 'path service_fragment'
@@ -109,16 +110,15 @@ class Grammar:
         self.ebnf.operator = ('plus, dash, multiplier, bslash, modulus, '
                               'power, not, and, or')
         self.ebnf.mutation = 'name arguments*'
-        self.ebnf.expression_fragment = 'operator entity'
-        self.ebnf.expression = ('entity (expression_fragment)+, '
+        self.ebnf.expression_fragment = 'operator (values, path)'
+        self.ebnf.expression = ('(values, path) (expression_fragment)+, '
                                 'values mutation')
         self.ebnf.absolute_expression = 'expression'
 
     def rules(self):
         self.ebnf._RETURN = 'return'
-        self.ebnf.return_statement = 'return entity'
-        self.ebnf.entity = 'values, path'
-        rules = ('entity, absolute_expression, assignment, imports, '
+        self.ebnf.return_statement = 'return (path, values)'
+        rules = ('values, absolute_expression, assignment, imports, '
                  'return_statement, block')
         self.ebnf.rules = rules
 
@@ -131,11 +131,12 @@ class Grammar:
         self.ebnf.EQUAL = '=='
         self.ebnf._IF = 'if'
         self.ebnf._ELSE = 'else'
+        self.ebnf.path_value = 'path, values'
         comparisons = ('greater, greater_equal, lesser, lesser_equal, not, '
                        'equal')
         self.ebnf.comparisons = comparisons
-        self.ebnf.if_statement = 'if entity (comparisons entity)?'
-        elseif_statement = 'else if entity (comparisons entity)?'
+        self.ebnf.if_statement = 'if path_value (comparisons path_value)?'
+        elseif_statement = 'else if path_value (comparisons path_value)?'
         self.ebnf.elseif_statement = elseif_statement
         self.ebnf.elseif_block = self.ebnf.simple_block('elseif_statement')
         self.ebnf.set_rule('!else_statement', 'else')

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -96,6 +96,7 @@ class Grammar:
         self.ebnf.output = '(as name (comma name)*)'
         self.ebnf.service_fragment = '(command arguments*|arguments+) output?'
         self.ebnf.service = 'path service_fragment'
+        self.ebnf.block_service = 'path service_fragment?'
 
     def expressions(self):
         self.ebnf.PLUS = '+'
@@ -173,7 +174,7 @@ class Grammar:
 
     def block(self):
         self.ebnf._WHEN = 'when'
-        self.ebnf.service_block = 'service nl (nested_block)?'
+        self.ebnf.service_block = 'block_service nl (nested_block)?'
         when = 'when (path output|service)'
         self.ebnf.when_block = self.ebnf.simple_block(when)
         self.ebnf.indented_arguments = 'indent (arguments nl)+ dedent'

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -61,6 +61,10 @@ class Transformer(LarkTransformer):
         Transforms service blocks, moving indented arguments back to the first
         node.
         """
+        # rename a global block_service to a pure service
+        for match in matches:
+            if hasattr(match, 'data') and match.data == 'block_service':
+                match.data = 'service'
         if len(matches) > 1:
             if matches[1].block.rules:
                 for argument in matches[1].find_data('arguments'):

--- a/tests/integration/compiler/Functions.py
+++ b/tests/integration/compiler/Functions.py
@@ -64,3 +64,28 @@ def test_functions_function_call_arguments(parser):
     assert result['tree']['3']['method'] == 'call'
     assert result['tree']['3']['service'] == 'f'
     assert result['tree']['3']['args'] == args
+
+
+def test_functions_function_call_without_arguments(parser):
+    """
+    Ensures that functions can be called without arguments
+    """
+    source = 'function clap\n\tx = 0\nclap\n'
+    tree = parser.parse(source)
+    result = Compiler.compile(tree)
+    assert result['tree']['3']['method'] == 'call'
+    assert result['tree']['3']['service'] == 'clap'
+    assert result['tree']['3']['args'] == []
+
+
+def test_functions_nested_function_call_without_arguments(parser):
+    """
+    Ensures that functions in nested scopes can be called without arguments
+    """
+    source = 'function clap\n\tx = 0\nif 2 > 1\n\tclap\n'
+    tree = parser.parse(source)
+    result = Compiler.compile(tree)
+    print(result)
+    assert result['tree']['4']['method'] == 'call'
+    assert result['tree']['4']['service'] == 'clap'
+    assert result['tree']['4']['args'] == []

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -8,9 +8,9 @@ def test_parser_sum(parser):
     result = parser.parse('3 + 3\n')
     expression = result.block.rules.absolute_expression.expression
     fragment = expression.expression_fragment
-    assert expression.entity.values.number.child(0) == Token('INT', 3)
+    assert expression.values.number.child(0) == Token('INT', 3)
     assert fragment.operator.child(0) == Token('PLUS', '+')
-    assert fragment.entity.values.number.child(0) == Token('INT', 3)
+    assert fragment.values.number.child(0) == Token('INT', 3)
 
 
 def test_parser_list_path(parser):
@@ -18,8 +18,8 @@ def test_parser_list_path(parser):
     Ensures that paths in lists can be parsed.
     """
     result = parser.parse('x = 0\n[3, x]\n')
-    list = result.child(1).rules.entity.values.list
-    assert list.child(3).path.child(0) == Token('NAME', 'x')
+    list = result.child(1).rules.values.list
+    assert list.child(3).child(0) == Token('NAME', 'x')
 
 
 @mark.parametrize('code, token', [
@@ -33,8 +33,7 @@ def test_parser_assignment(parser, code, token):
     assignment = result.block.rules.assignment
     assert assignment.path.child(0) == Token('NAME', 'var')
     assert assignment.assignment_fragment.child(0) == Token('EQUALS', '=')
-    entity = assignment.assignment_fragment.entity
-    assert entity.values.child(0).child(0) == token
+    assert assignment.assignment_fragment.values.child(0).child(0) == token
 
 
 def test_parser_assignment_path(parser):
@@ -51,8 +50,8 @@ def test_parser_assignment_indented_arguments(parser):
     correctly
     """
     result = parser.parse('x = alpine echo\n\tmessage:"hello"')
-    values = result.child(1).indented_arguments.arguments.entity.values
-    assert values.string.child(0) == Token('DOUBLE_QUOTED', '"hello"')
+    argument = result.child(1).indented_arguments.arguments.values.string
+    assert argument.child(0) == Token('DOUBLE_QUOTED', '"hello"')
 
 
 def test_parser_foreach_block(parser):
@@ -76,8 +75,7 @@ def test_parser_service_arguments(parser):
     result = parser.parse('container key:"value"\n')
     args = result.block.service_block.service.service_fragment.arguments
     assert args.child(0) == Token('NAME', 'key')
-    entity = args.entity
-    assert entity.values.string.child(0) == Token('DOUBLE_QUOTED', '"value"')
+    assert args.values.string.child(0) == Token('DOUBLE_QUOTED', '"value"')
 
 
 def test_parser_service_output(parser):
@@ -90,7 +88,7 @@ def test_parser_service_output(parser):
 def test_parser_if_block(parser):
     result = parser.parse('if expr\n\tvar=3\n')
     if_block = result.block.if_block
-    path = if_block.if_statement.entity.path
+    path = if_block.if_statement.path_value.path
     assignment = if_block.nested_block.block.rules.assignment
     assert path.child(0) == Token('NAME', 'expr')
     assert assignment.path.child(0) == Token('NAME', 'var')
@@ -99,7 +97,7 @@ def test_parser_if_block(parser):
 def test_parser_if_block_nested(parser):
     result = parser.parse('if expr\n\tif things\n\t\tvar=3\n')
     if_block = result.block.if_block.nested_block.block.if_block
-    path = if_block.if_statement.entity.path
+    path = if_block.if_statement.path_value.path
     assignment = if_block.nested_block.block.rules.assignment
     assert path.child(0) == Token('NAME', 'things')
     assert assignment.path.child(0) == Token('NAME', 'var')

--- a/tests/integration/parser/Values.py
+++ b/tests/integration/parser/Values.py
@@ -5,20 +5,18 @@ from lark.tree import Tree
 
 def test_values_true(parser):
     result = parser.parse('true\n')
-    entity = result.block.rules.entity
-    assert entity.values.boolean.child(0) == Token('TRUE', 'true')
+    assert result.block.rules.values.boolean.child(0) == Token('TRUE', 'true')
 
 
 def test_values_false(parser):
     result = parser.parse('false\n')
     token = Token('FALSE', 'false')
-    assert result.block.rules.entity.values.boolean.child(0) == token
+    assert result.block.rules.values.boolean.child(0) == token
 
 
 def test_values_null(parser):
     result = parser.parse('null\n')
-    entity = result.block.rules.entity
-    assert entity.values.void.child(0) == Token('NULL', 'null')
+    assert result.block.rules.values.void.child(0) == Token('NULL', 'null')
 
 
 def test_values_int(parser):
@@ -26,7 +24,7 @@ def test_values_int(parser):
     Ensures that parsing an int produces the expected tree
     """
     result = parser.parse('3\n')
-    assert result.block.rules.entity.values.number.child(0) == Token('INT', 3)
+    assert result.block.rules.values.number.child(0) == Token('INT', 3)
 
 
 def test_values_int_negative(parser):
@@ -34,7 +32,7 @@ def test_values_int_negative(parser):
     Ensures that parsing a negative int produces the expected tree
     """
     result = parser.parse('-3\n')
-    assert result.block.rules.entity.values.number.child(0) == Token('INT', -3)
+    assert result.block.rules.values.number.child(0) == Token('INT', -3)
 
 
 def test_values_float(parser):
@@ -42,8 +40,7 @@ def test_values_float(parser):
     Ensures that parsing a float produces the expected tree
     """
     result = parser.parse('3.14\n')
-    entity = result.block.rules.entity
-    assert entity.values.number.child(0) == Token('FLOAT', 3.14)
+    assert result.block.rules.values.number.child(0) == Token('FLOAT', 3.14)
 
 
 def test_values_float_negative(parser):
@@ -51,41 +48,39 @@ def test_values_float_negative(parser):
     Ensures that parsing a negative float produces the expected tree
     """
     result = parser.parse('-3.14\n')
-    entity = result.block.rules.entity
-    assert entity.values.number.child(0) == Token('FLOAT', -3.14)
+    assert result.block.rules.values.number.child(0) == Token('FLOAT', -3.14)
 
 
 def test_values_single_quoted_string(parser):
     result = parser.parse("'red'\n")
-    expected = result.block.rules.entity.values.string.child(0)
+    expected = result.block.rules.values.string.child(0)
     assert expected == Token('SINGLE_QUOTED', "'red'")
 
 
 def test_values_double_quoted_string(parser):
     result = parser.parse('"red"\n')
-    expected = result.block.rules.entity.values.string.child(0)
+    expected = result.block.rules.values.string.child(0)
     assert expected == Token('DOUBLE_QUOTED', '"red"')
 
 
 def test_values_list(parser):
     result = parser.parse('[3,4]\n')
-    list = result.block.rules.entity.values.list
-    assert list.entity.values.number.child(0) == Token('INT', 3)
-    assert list.child(3).values.number.child(0) == Token('INT', 4)
+    list = result.block.rules.values.list
+    assert list.values.number.child(0) == Token('INT', 3)
+    assert list.child(3).number.child(0) == Token('INT', 4)
 
 
 def test_values_list_empty(parser):
     result = parser.parse('[]\n')
     expected = Tree('list', [Token('_OSB', '['), Token('_CSB', ']')])
-    assert result.block.rules.entity.values.list == expected
+    assert result.block.rules.values.list == expected
 
 
 def test_values_object(parser):
     result = parser.parse("{'color':'red','shape':1}\n")
-    key_value = result.block.rules.entity.values.objects.key_value
+    key_value = result.block.rules.values.objects.key_value
     assert key_value.string.child(0) == Token('SINGLE_QUOTED', "'color'")
-    entity = key_value.entity
-    assert entity.values.string.child(0) == Token('SINGLE_QUOTED', "'red'")
+    assert key_value.values.string.child(0) == Token('SINGLE_QUOTED', "'red'")
 
 
 def test_values_regular_expression(parser):
@@ -94,8 +89,7 @@ def test_values_regular_expression(parser):
     """
     result = parser.parse('/^foo/')
     token = Token('REGEXP', '/^foo/')
-    entity = result.block.rules.entity
-    assert entity.values.regular_expression.child(0) == token
+    assert result.block.rules.values.regular_expression.child(0) == token
 
 
 def test_values_regular_expression_flags(parser):
@@ -104,5 +98,4 @@ def test_values_regular_expression_flags(parser):
     """
     result = parser.parse('/^foo/i')
     token = Token('NAME', 'i')
-    entity = result.block.rules.entity
-    assert entity.values.regular_expression.child(1) == token
+    assert result.block.rules.values.regular_expression.child(1) == token

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -39,12 +39,12 @@ def test_compiler_output_none():
 
 
 def test_compiler_extract_values(patch, tree):
-    patch.object(Objects, 'entity')
+    patch.object(Objects, 'values')
     tree.expression = None
     result = Compiler.extract_values(tree)
     tree.child.assert_called_with(1)
-    Objects.entity.assert_called_with(tree.child())
-    assert result == [Objects.entity()]
+    Objects.values.assert_called_with(tree.child())
+    assert result == [Objects.values()]
 
 
 def test_compiler_extract_values_expression(patch, tree):
@@ -313,11 +313,11 @@ def test_compiler_return_statement(patch, compiler, lines, tree):
     """
     Ensures Compiler.return_statement can compile return statements.
     """
-    patch.object(Objects, 'entity')
+    patch.object(Objects, 'values')
     compiler.return_statement(tree, '1')
     line = tree.line()
-    Objects.entity.assert_called_with(tree.child())
-    kwargs = {'args': [Objects.entity()], 'parent': '1'}
+    Objects.values.assert_called_with(tree.child())
+    kwargs = {'args': [Objects.values()], 'parent': '1'}
     lines.append.assert_called_with('return', line, **kwargs)
 
 

--- a/tests/unittests/compiler/Objects.py
+++ b/tests/unittests/compiler/Objects.py
@@ -171,22 +171,22 @@ def test_objects_boolean_false():
 
 
 def test_objects_list(patch, tree):
-    patch.object(Objects, 'entity')
+    patch.object(Objects, 'values')
     tree.children = [Tree('value', 'value'), 'token']
     result = Objects.list(tree)
-    Objects.entity.assert_called_with(Tree('value', 'value'))
-    assert result == {'$OBJECT': 'list', 'items': [Objects.entity()]}
+    Objects.values.assert_called_with(Tree('value', 'value'))
+    assert result == {'$OBJECT': 'list', 'items': [Objects.values()]}
 
 
 def test_objects_objects(patch, tree):
-    patch.many(Objects, ['string', 'entity'])
+    patch.many(Objects, ['string', 'values'])
     subtree = Tree('key_value', [Tree('string', ['key']), 'value'])
     tree.children = [subtree]
     result = Objects.objects(tree)
     Objects.string.assert_called_with(subtree.string)
-    Objects.entity.assert_called_with('value')
+    Objects.values.assert_called_with('value')
     expected = {'$OBJECT': 'dict', 'items': [[Objects.string(),
-                                              Objects.entity()]]}
+                                              Objects.values()]]}
     assert result == expected
 
 
@@ -194,7 +194,7 @@ def test_objects_objects_key_path(patch, tree):
     """
     Ensures that objects like {x: 0} are compiled
     """
-    patch.many(Objects, ['path', 'entity'])
+    patch.many(Objects, ['path', 'values'])
     subtree = Tree('key_value', [Tree('path', ['path'])])
     tree.children = [subtree]
     result = Objects.objects(tree)
@@ -219,14 +219,6 @@ def test_objects_regular_expression_flags():
 def test_objects_types(tree):
     token = tree.child(0)
     assert Objects.types(tree) == {'$OBJECT': 'type', 'type': token.value}
-
-
-def test_objects_entity(patch, tree):
-    patch.object(Objects, 'values')
-    result = Objects.entity(tree)
-    tree.child.assert_called_with(0)
-    Objects.values.assert_called_with(tree.child())
-    assert result == Objects.values()
 
 
 @mark.parametrize('value_type', [
@@ -261,12 +253,12 @@ def test_objects_values_path(patch, magic):
 
 
 def test_objects_argument(patch, tree):
-    patch.object(Objects, 'entity')
+    patch.object(Objects, 'values')
     result = Objects.argument(tree)
     assert tree.child.call_count == 2
-    Objects.entity.assert_called_with(tree.child())
+    Objects.values.assert_called_with(tree.child())
     expected = {'$OBJECT': 'argument', 'name': tree.child().value,
-                'argument': Objects.entity()}
+                'argument': Objects.values()}
     assert result == expected
 
 
@@ -312,15 +304,13 @@ def test_objects_expression(patch, tree):
     """
     Ensures Objects.expression can compile expressions
     """
-    patch.many(Objects, ['entity', 'values', 'expression_type'])
+    patch.many(Objects, ['values', 'expression_type'])
     result = Objects.expression(tree)
     operator = tree.expression_fragment.operator.child().value
     Objects.expression_type.assert_called_with(operator)
-    Objects.entity.assert_called_with(tree.entity)
-    Objects.values.assert_called_with(tree.expression_fragment.entity.values)
     assert result == {'$OBJECT': 'expression',
                       'expression': Objects.expression_type(),
-                      'values': [Objects.entity(), Objects.values()]}
+                      'values': [Objects.values(), Objects.values()]}
 
 
 def test_objects_expression_rhs(patch, tree):
@@ -329,19 +319,18 @@ def test_objects_expression_rhs(patch, tree):
     a path.
     """
     patch.many(Objects, ['values', 'expression_type'])
-    tree.expression_fragment.entity.values = None
+    tree.expression_fragment.values = None
     Objects.expression(tree)
     Objects.values.assert_called_with(tree.expression_fragment.path)
 
 
 def test_objects_assertion(patch, tree):
-    patch.many(Objects, ['entity', 'values', 'expression_type'])
+    patch.many(Objects, ['values', 'expression_type'])
     result = Objects.assertion(tree)
-    Objects.entity.assert_called_with(tree.entity)
     Objects.values.assert_called_with(tree.child().child())
     Objects.expression_type.assert_called_with(tree.child().child())
     expected = [
         {'$OBJECT': 'assertion', 'assertion': Objects.expression_type(),
-         'values': [Objects.entity(), Objects.values()]}
+         'values': [Objects.values(), Objects.values()]}
     ]
     assert result == expected

--- a/tests/unittests/compiler/Preprocessor.py
+++ b/tests/unittests/compiler/Preprocessor.py
@@ -23,12 +23,12 @@ def test_preprocessor_replace_expression(magic, tree):
     Preprocessor.replace_expression(tree, parent, expression)
     tree.add_assignment.assert_called_with(expression.service)
     assignment = tree.add_assignment().path.child()
-    parent.child().child().replace.assert_called_with(0, assignment)
+    parent.child().replace.assert_called_with(0, assignment)
 
 
-def test_preprocessor_replace_in_entity(magic, tree, block, fake_tree):
+def test_preprocessor_replace_pathvalue(magic, tree, block, fake_tree):
     path_value = magic()
-    Preprocessor.replace_in_entity(block, tree, path_value)
+    Preprocessor.replace_pathvalue(block, tree, path_value)
     fake_tree.assert_called_with(block)
     service = path_value.path.inline_expression.service
     fake_tree().add_assignment.assert_called_with(service)
@@ -43,7 +43,7 @@ def test_preprocessor_service_arguments(patch, magic, tree, fake_tree):
     Preprocessor.service_arguments('block', tree)
     fake_tree.assert_called_with('block')
     tree.find_data.assert_called_with('arguments')
-    argument.node.assert_called_with('entity.path.inline_expression')
+    argument.node.assert_called_with('path.inline_expression')
     args = (fake_tree(), argument, argument.node())
     Preprocessor.replace_expression.assert_called_with(*args)
 
@@ -89,7 +89,7 @@ def test_preprocessor_assignments_to_expression(patch, magic, tree):
     assignment.assignment_fragment.service = None
     tree.find_data.return_value = [assignment]
     Preprocessor.assignments(tree)
-    args = (tree, assignment.assignment_fragment.entity.path)
+    args = (tree, assignment.assignment_fragment.path)
     Preprocessor.assignment_expression.assert_called_with(*args)
 
 
@@ -97,7 +97,7 @@ def test_preprocessor_assignments_no_expression(patch, magic, tree):
     patch.object(Preprocessor, 'assignment_expression')
     assignment = magic()
     assignment.assignment_fragment.service = None
-    assignment.assignment_fragment.entity.path.inline_expression = None
+    assignment.assignment_fragment.path.inline_expression = None
     tree.find_data.return_value = [assignment]
     Preprocessor.assignments(tree)
     assert Preprocessor.assignment_expression.call_count == 0
@@ -187,15 +187,15 @@ def test_preprocessor_flow_statement(patch, magic, tree):
     """
     Ensures flow_statement replaces inline expressions inside if statements
     """
-    patch.object(Preprocessor, 'replace_in_entity')
+    patch.object(Preprocessor, 'replace_pathvalue')
     statement = magic()
     statement.child.return_value = None
     tree.find_data.return_value = [statement]
     Preprocessor.flow_statement('statement', tree)
     tree.find_data.assert_called_with('statement')
-    statement.node.assert_called_with('entity.path.inline_expression')
-    args = (tree, statement, statement.entity)
-    Preprocessor.replace_in_entity.assert_called_with(*args)
+    statement.node.assert_called_with('path_value.path.inline_expression')
+    args = (tree, statement, statement.path_value)
+    Preprocessor.replace_pathvalue.assert_called_with(*args)
 
 
 def test_preprocessor_flow_statement_rhs(patch, magic, tree):
@@ -203,26 +203,26 @@ def test_preprocessor_flow_statement_rhs(patch, magic, tree):
     Ensures flow_statement replaces inline expressions on the right hand-side
     of statements
     """
-    patch.object(Preprocessor, 'replace_in_entity')
+    patch.object(Preprocessor, 'replace_pathvalue')
     statement = magic()
     statement.node.return_value = None
     tree.find_data.return_value = [statement]
     Preprocessor.flow_statement('statement', tree)
     args = (tree, statement, statement.child())
-    Preprocessor.replace_in_entity.assert_called_with(*args)
+    Preprocessor.replace_pathvalue.assert_called_with(*args)
 
 
 def test_preprocessor_flow_statement_no_expression(patch, magic, tree):
     """
     Ensures flow_statement ignores statements without inline expressions
     """
-    patch.object(Preprocessor, 'replace_in_entity')
+    patch.object(Preprocessor, 'replace_pathvalue')
     statement = magic()
     statement.child.return_value = None
     statement.node.return_value = None
     tree.find_data.return_value = [statement]
     Preprocessor.flow_statement('statement', tree)
-    assert Preprocessor.replace_in_entity.call_count == 0
+    assert Preprocessor.replace_pathvalue.call_count == 0
 
 
 def test_preprocessor_process(patch, magic, tree, block):

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -66,7 +66,7 @@ def test_grammar_values(grammar, ebnf):
     assert ebnf.void == 'null'
     assert ebnf.number == 'int, float'
     assert ebnf.string == 'single_quoted, double_quoted'
-    assert ebnf.key_value == '(string, path) colon entity'
+    assert ebnf.key_value == '(string, path) colon (values, path)'
     assert ebnf.objects == ebnf.collection()
     assert ebnf.regular_expression == 'regexp name?'
     assert ebnf.inline_expression == 'op service cp'
@@ -83,7 +83,7 @@ def test_grammar_assignments(grammar, ebnf):
     assert ebnf.path_fragment == path_fragment
     assert ebnf.path == ('name (path_fragment)* | '
                          'inline_expression (path_fragment)*')
-    assignment_fragment = 'equals (entity, expression, service)'
+    assignment_fragment = 'equals (values, expression, path, service)'
     assert ebnf.assignment_fragment == assignment_fragment
     assert ebnf.assignment == 'path assignment_fragment'
 
@@ -98,7 +98,7 @@ def test_grammar_imports(grammar, ebnf):
 def test_grammar_service(grammar, ebnf):
     grammar.service()
     assert ebnf.command == 'name'
-    assert ebnf.arguments == 'name? colon entity'
+    assert ebnf.arguments == 'name? colon (values, path)'
     assert ebnf.output == '(as name (comma name)*)'
     assert ebnf.service_fragment == '(command arguments*|arguments+) output?'
     assert ebnf.service == 'path service_fragment'
@@ -118,8 +118,8 @@ def test_grammar_expressions(grammar, ebnf):
     assert ebnf.operator == ('plus, dash, multiplier, bslash, modulus, '
                              'power, not, and, or')
     assert ebnf.mutation == 'name arguments*'
-    assert ebnf.expression_fragment == 'operator entity'
-    assert ebnf.expression == ('entity (expression_fragment)+, '
+    assert ebnf.expression_fragment == 'operator (values, path)'
+    assert ebnf.expression == ('(values, path) (expression_fragment)+, '
                                'values mutation')
     assert ebnf.absolute_expression == 'expression'
 
@@ -127,9 +127,8 @@ def test_grammar_expressions(grammar, ebnf):
 def test_grammar_rules(grammar, ebnf):
     grammar.rules()
     assert ebnf._RETURN == 'return'
-    assert ebnf.entity == 'values, path'
-    assert ebnf.return_statement == 'return entity'
-    rules = ('entity, absolute_expression, assignment, imports, '
+    assert ebnf.return_statement == 'return (path, values)'
+    rules = ('values, absolute_expression, assignment, imports, '
              'return_statement, block')
     assert ebnf.rules == rules
 
@@ -144,10 +143,11 @@ def test_grammar_if_block(grammar, ebnf):
     assert ebnf.EQUAL == '=='
     assert ebnf._IF == 'if'
     assert ebnf._ELSE == 'else'
+    assert ebnf.path_value == 'path, values'
     comparisons = 'greater, greater_equal, lesser, lesser_equal, not, equal'
     assert ebnf.comparisons == comparisons
-    assert ebnf.if_statement == 'if entity (comparisons entity)?'
-    elseif_statement = 'else if entity (comparisons entity)?'
+    assert ebnf.if_statement == 'if path_value (comparisons path_value)?'
+    elseif_statement = 'else if path_value (comparisons path_value)?'
     assert ebnf.elseif_statement == elseif_statement
     assert ebnf.elseif_block == ebnf.simple_block()
     ebnf.set_rule.assert_called_with('!else_statement', 'else')

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -192,7 +192,7 @@ def test_grammar_try_block(grammar, ebnf):
 def test_grammar_block(grammar, ebnf):
     grammar.block()
     assert ebnf._WHEN == 'when'
-    assert ebnf.service_block == 'service nl (nested_block)?'
+    assert ebnf.service_block == 'block_service nl (nested_block)?'
     ebnf.simple_block.assert_called_with('when (path output|service)')
     assert ebnf.when_block == ebnf.simple_block()
     assert ebnf.indented_arguments == 'indent (arguments nl)+ dedent'


### PR DESCRIPTION
This is a WIP attempt at fixing #377.
This  allows function calls by introducing a new `block_service` rule and renaming it in the transformer to `service`.

TODO:
- [ ] I had to revert #395 as the parser was't able anymore the rules unambiguously otherwise