### PR TITLE
feat(api): add ability to compile stories from a map

### DIFF
--- a/storyscript/Api.py
+++ b/storyscript/Api.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from .Bundle import Bundle
 from .Story import Story
 
 
@@ -8,9 +9,22 @@ class Api:
     """
     @staticmethod
     def loads(string):
+        """
+        Load story from a string.
+        """
         return Story(string).process(debug=True)
 
     @staticmethod
     def load(stream):
+        """
+        Load story from a file stream.
+        """
         story = Story.from_stream(stream).process(debug=True)
         return {stream.name: story, 'services': story['services']}
+
+    @staticmethod
+    def load_map(files):
+        """
+        Load multiple stories from a file mapping
+        """
+        return Bundle(files).bundle(debug=True)

--- a/storyscript/App.py
+++ b/storyscript/App.py
@@ -15,14 +15,14 @@ class App:
         """
         Parses stories found in path, returning their trees
         """
-        return Bundle(path).bundle_trees(ebnf=ebnf, debug=debug)
+        return Bundle.from_path(path).bundle_trees(ebnf=ebnf, debug=debug)
 
     @staticmethod
     def compile(path, ebnf=None, debug=False):
         """
         Parses and compiles stories found in path, returning JSON
         """
-        bundle = Bundle(path).bundle(ebnf=ebnf, debug=debug)
+        bundle = Bundle.from_path(path).bundle(ebnf=ebnf, debug=debug)
         return json.dumps(bundle, indent=2)
 
     @staticmethod
@@ -30,7 +30,7 @@ class App:
         """
         Lex stories, producing the list of used tokens
         """
-        return Bundle(path).lex(ebnf=ebnf)
+        return Bundle.from_path(path).lex(ebnf=ebnf)
 
     @staticmethod
     def grammar():

--- a/tests/unittests/Api.py
+++ b/tests/unittests/Api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from storyscript.Api import Api
+from storyscript.Bundle import Bundle
 from storyscript.Story import Story
 
 
@@ -20,3 +21,18 @@ def test_api_load(patch, magic):
     Story.from_stream().process.assert_called_with(debug=True)
     story = Story.from_stream().process()
     assert result == {stream.name: story, 'services': story['services']}
+
+
+def test_api_load_map(patch, magic):
+    patch.object(Bundle, 'load_story')
+    result = Api.load_map({'a.story': "import 'b' as b", 'b.story': 'string'})
+    Bundle.load_story().parse.assert_called_with(debug=True, ebnf=None)
+    Bundle.load_story().compile.assert_called_with(debug=True)
+    assert result == {
+        'services': [],
+        'entrypoint': ['a.story', 'b.story'],
+        'stories': {
+            'a.story': Bundle.load_story().compiled,
+            'b.story': Bundle.load_story().compiled,
+        }
+    }

--- a/tests/unittests/App.py
+++ b/tests/unittests/App.py
@@ -10,8 +10,7 @@ from storyscript.parser import Grammar
 
 @fixture
 def bundle(patch):
-    patch.init(Bundle)
-    patch.many(Bundle, ['bundle_trees', 'bundle', 'lex'])
+    patch.many(Bundle, ['from_path', 'bundle_trees', 'bundle', 'lex'])
 
 
 def test_app_parse(bundle):
@@ -19,9 +18,9 @@ def test_app_parse(bundle):
     Ensures App.parse returns the parsed bundle
     """
     result = App.parse('path')
-    Bundle.__init__.assert_called_with('path')
-    Bundle.bundle_trees.assert_called_with(ebnf=None, debug=None)
-    assert result == Bundle.bundle_trees()
+    Bundle.from_path.assert_called_with('path')
+    Bundle.from_path().bundle_trees.assert_called_with(ebnf=None, debug=None)
+    assert result == Bundle.from_path().bundle_trees()
 
 
 def test_app_parse_ebnf(bundle):
@@ -29,7 +28,7 @@ def test_app_parse_ebnf(bundle):
     Ensures App.parse supports specifying an ebnf
     """
     App.parse('path', ebnf='ebnf')
-    Bundle.bundle_trees.assert_called_with(ebnf='ebnf', debug=None)
+    Bundle.from_path().bundle_trees.assert_called_with(ebnf='ebnf', debug=None)
 
 
 def test_app_parse_debug(bundle):
@@ -37,15 +36,15 @@ def test_app_parse_debug(bundle):
     Ensures App.parse can run in debug mode
     """
     App.parse('path', debug=True)
-    Bundle.bundle_trees.assert_called_with(ebnf=None, debug=True)
+    Bundle.from_path().bundle_trees.assert_called_with(ebnf=None, debug=True)
 
 
 def test_app_compile(patch, bundle):
     patch.object(json, 'dumps')
     result = App.compile('path')
-    Bundle.__init__.assert_called_with('path')
-    Bundle.bundle.assert_called_with(ebnf=None, debug=False)
-    json.dumps.assert_called_with(Bundle.bundle(), indent=2)
+    Bundle.from_path.assert_called_with('path')
+    Bundle.from_path().bundle.assert_called_with(ebnf=None, debug=False)
+    json.dumps.assert_called_with(Bundle.from_path().bundle(), indent=2)
     assert result == json.dumps()
 
 
@@ -55,25 +54,25 @@ def test_app_compile_ebnf(patch, bundle):
     """
     patch.object(json, 'dumps')
     App.compile('path', ebnf='ebnf')
-    Bundle.bundle.assert_called_with(ebnf='ebnf', debug=False)
+    Bundle.from_path().bundle.assert_called_with(ebnf='ebnf', debug=False)
 
 
 def test_app_compile_debug(patch, bundle):
     patch.object(json, 'dumps')
     App.compile('path', debug='debug')
-    Bundle.bundle.assert_called_with(ebnf=None, debug='debug')
+    Bundle.from_path().bundle.assert_called_with(ebnf=None, debug='debug')
 
 
 def test_app_lex(bundle):
     result = App.lex('/path')
-    Bundle.__init__.assert_called_with('/path')
-    Bundle.lex.assert_called_with(ebnf=None)
-    assert result == Bundle.lex()
+    Bundle.from_path.assert_called_with('/path')
+    Bundle.from_path().lex.assert_called_with(ebnf=None)
+    assert result == Bundle.from_path().lex()
 
 
 def test_app_lex_ebnf(bundle):
     App.lex('/path', ebnf='my.ebnf')
-    Bundle.lex.assert_called_with(ebnf='my.ebnf')
+    Bundle.from_path().lex.assert_called_with(ebnf='my.ebnf')
 
 
 def test_app_grammar(patch):


### PR DESCRIPTION
Closes #396.

**- What I did**

- added the possibility to fallback to `string` files in `Bundle`
- add `loadm` to the public API for loading multiple stories from memory

**- Description for the changelog**

Add `loadm` to the API for compiling stories from a map.

---

I'm still inexperienced with Storyscript, so please review with care.
Also, I went with a very naive approach of falling back to string files in the `Bundle`. Better ideas are welcome!