### PR TITLE
docs(README): fix error in getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ echo "alpine echo text:'hello world!'" > hello.story
 Compile a story to JSON:
 
 ```sh
-storyscript parse -j hello.story
+storyscript compile -j hello.story
 ```
 
 ## Development documentation


### PR DESCRIPTION
**- What I did**
Changed instructions from `storyscript parse` to `storyscript compile` in README.md

Did not create a new issue as I feel the change is trivial and I believe this was a type (parse does not even have a -j option) 
