### PR TITLE
Allow `entity` in `foreach` blocks

### DIFF
--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -201,8 +201,7 @@ class Compiler:
 
     def foreach_block(self, tree, parent):
         line = tree.line()
-        path = Tree('path', [tree.foreach_statement.child(0)])
-        args = [Objects.path(path)]
+        args = [Objects.entity(tree.foreach_statement.child(0))]
         output = self.output(tree.foreach_statement.output)
         nested_block = tree.nested_block
         self.lines.append('for', line, args=args, enter=nested_block.line(),

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -145,7 +145,7 @@ class Grammar:
 
     def foreach_block(self):
         self.ebnf._FOREACH = 'foreach'
-        self.ebnf.foreach_statement = 'foreach name output'
+        self.ebnf.foreach_statement = 'foreach entity output'
         self.ebnf.foreach_block = self.ebnf.simple_block('foreach_statement')
 
     def function_block(self):

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -59,7 +59,7 @@ def test_parser_foreach_block(parser):
     result = parser.parse('foreach items as one, two\n\tvar=3\n')
     block = result.block.foreach_block
     foreach = block.foreach_statement
-    assert foreach.child(0) == Token('NAME', 'items')
+    assert foreach.entity.path.child(0) == Token('NAME', 'items')
     assert foreach.output.child(0) == Token('NAME', 'one')
     assert foreach.output.child(1) == Token('NAME', 'two')
     assert block.nested_block.data == 'nested_block'

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -386,13 +386,12 @@ def test_compiler_else_block(patch, compiler, lines, tree):
 
 def test_compiler_foreach_block(patch, compiler, lines, tree):
     patch.init(Tree)
-    patch.object(Objects, 'path')
+    patch.object(Objects, 'entity')
     patch.many(Compiler, ['subtree', 'output'])
     compiler.foreach_block(tree, '1')
-    Tree.__init__.assert_called_with('path', [tree.foreach_statement.child()])
-    assert Objects.path.call_count == 1
+    assert Objects.entity.call_count == 1
     compiler.output.assert_called_with(tree.foreach_statement.output)
-    args = [Objects.path()]
+    args = [Objects.entity()]
     lines.append.assert_called_with('for', tree.line(), args=args,
                                     enter=tree.nested_block.line(),
                                     output=Compiler.output(), parent='1')

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -159,7 +159,7 @@ def test_grammar_if_block(grammar, ebnf):
 def test_grammar_foreach_block(grammar, ebnf):
     grammar.foreach_block()
     assert ebnf._FOREACH == 'foreach'
-    assert ebnf.foreach_statement == 'foreach name output'
+    assert ebnf.foreach_statement == 'foreach entity output'
     ebnf.simple_block.assert_called_with('foreach_statement')
     assert ebnf.foreach_block == ebnf.simple_block()
 


### PR DESCRIPTION
Closes #406

**- What I did**

Add `entity` to foreach blocks in grammar and compiler.

**- Description for the changelog**

Allow `entity` in `foreach` blocks.