### PR TITLE
Add raise to syntax

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -53,3 +53,4 @@ class ErrorCodes:
     future_reserved_keyword_mock = (
         'E0038',
         '`mock` is reserved for future use')
+    raise_outside = ('E0039', '`raise` is allowed only inside catch blocks')

--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -37,18 +37,19 @@ class ErrorCodes:
     reserved_keyword_as = ('E0030', '`as` is a reserved keyword')
     reserved_keyword_import = ('E0031', '`import` is a reserved keyword')
     reserved_keyword_while = ('E0032', '`while` is a reserved keyword')
+    reserved_keyword_raise = ('E0033', '`raise` is a reserved keyword')
     future_reserved_keyword_async = (
-        'E0033',
+        'E0034',
         '`async` is reserved for future use')
     future_reserved_keyword_story = (
-        'E0034',
+        'E0035',
         '`story` is reserved for future use')
     future_reserved_keyword_assert = (
-        'E0035',
+        'E0036',
         '`assert` is reserved for future use')
     future_reserved_keyword_called = (
-        'E0036',
+        'E0037',
         '`called` is reserved for future use')
     future_reserved_keyword_mock = (
-        'E0037',
+        'E0038',
         '`mock` is reserved for future use')

--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -53,4 +53,3 @@ class ErrorCodes:
     future_reserved_keyword_mock = (
         'E0038',
         '`mock` is reserved for future use')
-    raise_outside = ('E0039', '`raise` is allowed only inside catch blocks')

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -264,7 +264,7 @@ class Compiler:
         line = tree.line()
         args = []
         # the first child is `raise` which isn't ignored as
-        # its needed to infer the line number in case no other
+        # it is needed to infer the line number in case no other
         # childrens were provided
         if len(tree.children) > 1:
             args = [Objects.entity(tree.child(1))]

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -257,30 +257,10 @@ class Compiler:
         if tree.finally_block:
             self.finally_block(tree.finally_block, parent=parent)
 
-    def find_parent(self, parent, cond):
-        """
-        Search up the tree for a specific node.
-        Returns `None` if no node matched `cond`
-        """
-        it_parent = parent
-        while it_parent is not None:
-            current_parent = self.lines.lines[it_parent]
-            if cond(current_parent):
-                return current_parent
-            it_parent = current_parent['parent']
-        return None
-
     def raise_statement(self, tree, parent):
         """
         Compiles a raise statement
         """
-        # go to the top and check whether we're in a raise statement
-        it_parent = self.find_parent(
-            parent,
-            lambda n: 'method' in n and n['method'] == 'catch')
-        if it_parent is None:
-            raise CompilerError('raise_outside', tree=tree)
-
         line = tree.line()
         args = []
         # the first child is `raise` which isn't ignored as

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -162,6 +162,10 @@ class Grammar:
         self.ebnf.function_statement = function_statement
         self.ebnf.function_block = self.ebnf.simple_block('function_statement')
 
+    def raise_statement(self):
+        self.ebnf._RAISE = 'raise'
+        self.ebnf.raise_statement = ('raise entity?')
+
     def try_block(self):
         self.ebnf.TRY = 'try'
         self.ebnf._CATCH = 'catch'
@@ -183,7 +187,7 @@ class Grammar:
         self.ebnf.indented_arguments = 'indent (arguments nl)+ dedent'
         block = ('rules nl, if_block, foreach_block, function_block, '
                  'arguments, service_block, when_block, try_block, '
-                 'indented_arguments, while_block')
+                 'indented_arguments, while_block, raise_statement')
         self.ebnf.block = block
         self.ebnf.nested_block = 'indent block+ dedent'
 
@@ -202,6 +206,7 @@ class Grammar:
         self.while_block()
         self.function_block()
         self.try_block()
+        self.raise_statement()
         self.block()
         self.ebnf.start = 'nl? block+'
         self.ebnf.ignore('_WS')

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -163,7 +163,7 @@ class Grammar:
         self.ebnf.function_block = self.ebnf.simple_block('function_statement')
 
     def raise_statement(self):
