### PR TITLE
docs(README): update circleci badge to use the master branch only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ jobs:
             - image: circleci/python:3.6.1
         steps:
             - checkout
-            - restore_cache:
-                keys:
-                    - v1-dependencies-{{ checksum "setup.py" }}
-                    - v1-dependencies-
+            #- restore_cache:
+                #keys:
+                    #- v1-dependencies-{{ checksum "setup.py" }}
+                    #- v1-dependencies-
 
             - run:
                 name: install dependencies
@@ -19,10 +19,10 @@ jobs:
                     python3 setup.py install
                     pip install tox
 
-            - save_cache:
-                paths:
-                    - ./venv
-                key: v1-dependencies-{{ checksum "setup.py" }}
+            #- save_cache:
+                #paths:
+                    #- ./venv
+                #key: v1-dependencies-{{ checksum "setup.py" }}
 
             - run:
                 name: run unit tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![storyscript-logo](https://user-images.githubusercontent.com/2041757/44708914-9c66a380-aaa8-11e8-8e53-502c17ab5be3.png)
 
 [![PyPi](https://img.shields.io/pypi/v/storyscript.svg?maxAge=600&style=for-the-badge)](https://pypi.python.org/pypi/storyscript)
-[![CircleCI](https://img.shields.io/circleci/project/github/storyscript/storyscript.svg?style=for-the-badge)](https://circleci.com/gh/storyscript/storyscript)
+[![CircleCI](https://img.shields.io/circleci/project/github/storyscript/storyscript/master.svg?style=for-the-badge)](https://circleci.com/gh/storyscript/storyscript)
 [![Codecov](https://img.shields.io/codecov/c/github/storyscript/storyscript.svg?style=for-the-badge)](https://codecov.io/github/storyscript/storyscript)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg?style=for-the-badge)](https://docs.asyncy.com/storyscript)
 [![Devdocs](https://img.shields.io/badge/devdocs-online-brightgreen.svg?style=for-the-badge)](https://storyscript.readthedocs.io)


### PR DESCRIPTION
To avoid showing a failed status badge if any PR is currently failing as by default it takes the latest build.