### PR TITLE
Implicit event name

### DIFF
--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -15,8 +15,7 @@ class Transformer(LarkTransformer):
     reserved_keywords = ['function', 'if', 'else', 'foreach', 'return',
                          'returns', 'try', 'catch', 'finally', 'when', 'as',
                          'import', 'while', 'raise']
-    future_reserved_keywords = ['async', 'story', 'assert',
-                                'called', 'mock']
+    future_reserved_keywords = ['async', 'story', 'assert', 'called', 'mock']
 
     @classmethod
     def is_keyword(cls, token):
@@ -63,14 +62,12 @@ class Transformer(LarkTransformer):
 
     @classmethod
     def command(cls, matches):
-        token = matches[0]
-        cls.is_keyword(token)
+        cls.is_keyword(matches[0])
         return Tree('command', matches)
 
     @classmethod
     def path(cls, matches):
-        token = matches[0]
-        cls.is_keyword(token)
+        cls.is_keyword(matches[0])
         return Tree('path', matches)
 
     @classmethod

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -76,5 +76,16 @@ class Transformer(LarkTransformer):
                 return Tree('service_block', [matches[0]])
         return Tree('service_block', matches)
 
+    @staticmethod
+    def when_block(matches):
+        """
+        Transforms when blocks, adding implicit outputs
+        """
+        fragment = matches[0].service_fragment
+        if fragment.output is None:
+            output = Tree('output', [fragment.command.child(0)])
+            fragment.children.append(output)
+        return Tree('when_block', matches)
+
     def __getattr__(self, attribute, *args):
         return lambda matches: Tree(attribute, matches)

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -73,13 +73,15 @@ class Transformer(LarkTransformer):
         cls.is_keyword(token)
         return Tree('path', matches)
 
-    @staticmethod
-    def service_block(matches):
+    @classmethod
+    def service_block(cls, matches):
         """
         Transforms service blocks, moving indented arguments back to the first
         node.
         """
         if len(matches) > 1:
+            if matches[1].block.when_block:
+                cls.implicit_output(matches[0])
             if matches[1].block.rules:
                 for argument in matches[1].find_data('arguments'):
                     matches[0].service_fragment.children.append(argument)

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -29,6 +29,16 @@ class Transformer(LarkTransformer):
             raise StorySyntaxError(error_name, token=token)
 
     @staticmethod
+    def implicit_output(tree):
+        """
+        Adds implicit output to a service.
+        """
+        fragment = tree.service_fragment
+        if fragment.output is None:
+            output = Tree('output', [fragment.command.child(0)])
+            fragment.children.append(output)
+
+    @staticmethod
     def arguments(matches):
         """
         Transforms an argument tree. If dealing with is a short-hand argument,
@@ -76,15 +86,12 @@ class Transformer(LarkTransformer):
                 return Tree('service_block', [matches[0]])
         return Tree('service_block', matches)
 
-    @staticmethod
-    def when_block(matches):
+    @classmethod
+    def when_block(cls, matches):
         """