-        self.ebnf._RAISE = 'raise'
+        self.ebnf.RAISE = 'raise'
         self.ebnf.raise_statement = ('raise entity?')
 
     def try_block(self):

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -14,7 +14,7 @@ class Transformer(LarkTransformer):
     """
     reserved_keywords = ['function', 'if', 'else', 'foreach', 'return',
                          'returns', 'try', 'catch', 'finally', 'when', 'as',
-                         'import', 'while']
+                         'import', 'while', 'raise']
     future_reserved_keywords = ['async', 'story', 'assert',
                                 'called', 'mock']
 

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -62,23 +62,3 @@ def test_exception_missing_value(capsys):
     assert lines[0] == 'Error: syntax error in story at line 1, column 5'
     assert lines[2] == '1|    a = '
     assert lines[5] == 'Missing value after `=`'
-
-
-def test_exception_raise_outside(capsys):
-    with raises(SystemExit):
-        Story('raise').process()
-    output, error = capsys.readouterr()
-    lines = output.splitlines()
-    assert lines[0] == 'Error: syntax error in story at line 1, column 1'
-    assert lines[2] == '1|    raise'
-    assert lines[5] == '`raise` is allowed only inside catch blocks'
-
-
-def test_exception_nested_raise_outside(capsys):
-    with raises(SystemExit):
-        Story('if TRUE\n\traise').process()
-    output, error = capsys.readouterr()
-    lines = output.splitlines()
-    assert lines[0] == 'Error: syntax error in story at line 2, column 2'
-    assert lines[2] == '2|    \traise'
-    assert lines[5] == '`raise` is allowed only inside catch blocks'

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -62,3 +62,23 @@ def test_exception_missing_value(capsys):
     assert lines[0] == 'Error: syntax error in story at line 1, column 5'
     assert lines[2] == '1|    a = '
     assert lines[5] == 'Missing value after `=`'
+
+
+def test_exception_raise_outside(capsys):
+    with raises(SystemExit):
+        Story('raise').process()
+    output, error = capsys.readouterr()
+    lines = output.splitlines()
+    assert lines[0] == 'Error: syntax error in story at line 1, column 1'
+    assert lines[2] == '1|    raise'
+    assert lines[5] == '`raise` is allowed only inside catch blocks'
+
+
+def test_exception_nested_raise_outside(capsys):
+    with raises(SystemExit):
+        Story('if TRUE\n\traise').process()
+    output, error = capsys.readouterr()
+    lines = output.splitlines()
+    assert lines[0] == 'Error: syntax error in story at line 2, column 2'
+    assert lines[2] == '2|    \traise'
+    assert lines[5] == '`raise` is allowed only inside catch blocks'

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -216,3 +216,39 @@ def test_compiler_try_finally(parser):
     assert result['tree']['3']['method'] == 'finally'
     assert result['tree']['3']['enter'] == '4'
     assert result['tree']['4']['parent'] == '3'
+
+
+def test_compiler_try_raise(parser):
+    source = 'try\n\tx=0\ncatch as error\n\traise'
+    tree = parser.parse(source)
+    result = Compiler.compile(tree)
+    assert result['tree']['1']['exit'] == '3'
+    assert result['tree']['3']['method'] == 'catch'
+    assert result['tree']['4']['method'] == 'raise'
+    assert result['tree']['4']['parent'] == '3'
+
+
+def test_compiler_try_raise_error(parser):
+    source = 'try\n\tx=0\ncatch as error\n\traise error'
+    tree = parser.parse(source)
+    result = Compiler.compile(tree)
+    args = [{'$OBJECT': 'path', 'paths': ['error']}]
+    assert result['tree']['1']['exit'] == '3'
+    assert result['tree']['3']['method'] == 'catch'
+    assert result['tree']['3']['enter'] == '4'
+    assert result['tree']['4']['method'] == 'raise'
+    assert result['tree']['4']['parent'] == '3'
+    assert result['tree']['4']['args'] == args
+
+
+def test_compiler_try_nested_raise_error(parser):
+    source = 'try\n\tx=0\ncatch as error\n\tif TRUE\n\t\traise error'
+    tree = parser.parse(source)
+    result = Compiler.compile(tree)
+    args = [{'$OBJECT': 'path', 'paths': ['error']}]
+    assert result['tree']['1']['exit'] == '3'
+    assert result['tree']['3']['method'] == 'catch'
+    assert result['tree']['3']['enter'] == '4'
+    assert result['tree']['5']['method'] == 'raise'
+    assert result['tree']['5']['parent'] == '4'
+    assert result['tree']['5']['args'] == args

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -169,3 +169,28 @@ def test_parser_try_finally(parser):
     assert finally_block.finally_statement.child(0) == token
     path = finally_block.nested_block.block.rules.assignment.path
     assert path.child(0) == Token('NAME', 'x')
+
+
+def test_parser_try_raise(parser):
+    result = parser.parse('try\n\tx=0\ncatch as error\n\traise')
+    catch_block = result.block.try_block.catch_block.nested_block \
+                        .block.rules.block
+    assert catch_block.child(0).data == 'raise_statement'
+
+
+def test_parser_try_raise_error(parser):
+    result = parser.parse('try\n\tx=0\ncatch as error\n\traise error')
+    catch_block = result.block.try_block.catch_block.nested_block \
+                        .block.rules.block
+    assert catch_block.child(0).data == 'raise_statement'
+    entity = catch_block.child(0).entity.path
+    assert entity.child(0) == Token('NAME', 'error')
+
+
+def test_parser_try_raise_error_message(parser):
+    result = parser.parse('try\n\tx=0\ncatch as error\n\traise "error msg"')
+    catch_block = result.block.try_block.catch_block.nested_block \
+                        .block.rules.block
+    assert catch_block.child(0).data == 'raise_statement'
+    entity = catch_block.child(0).entity.values.string
+    assert entity.child(0) == Token('DOUBLE_QUOTED', '"error msg"')

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -45,20 +45,21 @@ from storyscript.ErrorCodes import ErrorCodes
     ('reserved_keyword_as', ('E0030', '`as` is a reserved keyword')),
     ('reserved_keyword_import', ('E0031', '`import` is a reserved keyword')),
     ('reserved_keyword_while', ('E0032', '`while` is a reserved keyword')),
+    ('reserved_keyword_raise', ('E0033', '`raise` is a reserved keyword')),
     ('future_reserved_keyword_async', (
-        'E0033',
+        'E0034',
         '`async` is reserved for future use')),
     ('future_reserved_keyword_story', (
-        'E0034',
+        'E0035',
         '`story` is reserved for future use')),
     ('future_reserved_keyword_assert', (
-        'E0035',
+        'E0036',
         '`assert` is reserved for future use')),
     ('future_reserved_keyword_called', (
-        'E0036',
+        'E0037',
         '`called` is reserved for future use')),
     ('future_reserved_keyword_mock', (
-        'E0037',
+        'E0038',
         '`mock` is reserved for future use')),
 ])
 def test_errorcodes(name, definition):

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -61,6 +61,9 @@ from storyscript.ErrorCodes import ErrorCodes
     ('future_reserved_keyword_mock', (
         'E0038',
         '`mock` is reserved for future use')),
+    ('raise_outside',
+        ('E0039',
+         '`raise` is allowed only inside catch blocks')),
 ])
 def test_errorcodes(name, definition):
     assert getattr(ErrorCodes, name) == definition

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -61,9 +61,6 @@ from storyscript.ErrorCodes import ErrorCodes
     ('future_reserved_keyword_mock', (
         'E0038',
         '`mock` is reserved for future use')),
-    ('raise_outside',
-        ('E0039',
-         '`raise` is allowed only inside catch blocks')),
 ])
 def test_errorcodes(name, definition):
     assert getattr(ErrorCodes, name) == definition

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -426,25 +426,7 @@ def test_compiler_function_block(patch, compiler, lines, tree):
     compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
-def test_compiler_find_parent(patch, compiler, lines, tree):
-    def cond(n):
-        return 'method' in n and n['method'] == 'catch'
-
-    assert compiler.find_parent(None, cond) is None
-    catch_node = {'method': 'catch'}
-    lines.lines = {'1': catch_node}
-    assert compiler.find_parent('1', cond) == catch_node
-
-    lines.lines = {'1': catch_node, '2': {'parent': '1'}}
-    assert compiler.find_parent('2', cond) == catch_node
-
-    lines.lines = {'1': {'parent': None}, '2': {'parent': '1'}}
-    assert compiler.find_parent('2', cond) is None
-
-
 def test_compiler_raise_statement(patch, compiler, lines, tree):
-    patch.object(Compiler, 'find_parent')
-    Compiler.find_parent.return_value = True
     tree.children = [Token('RAISE', 'raise')]
     compiler.raise_statement(tree, '1')
     lines.append.assert_called_with('raise', tree.line(), args=[],
@@ -452,26 +434,12 @@ def test_compiler_raise_statement(patch, compiler, lines, tree):
 
 
 def test_compiler_raise_name_statement(patch, compiler, lines, tree):
-    patch.object(Compiler, 'find_parent')
     patch.object(Objects, 'entity')
-    Compiler.find_parent.return_value = True
     tree.children = [Token('RAISE', 'raise'), Token('NAME', 'error')]
     compiler.raise_statement(tree, '1')
     args = [Objects.entity()]
     lines.append.assert_called_with('raise', tree.line(), args=args,
                                     parent='1')
-
-
-def test_compiler_raise_statement_throw(patch, compiler, lines, tree):
-    patch.object(Compiler, 'find_parent')
-    patch.init(CompilerError)
-    Compiler.find_parent.return_value = None
-    tree.children = [Token('RAISE', 'raise')]
-    with raises(CompilerError):
-        compiler.raise_statement(tree, '1')
-
-    error = 'raise_outside'
-    CompilerError.__init__.assert_called_with(error, tree=tree)
 
 
 def test_compiler_service_block(patch, compiler, tree):

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -220,7 +220,8 @@ def test_grammar_block(grammar, ebnf):
 def test_grammar_build(patch, call_count, grammar, ebnf):
     methods = ['macros', 'types', 'values', 'assignments', 'imports',
                'service', 'expressions', 'rules', 'if_block', 'foreach_block',
-               'function_block', 'try_block', 'block', 'while_block', 'raise_statement']
+               'function_block', 'try_block', 'block', 'while_block',
+               'raise_statement']
     patch.many(Grammar, methods)
     result = grammar.build()
     assert ebnf._WS == '(" ")+'

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -197,6 +197,12 @@ def test_grammar_try_block(grammar, ebnf):
     assert ebnf.try_block == try_block
 
 
+def test_grammar_raise_statement(grammar, ebnf):
+    grammar.raise_statement()
+    assert ebnf._RAISE == 'raise'
+    assert ebnf.raise_statement == 'raise entity?'
+
+
 def test_grammar_block(grammar, ebnf):
     grammar.block()
     assert ebnf._WHEN == 'when'
@@ -206,7 +212,7 @@ def test_grammar_block(grammar, ebnf):
     assert ebnf.indented_arguments == 'indent (arguments nl)+ dedent'
     block = ('rules nl, if_block, foreach_block, function_block, arguments, '
              'service_block, when_block, try_block, indented_arguments, '
-             'while_block')
+             'while_block, raise_statement')
     assert ebnf.block == block
     assert ebnf.nested_block == 'indent block+ dedent'
 
@@ -214,7 +220,7 @@ def test_grammar_block(grammar, ebnf):
 def test_grammar_build(patch, call_count, grammar, ebnf):
     methods = ['macros', 'types', 'values', 'assignments', 'imports',
                'service', 'expressions', 'rules', 'if_block', 'foreach_block',
-               'function_block', 'try_block', 'block', 'while_block']
+               'function_block', 'try_block', 'block', 'while_block', 'raise_statement']
     patch.many(Grammar, methods)
     result = grammar.build()
     assert ebnf._WS == '(" ")+'

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -199,7 +199,7 @@ def test_grammar_try_block(grammar, ebnf):
 
 def test_grammar_raise_statement(grammar, ebnf):
     grammar.raise_statement()
-    assert ebnf._RAISE == 'raise'
+    assert ebnf.RAISE == 'raise'
     assert ebnf.raise_statement == 'raise entity?'
 
 

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -15,7 +15,8 @@ def syntax_error(patch):
 
 def test_transformer():
     keywords = ['function', 'if', 'else', 'foreach', 'return', 'returns',
-                'try', 'catch', 'finally', 'when', 'as', 'import', 'while', 'raise']
+                'try', 'catch', 'finally', 'when', 'as', 'import', 'while',
+                'raise']
     assert Transformer.reserved_keywords == keywords
     assert issubclass(Transformer, LarkTransformer)
 

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -15,7 +15,7 @@ def syntax_error(patch):
 
 def test_transformer():
     keywords = ['function', 'if', 'else', 'foreach', 'return', 'returns',
-                'try', 'catch', 'finally', 'when', 'as', 'import', 'while']
+                'try', 'catch', 'finally', 'when', 'as', 'import', 'while', 'raise']
     assert Transformer.reserved_keywords == keywords
     assert issubclass(Transformer, LarkTransformer)
 
@@ -58,7 +58,7 @@ def test_transformer_command(patch, magic):
 
 @mark.parametrize('keyword', [
     'function', 'if', 'else', 'foreach', 'return', 'returns', 'try', 'catch',
-    'finally', 'when', 'as', 'import', 'while'
+    'finally', 'when', 'as', 'import', 'while', 'raise'
 ])
 def test_transformer_command_keyword_error(syntax_error, magic, keyword):
     token = magic(value=keyword)
@@ -89,7 +89,7 @@ def test_transformer_path(patch, magic):
 
 @mark.parametrize('keyword', [
     'function', 'if', 'else', 'foreach', 'return', 'returns', 'try', 'catch',
-    'finally', 'when', 'as', 'import', 'while'
+    'finally', 'when', 'as', 'import', 'while', 'raise'
 ])
 def test_transformer_path_keyword_error(syntax_error, magic, keyword):
     token = magic(value=keyword)


### PR DESCRIPTION
Closes #393

**- What I did**

Add `raise` statement to the grammar, transformer (with error codes) and compiler.
The compiler will also check whether `raise` is inside of a `catch` block and if not throw a special error (`raise_outside`).

**- Description for the changelog**

Add `raise` statement to the Storyscript syntax.

---

- [x] I still need to figure out why the `tree` passed to `raise_statement` is always empty