### PR TITLE
chore(tox): be independent from the python installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
                 name: run unit tests
                 command: |
                     . venv/bin/activate
-                    tox -e pep8,py36-unit
+                    tox -e pep8,unit
 
             - run:
                 name: collect unit coverage
@@ -39,7 +39,7 @@ jobs:
                 name: run integration tests
                 command: |
                     . venv/bin/activate
-                    tox -e py36-integration
+                    tox -e integration
 
             - run:
                 name: collect integration coverage

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,14 @@ deps =
     pytest-mock
 
 
-[testenv:py36-unit]
+[testenv:unit]
 commands =
     pytest tests/unittests --cov=. --cov-config=.coveragerc --cov-report=term-missing {posargs}
     coverage xml
     mv coverage.xml unittest.xml
 
 
-[testenv:py36-integration]
+[testenv:integration]
 commands =
     pytest tests/integration --cov=. --cov-config=.coveragerc --cov-report=term-missing {posargs}
     coverage xml


### PR DESCRIPTION
Python 3.7 has been released since quite a while (and there's Python
3.5) too, so I don't see any reason why tox should require 3.6 only.

This also make it easier to test storyscript with different Python
versions (I use Python 3.7).