-        Transforms when blocks, adding implicit outputs
+        Transforms when blocks.
         """
-        fragment = matches[0].service_fragment
-        if fragment.output is None:
-            output = Tree('output', [fragment.command.child(0)])
-            fragment.children.append(output)
+        cls.implicit_output(matches[0])
         return Tree('when_block', matches)
 
     def __getattr__(self, attribute, *args):

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from lark import Transformer as LarkTransformer
+from lark.lexer import Token
 
 from pytest import fixture, mark, raises
 
@@ -17,8 +18,33 @@ def test_transformer():
     keywords = ['function', 'if', 'else', 'foreach', 'return', 'returns',
                 'try', 'catch', 'finally', 'when', 'as', 'import', 'while',
                 'raise']
+    future_keywords = ['async', 'story', 'assert', 'called', 'mock']
     assert Transformer.reserved_keywords == keywords
+    assert Transformer.future_reserved_keywords == future_keywords
     assert issubclass(Transformer, LarkTransformer)
+
+
+@mark.parametrize('keyword', [
+    'function', 'if', 'else', 'foreach', 'return', 'returns', 'try', 'catch',
+    'finally', 'when', 'as', 'import', 'while', 'raise'
+])
+def test_transformer_is_keyword(syntax_error, keyword):
+    token = Token('any', keyword)
+    with raises(StorySyntaxError):
+        Transformer.is_keyword(token)
+    name = 'reserved_keyword_{}'.format(keyword)
+    syntax_error.assert_called_with(name, token=token)
+
+
+@mark.parametrize('keyword', [
+    'async', 'story', 'mock', 'assert', 'called', 'mock'
+])
+def test_transformer_is_keyword_future(syntax_error, keyword):
+    token = Token('any', keyword)
+    with raises(StorySyntaxError):
+        Transformer.is_keyword(token)
+    name = 'future_reserved_keyword_{}'.format(keyword)
+    syntax_error.assert_called_with(name, token=token)
 
 
 def test_transformer_implicit_output(tree):
@@ -68,64 +94,17 @@ def test_transformer_assignment_error_dash(syntax_error, magic):
 
 
 def test_transformer_command(patch, magic):
-    matches = [magic()]
-    assert Transformer.command(matches) == Tree('command', matches)
+    patch.object(Transformer, 'is_keyword')
+    result = Transformer.command(['matches'])
+    Transformer.is_keyword.assert_called_with('matches')
+    assert result == Tree('command', ['matches'])
 
 
-@mark.parametrize('keyword', [
-    'function', 'if', 'else', 'foreach', 'return', 'returns', 'try', 'catch',
-    'finally', 'when', 'as', 'import', 'while', 'raise'
-])
-def test_transformer_command_keyword_error(syntax_error, magic, keyword):
-    token = magic(value=keyword)
-    matches = [token]
-    with raises(StorySyntaxError):
-        Transformer.command(matches)
-    error_name = 'reserved_keyword_{}'.format(keyword)
-    syntax_error.assert_called_with(error_name, token=token)
-
-
-@mark.parametrize('keyword', [
-    'async', 'story', 'mock', 'assert', 'called', 'mock'
-])
-def test_transformer_command_future_keyword_error(syntax_error,
-                                                  magic, keyword):
-    token = magic(value=keyword)
-    matches = [token]
-    with raises(StorySyntaxError):
-        Transformer.command(matches)
-    error_name = 'future_reserved_keyword_{}'.format(keyword)
-    syntax_error.assert_called_with(error_name, token=token)
-
-
-def test_transformer_path(patch, magic):
-    matches = [magic()]
-    assert Transformer.path(matches) == Tree('path', matches)
-
-
-@mark.parametrize('keyword', [
-    'function', 'if', 'else', 'foreach', 'return', 'returns', 'try', 'catch',
-    'finally', 'when', 'as', 'import', 'while', 'raise'
-])
-def test_transformer_path_keyword_error(syntax_error, magic, keyword):
-    token = magic(value=keyword)
-    matches = [token]
-    with raises(StorySyntaxError):
-        Transformer.path(matches)
-    error_name = 'reserved_keyword_{}'.format(keyword)
-    syntax_error.assert_called_with(error_name, token=token)
-
-
-@mark.parametrize('keyword', [
-    'async', 'story', 'mock', 'assert', 'called', 'mock'
-])
-def test_transformer_path_future_keyword_error(syntax_error, magic, keyword):
-    token = magic(value=keyword)
-    matches = [token]
-    with raises(StorySyntaxError):
-        Transformer.path(matches)
-    error_name = 'future_reserved_keyword_{}'.format(keyword)
-    syntax_error.assert_called_with(error_name, token=token)
+def test_transformer_path(patch):
+    patch.object(Transformer, 'is_keyword')
+    result = Transformer.path(['matches'])
+    Transformer.is_keyword.assert_called_with('matches')
+    assert result == Tree('path', ['matches'])
 
 
 def test_transformer_service_block():

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -142,6 +142,24 @@ def test_transformer_service_block_indented_args(tree, magic):
     assert result == Tree('service_block', [block])
 
 
+def test_transformer_when_block(tree):
+    """
+    Ensures when_block nodes are transformed correctly
+    """
+    assert Transformer.when_block([tree]) == Tree('when_block', [tree])
+
+
+def test_transformer_when_block_output(tree):
+    """
+    Ensures when blocks without an output are transformed
+    """
+    tree.service_fragment.output = None
+    tree.service_fragment.children = []
+    Transformer.when_block([tree])
+    expected = Tree('output', [tree.service_fragment.command.child()])
+    assert tree.service_fragment.children[-1] == expected
+
+
 @mark.parametrize('rule', ['start', 'line', 'block', 'statement'])
 def test_transformer_rules(rule):
     result = getattr(Transformer(), rule)(['matches'])

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -135,13 +135,15 @@ def test_transformer_service_block():
     assert Transformer.service_block([]) == Tree('service_block', [])
 
 
-def test_transformer_service_block_when(tree):
+def test_transformer_service_block_when(patch, tree):
     """
     Ensures service_block nodes with a when block are transformed correctly
     """
+    patch.object(Transformer, 'implicit_output')
     tree.block.rules = None
     matches = ['service_block', tree]
     result = Transformer.service_block(matches)
+    Transformer.implicit_output.assert_called_with('service_block')
     assert result == Tree('service_block', matches)
 
 


### PR DESCRIPTION
closes #348

**- What I did**
Add transformations to add events name when not specified in the code. The Transformer will use the command as implicit name:

```coffee
twitter stream # as stream
    when stream tweet hashtag:'asyncy' # as tweet
        res = machinebox/language data:tweet.message
```

**- Description for the changelog**
Events with implicit names are transformed, assuming the service command is the name
