### PR TITLE
Mutations chains

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -53,3 +53,6 @@ class ErrorCodes:
     future_reserved_keyword_mock = (
         'E0038',
         '`mock` is reserved for future use')
+    arguments_nomutation = (
+        'E0039',
+        'You have defined a chained mutation, but not a mutation')

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -248,6 +248,8 @@ class Compiler:
                 Objects.mutation(tree.mutation.mutation_fragment)
             ]
             args = args + self.chained_mutations(tree.mutation)
+        if tree.nested_block:
+            args = args + self.chained_mutations(tree.nested_block)
         self.lines.append('mutation', tree.line(), args=args, parent=parent)
 
     def indented_chain(self, tree, parent):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -234,13 +234,20 @@ class Compiler:
 
     def mutation_block(self, tree, parent):
         """
-        Compiles a mutation
+        Compiles a mutation or a service that is actually a mutation.
         """
-        args = [
-            Objects.entity(tree.mutation.entity),
-            Objects.mutation(tree.mutation.mutation_fragment)
-        ]
-        args = args + self.chained_mutations(tree.mutation)
+        if tree.path:
+            args = [
+                Objects.path(tree.path),
+                Objects.mutation(tree.service_fragment)
+            ]
+            args = args + self.chained_mutations(tree)
+        else:
+            args = [
+                Objects.entity(tree.mutation.entity),
+                Objects.mutation(tree.mutation.mutation_fragment)
+            ]
+            args = args + self.chained_mutations(tree.mutation)
         self.lines.append('mutation', tree.line(), args=args, parent=parent)
 
     def indented_chain(self, tree, parent):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -238,7 +238,12 @@ class Compiler:
         """
         Compiles a mutation
         """
-        args = Objects.mutation(tree.mutation)
+        args = [
+            Objects.entity(tree.mutation.entity),
+            Objects.mutation(tree.mutation.mutation_fragment)
+        ]
+        for mutation in tree.mutation.find_data('chained_mutation'):
+            args.append(Objects.mutation(mutation.mutation_fragment))
         self.lines.append('mutation', tree.line(), args=args, parent=parent)
 
     def service_block(self, tree, parent):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -133,7 +133,7 @@ class Compiler:
         """
         service_name = Objects.names(tree.path)
         if service_name in self.lines.variables:
-            self.expression(tree, parent)
+            self.mutation_block(tree, parent)
             return
         line = tree.line()
         command = tree.service_fragment.command

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -252,8 +252,7 @@ class Compiler:
             Objects.entity(tree.mutation.entity),
             Objects.mutation(tree.mutation.mutation_fragment)
         ]
-        for mutation in tree.mutation.find_data('chained_mutation'):
-            args.append(Objects.mutation(mutation.mutation_fragment))
+        args = args + self.chained_mutations(tree.mutation)
         self.lines.append('mutation', tree.line(), args=args, parent=parent)
 
     def service_block(self, tree, parent):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -232,6 +232,13 @@ class Compiler:
                           parent=parent)
         self.subtree(nested_block, parent=line)
 
+    def mutation_block(self, tree, parent):
+        """
+        Compiles a mutation
+        """
+        args = Objects.mutation(tree.mutation)
+        self.lines.append('mutation', tree.line(), args=args, parent=parent)
+
     def service_block(self, tree, parent):
         """
         Compiles a service block and the eventual nested block.
@@ -308,7 +315,8 @@ class Compiler:
                          'if_block', 'elseif_block', 'else_block',
                          'foreach_block', 'function_block', 'when_block',
                          'try_block', 'return_statement', 'arguments',
-                         'imports', 'while_block', 'raise_statement']
+                         'imports', 'while_block', 'raise_statement',
+                         'mutation_block',]
         if tree.data in allowed_nodes:
             getattr(self, tree.data)(tree, parent)
             return

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -36,6 +36,16 @@ class Compiler:
             return [Objects.expression(fragment.expression)]
         return [Objects.entity(fragment.child(1))]
 
+    @staticmethod
+    def chained_mutations(tree):
+        """
+        Finds and compile chained mutations
+        """
+        mutations = []
+        for mutation in tree.find_data('chained_mutation'):
+            mutations.append(Objects.mutation(mutation.mutation_fragment))
+        return mutations
+
     @classmethod
     def function_output(cls, tree):
         return cls.output(tree.node('function_output.types'))

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -255,6 +255,19 @@ class Compiler:
         args = args + self.chained_mutations(tree.mutation)
         self.lines.append('mutation', tree.line(), args=args, parent=parent)
 
+    def indented_chain(self, tree, parent):
+        """
+        Compiles an indented mutation.
+        """
+        previous_line = self.lines.last()
+        if previous_line:
+            line = self.lines.lines[previous_line]
+            if line['method'] != 'mutation':
+                raise StorySyntaxError('arguments_nomutation', tree=tree)
+            line['args'] = line['args'] + self.chained_mutations(tree)
+            return
+        raise StorySyntaxError('arguments_nomutation', tree=tree)
+
     def service_block(self, tree, parent):
         """
         Compiles a service block and the eventual nested block.
@@ -332,7 +345,7 @@ class Compiler:
                          'foreach_block', 'function_block', 'when_block',
                          'try_block', 'return_statement', 'arguments',
                          'imports', 'while_block', 'raise_statement',
-                         'mutation_block']
+                         'mutation_block', 'indented_chain']
         if tree.data in allowed_nodes:
             getattr(self, tree.data)(tree, parent)
             return

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -93,8 +93,10 @@ class Compiler:
                 self.service(service, None, parent)
                 self.lines.set_name(name)
                 return
-            else:
-                return self.expression_assignment(service, name, parent)
+        elif fragment.mutation:
+            self.mutation_block(fragment, parent)
+            self.lines.set_name(name)
+            return
         elif fragment.expression:
             if fragment.expression.is_unary() is False:
                 return self.expression_assignment(fragment, name, parent)
@@ -316,7 +318,7 @@ class Compiler:
                          'foreach_block', 'function_block', 'when_block',
                          'try_block', 'return_statement', 'arguments',
                          'imports', 'while_block', 'raise_statement',
-                         'mutation_block',]
+                         'mutation_block']
         if tree.data in allowed_nodes:
             getattr(self, tree.data)(tree, parent)
             return

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -61,19 +61,7 @@ class Compiler:
         """
         Compiles an expression
         """
-        mutation = None
-        if tree.expression:
-            if tree.expression.mutation:
-                value = Objects.entity(tree.expression.entity)
-                mutation = Objects.mutation(tree.expression.mutation)
-            else:
-                value = Objects.expression(tree.expression)
-        elif tree.service_fragment:
-            value = Objects.path(tree.path)
-            mutation = Objects.mutation(tree.service_fragment)
-        args = [value]
-        if mutation:
-            args.append(mutation)
+        args = [Objects.expression(tree.expression)]
         self.lines.append('expression', tree.line(), args=args, parent=parent)
 
     def expression_assignment(self, tree, name, parent):

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -106,13 +106,12 @@ class Grammar:
         self.ebnf.NOT = 'not'
         self.ebnf.AND = 'and'
         self.ebnf.OR = 'or'
-        self.ebnf.mutation = 'name arguments*'
         self.ebnf.factor = '(dash, plus)? entity, op expression cp'
         self.ebnf.exponential = 'factor (power exponential)?'
         self.ebnf.multiplication = ('exponential (( multiplier, bslash, '
                                     'modulus ) exponential)*')
         self.ebnf.expression = ('multiplication ( ( plus, dash ) '
-                                'multiplication)*, entity mutation')
+                                'multiplication)*')
         self.ebnf.absolute_expression = 'expression'
 
     def rules(self):
@@ -122,6 +121,14 @@ class Grammar:
         rules = ('absolute_expression, assignment, imports, return_statement, '
                  'block')
         self.ebnf.rules = rules
+
+    def mutation_block(self):
+        self.ebnf._THEN = 'then'
+        self.ebnf.mutation_fragment = 'name arguments*'
+        self.ebnf.chained_mutation = 'then mutation_fragment'
+        self.ebnf.mutation = 'entity (mutation_fragment (chained_mutation)*)'
+        self.ebnf.mutation_block = 'mutation nl (nested_block)?'
+        self.ebnf.indented_chain = 'indent (chained_mutation nl)+ dedent'
 
     def if_block(self):
         self.ebnf.GREATER = '>'

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -114,12 +114,19 @@ class Grammar:
                                 'multiplication)*')
         self.ebnf.absolute_expression = 'expression'
 
+    def raise_statement(self):
+        # NOTE(@wilzbach): raise can't be ignored as it is required to infer
+        # the line without children
+        # raise is a statement or a block?????
+        self.ebnf.RAISE = 'raise'
+        self.ebnf.raise_statement = ('raise entity?')
+
     def rules(self):
         self.ebnf._RETURN = 'return'
         self.ebnf.return_statement = 'return entity'
         self.ebnf.entity = 'values, path'
         rules = ('absolute_expression, assignment, imports, return_statement, '
-                 'block')
+                 'raise_statement, block')
         self.ebnf.rules = rules
 
     def mutation_block(self):
@@ -170,12 +177,6 @@ class Grammar:
         self.ebnf.function_statement = function_statement
         self.ebnf.function_block = self.ebnf.simple_block('function_statement')
 
-    def raise_statement(self):
-        # NOTE(@wilzbach): raise can't be ignored as it is required to infer
-        # the line without children
-        self.ebnf.RAISE = 'raise'
-        self.ebnf.raise_statement = ('raise entity?')
-
     def try_block(self):
         self.ebnf.TRY = 'try'
         self.ebnf._CATCH = 'catch'
@@ -198,7 +199,7 @@ class Grammar:
         block = ('rules nl, if_block, foreach_block, function_block, '
                  'arguments, indented_chain, chained_mutation, '
                  'mutation_block, service_block, when_block, try_block, '
-                 'indented_arguments, while_block, raise_statement')
+                 'indented_arguments, while_block')
         self.ebnf.block = block
         self.ebnf.nested_block = 'indent block+ dedent'
 

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -89,13 +89,6 @@ class Grammar:
         self.ebnf._IMPORT = 'import'
         self.ebnf.imports = 'import string as name'
 
-    def service(self):
-        self.ebnf.command = 'name'
-        self.ebnf.arguments = 'name? colon entity'
-        self.ebnf.output = '(as name (comma name)*)'
-        self.ebnf.service_fragment = '(command arguments*|arguments+) output?'
-        self.ebnf.service = 'path service_fragment'
-
     def expressions(self):
         self.ebnf.PLUS = '+'
         self.ebnf.set_token('DASH.4', '-')
@@ -136,6 +129,14 @@ class Grammar:
         self.ebnf.mutation = 'entity (mutation_fragment (chained_mutation)*)'
         self.ebnf.mutation_block = 'mutation nl (nested_block)?'
         self.ebnf.indented_chain = 'indent (chained_mutation nl)+ dedent'
+
+    def service_block(self):
+        self.ebnf.command = 'name'
+        self.ebnf.arguments = 'name? colon entity'
+        self.ebnf.output = '(as name (comma name)*)'
+        self.ebnf.service_fragment = '(command arguments*|arguments+) output?'
+        self.ebnf.service = 'path service_fragment'
+        self.ebnf.service_block = 'service nl (nested_block)?'
 
     def if_block(self):
         self.ebnf.GREATER = '>'
@@ -192,7 +193,6 @@ class Grammar:
 
     def block(self):
         self.ebnf._WHEN = 'when'
-        self.ebnf.service_block = 'service nl (nested_block)?'
         when = 'when (path output|service)'
         self.ebnf.when_block = self.ebnf.simple_block(when)
         self.ebnf.indented_arguments = 'indent (arguments nl)+ dedent'
@@ -210,10 +210,10 @@ class Grammar:
         self.values()
         self.assignments()
         self.imports()
-        self.service()
         self.expressions()
         self.rules()
         self.mutation_block()
+        self.service_block()
         self.if_block()
         self.foreach_block()
         self.while_block()

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -80,7 +80,7 @@ class Grammar:
         self.ebnf.path_fragment = path_fragment
         self.ebnf.path = ('name (path_fragment)* | '
                           'inline_expression (path_fragment)*')
-        assignment_fragment = 'equals (expression, service)'
+        assignment_fragment = 'equals (expression, service, mutation)'
         self.ebnf.assignment_fragment = assignment_fragment
         self.ebnf.assignment = 'path assignment_fragment'
 
@@ -196,7 +196,8 @@ class Grammar:
         self.ebnf.when_block = self.ebnf.simple_block(when)
         self.ebnf.indented_arguments = 'indent (arguments nl)+ dedent'
         block = ('rules nl, if_block, foreach_block, function_block, '
-                 'arguments, service_block, when_block, try_block, '
+                 'arguments, indented_chain, chained_mutation, '
+                 'mutation_block, service_block, when_block, try_block, '
                  'indented_arguments, while_block, raise_statement')
         self.ebnf.block = block
         self.ebnf.nested_block = 'indent block+ dedent'
@@ -211,6 +212,7 @@ class Grammar:
         self.service()
         self.expressions()
         self.rules()
+        self.mutation_block()
         self.if_block()
         self.foreach_block()
         self.while_block()

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -135,7 +135,7 @@ class Grammar:
         self.ebnf.arguments = 'name? colon entity'
         self.ebnf.output = '(as name (comma name)*)'
         self.ebnf.service_fragment = '(command arguments*|arguments+) output?'
-        self.ebnf.service = 'path service_fragment'
+        self.ebnf.service = 'path service_fragment chained_mutation*'
         self.ebnf.service_block = 'service nl (nested_block)?'
 
     def if_block(self):

--- a/tests/integration/compiler/Assignments.py
+++ b/tests/integration/compiler/Assignments.py
@@ -234,7 +234,7 @@ def test_assignments_mutation(parser):
     tree = parser.parse('0 increase by:1')
     result = Compiler.compile(tree)
     assert result['services'] == []
-    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['method'] == 'mutation'
     assert result['tree']['1']['args'][1]['$OBJECT'] == 'mutation'
 
 
@@ -246,5 +246,5 @@ def test_assignments_mutation_variable(parser):
     tree = parser.parse('a = 0\na increase by:1')
     result = Compiler.compile(tree)
     assert result['services'] == []
-    assert result['tree']['2']['method'] == 'expression'
+    assert result['tree']['2']['method'] == 'mutation'
     assert result['tree']['2']['args'][1]['$OBJECT'] == 'mutation'

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -76,7 +76,7 @@ def test_compiler_expression_mutation(parser):
         {'$OBJECT': 'string', 'string': 'hello'},
         {'$OBJECT': 'mutation', 'mutation': 'length', 'arguments': []}
     ]
-    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['method'] == 'mutation'
     assert result['tree']['1']['args'] == args
 
 

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from pytest import mark
+
 from storyscript.compiler import Compiler
 
 
@@ -66,9 +68,9 @@ def test_compiler_expression_complex(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_expression_mutation(parser):
+def test_compiler_mutation(parser):
     """
-    Ensures that mutation expressions are compiled correctly
+    Ensures that mutations are compiled correctly
     """
     tree = parser.parse("'hello' length")
     result = Compiler.compile(tree)
@@ -77,6 +79,24 @@ def test_compiler_expression_mutation(parser):
         {'$OBJECT': 'mutation', 'mutation': 'length', 'arguments': []}
     ]
     assert result['tree']['1']['method'] == 'mutation'
+    assert result['tree']['1']['args'] == args
+
+
+@mark.parametrize('source', [
+    '1 increment then format to:"string"',
+    '1 increment\n\tthen format to:"string"'
+])
+def test_compiler_mutation_chained(parser, source):
+    """
+    Ensures that chained mutations are compiled correctly
+    """
+    tree = parser.parse(source)
+    result = Compiler.compile(tree)
+    args = [1,
+            {'$OBJECT': 'mutation', 'mutation': 'increment', 'arguments': []},
+            {'$OBJECT': 'mutation', 'mutation': 'format', 'arguments': [
+                {'$OBJECT': 'argument', 'name': 'to',
+                 'argument': {'$OBJECT': 'string', 'string': 'string'}}]}]
     assert result['tree']['1']['args'] == args
 
 

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -176,24 +176,23 @@ def test_parser_try_finally(parser):
 
 def test_parser_try_raise(parser):
     result = parser.parse('try\n\tx=0\ncatch as error\n\traise')
-    catch_block = result.block.try_block.catch_block.nested_block \
-                        .block.rules.block
-    assert catch_block.child(0).data == 'raise_statement'
+    nested_block = result.block.try_block.catch_block.nested_block
+    assert nested_block.block.rules.raise_statement.child(0) == 'raise'
 
 
 def test_parser_try_raise_error(parser):
     result = parser.parse('try\n\tx=0\ncatch as error\n\traise error')
-    catch_block = result.block.try_block.catch_block.nested_block \
-                        .block.rules.block
-    assert catch_block.child(0).data == 'raise_statement'
-    entity = catch_block.child(0).entity.path
-    assert entity.child(0) == Token('NAME', 'error')
+    nested_block = result.block.try_block.catch_block.nested_block
+    raise_statement = nested_block.block.rules.raise_statement
+    assert raise_statement.child(0) == 'raise'
+    assert raise_statement.entity.path.child(0) == Token('NAME', 'error')
 
 
 def test_parser_try_raise_error_message(parser):
-    result = parser.parse('try\n\tx=0\ncatch as error\n\traise "error msg"')
-    catch_block = result.block.try_block.catch_block.nested_block \
-                        .block.rules.block
-    assert catch_block.child(0).data == 'raise_statement'
-    entity = catch_block.child(0).entity.values.string
-    assert entity.child(0) == Token('DOUBLE_QUOTED', '"error msg"')
+    result = parser.parse('try\n\tx=0\ncatch as error\n\traise "error"')
+    nested_block = result.block.try_block.catch_block.nested_block
+    raise_statement = nested_block.block.rules.raise_statement
+    print(raise_statement.pretty())
+    assert raise_statement.child(0) == 'raise'
+    token = Token('DOUBLE_QUOTED', '"error"')
+    assert raise_statement.entity.values.string.child(0) == token

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -61,6 +61,9 @@ from storyscript.ErrorCodes import ErrorCodes
     ('future_reserved_keyword_mock', (
         'E0038',
         '`mock` is reserved for future use')),
+    ('arguments_nomutation', (
+        'E0039',
+        'You have defined a chained mutation, but not a mutation'))
 ])
 def test_errorcodes(name, definition):
     assert getattr(ErrorCodes, name) == definition

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -428,6 +428,7 @@ def test_compiler_mutation_block(patch, compiler, lines, tree):
     patch.many(Objects, ['entity', 'mutation'])
     patch.object(Compiler, 'chained_mutations', return_value=['chained'])
     tree.path = None
+    tree.nested_block = None
     compiler.mutation_block(tree, None)
     Objects.entity.assert_called_with(tree.mutation.entity)
     Objects.mutation.assert_called_with(tree.mutation.mutation_fragment)
@@ -437,9 +438,21 @@ def test_compiler_mutation_block(patch, compiler, lines, tree):
     lines.append.assert_called_with('mutation', tree.line(), **kwargs)
 
 
+def test_compiler_mutation_block_nested(patch, compiler, lines, tree):
+    patch.many(Objects, ['entity', 'mutation'])
+    patch.object(Compiler, 'chained_mutations', return_value=['chained'])
+    tree.path = None
+    compiler.mutation_block(tree, None)
+    Compiler.chained_mutations.assert_called_with(tree.nested_block)
+    args = [Objects.entity(), Objects.mutation(), 'chained', 'chained']
+    kwargs = {'args': args, 'parent': None}
+    lines.append.assert_called_with('mutation', tree.line(), **kwargs)
+
+
 def test_compiler_mutation_block_from_service(patch, compiler, lines, tree):
     patch.many(Objects, ['path', 'mutation'])
     patch.object(Compiler, 'chained_mutations', return_value=['chained'])
+    tree.nested_block = None
     compiler.mutation_block(tree, None)
     Objects.path.assert_called_with(tree.path)
     Objects.mutation.assert_called_with(tree.service_fragment)

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -63,6 +63,15 @@ def test_compiler_extract_values_mutation(patch, tree):
     assert result == [Objects.values(), Objects.mutation()]
 
 
+def test_compiler_chained_mutations(patch, magic, tree):
+    patch.object(Objects, 'mutation')
+    mutation = magic()
+    tree.find_data.return_value = [mutation]
+    result = Compiler.chained_mutations(tree)
+    Objects.mutation.assert_called_with(mutation.mutation_fragment)
+    assert result == [Objects.mutation()]
+
+
 def test_compiler_function_output(patch, tree):
     patch.object(Compiler, 'output')
     result = Compiler.function_output(tree)

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -427,11 +427,24 @@ def test_compiler_raise_name_statement(patch, compiler, lines, tree):
 def test_compiler_mutation_block(patch, compiler, lines, tree):
     patch.many(Objects, ['entity', 'mutation'])
     patch.object(Compiler, 'chained_mutations', return_value=['chained'])
+    tree.path = None
     compiler.mutation_block(tree, None)
     Objects.entity.assert_called_with(tree.mutation.entity)
     Objects.mutation.assert_called_with(tree.mutation.mutation_fragment)
     Compiler.chained_mutations.assert_called_with(tree.mutation)
     args = [Objects.entity(), Objects.mutation(), 'chained']
+    kwargs = {'args': args, 'parent': None}
+    lines.append.assert_called_with('mutation', tree.line(), **kwargs)
+
+
+def test_compiler_mutation_block_from_service(patch, compiler, lines, tree):
+    patch.many(Objects, ['path', 'mutation'])
+    patch.object(Compiler, 'chained_mutations', return_value=['chained'])
+    compiler.mutation_block(tree, None)
+    Objects.path.assert_called_with(tree.path)
+    Objects.mutation.assert_called_with(tree.service_fragment)
+    Compiler.chained_mutations.assert_called_with(tree)
+    args = [Objects.path(), Objects.mutation(), 'chained']
     kwargs = {'args': args, 'parent': None}
     lines.append.assert_called_with('mutation', tree.line(), **kwargs)
 

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -282,11 +282,11 @@ def test_compiler_service_expressions(patch, compiler, lines, tree):
     correctly
     """
     patch.object(Objects, 'names', return_value='x')
-    patch.object(Compiler, 'expression')
+    patch.object(Compiler, 'mutation_block')
     lines.variables = ['x']
     compiler.service(tree, None, 'parent')
     Objects.names.assert_called_with(tree.path)
-    Compiler.expression.assert_called_with(tree, 'parent')
+    Compiler.mutation_block.assert_called_with(tree, 'parent')
 
 
 def test_compiler_service_syntax_error(patch, compiler, lines, tree):

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -444,10 +444,22 @@ def test_compiler_raise_name_statement(patch, compiler, lines, tree):
 
 
 def test_compiler_mutation_block(patch, compiler, lines, tree):
-    patch.object(Objects, 'mutation')
+    patch.many(Objects, ['entity', 'mutation'])
     compiler.mutation_block(tree, None)
-    Objects.mutation.assert_called_with(tree.mutation)
-    kwargs = {'args': Objects.mutation(), 'parent': None}
+    Objects.entity.assert_called_with(tree.mutation.entity)
+    Objects.mutation.assert_called_with(tree.mutation.mutation_fragment)
+    kwargs = {'args': [Objects.entity(), Objects.mutation()], 'parent': None}
+    lines.append.assert_called_with('mutation', tree.line(), **kwargs)
+
+
+def test_compiler_mutation_block_chained(patch, magic, compiler, lines, tree):
+    patch.many(Objects, ['entity', 'mutation'])
+    chained_mutation = magic()
+    tree.mutation.find_data.return_value = [chained_mutation]
+    compiler.mutation_block(tree, None)
+    Objects.mutation.assert_called_with(chained_mutation.mutation_fragment)
+    args = [Objects.entity(), Objects.mutation(), Objects.mutation()]
+    kwargs = {'args': args, 'parent': None}
     lines.append.assert_called_with('mutation', tree.line(), **kwargs)
 
 

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -454,20 +454,12 @@ def test_compiler_raise_name_statement(patch, compiler, lines, tree):
 
 def test_compiler_mutation_block(patch, compiler, lines, tree):
     patch.many(Objects, ['entity', 'mutation'])
+    patch.object(Compiler, 'chained_mutations', return_value=['chained'])
     compiler.mutation_block(tree, None)
     Objects.entity.assert_called_with(tree.mutation.entity)
     Objects.mutation.assert_called_with(tree.mutation.mutation_fragment)
-    kwargs = {'args': [Objects.entity(), Objects.mutation()], 'parent': None}
-    lines.append.assert_called_with('mutation', tree.line(), **kwargs)
-
-
-def test_compiler_mutation_block_chained(patch, magic, compiler, lines, tree):
-    patch.many(Objects, ['entity', 'mutation'])
-    chained_mutation = magic()
-    tree.mutation.find_data.return_value = [chained_mutation]
-    compiler.mutation_block(tree, None)
-    Objects.mutation.assert_called_with(chained_mutation.mutation_fragment)
-    args = [Objects.entity(), Objects.mutation(), Objects.mutation()]
+    Compiler.chained_mutations.assert_called_with(tree.mutation)
+    args = [Objects.entity(), Objects.mutation(), 'chained']
     kwargs = {'args': args, 'parent': None}
     lines.append.assert_called_with('mutation', tree.line(), **kwargs)
 

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -444,6 +444,14 @@ def test_compiler_raise_name_statement(patch, compiler, lines, tree):
                                     parent='1')
 
 
+def test_compiler_mutation_block(patch, compiler, lines, tree):
+    patch.object(Objects, 'mutation')
+    compiler.mutation_block(tree, None)
+    Objects.mutation.assert_called_with(tree.mutation)
+    kwargs = {'args': Objects.mutation(), 'parent': None}
+    lines.append.assert_called_with('mutation', tree.line(), **kwargs)
+
+
 def test_compiler_service_block(patch, compiler, tree):
     patch.object(Compiler, 'service')
     tree.node.return_value = None
@@ -526,7 +534,8 @@ def test_compiler_finally_block(patch, compiler, lines, tree):
 @mark.parametrize('method_name', [
     'service_block', 'absolute_expression', 'assignment', 'if_block',
     'elseif_block', 'else_block', 'foreach_block', 'function_block',
-    'when_block', 'try_block', 'return_statement', 'arguments', 'imports'
+    'when_block', 'try_block', 'return_statement', 'arguments', 'imports',
+    'mutation_block'
 ])
 def test_compiler_subtree(patch, compiler, method_name):
     patch.object(Compiler, method_name)

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -90,38 +90,10 @@ def test_compiler_expression(patch, compiler, lines, tree):
     """
     Ensures that expressions are compiled correctly
     """
-    patch.many(Objects, ['mutation', 'path'])
-    tree.expression = None
-    compiler.expression(tree, '1')
-    Objects.mutation.assert_called_with(tree.service_fragment)
-    Objects.path.assert_called_with(tree.path)
-    args = [Objects.path(), Objects.mutation()]
-    lines.append.assert_called_with('expression', tree.line(), args=args,
-                                    parent='1')
-
-
-def test_compiler_expression_absolute(patch, compiler, lines, tree):
-    """
-    Ensures that absolute expressions are compiled correctly
-    """
     patch.object(Objects, 'expression')
-    tree.expression.mutation = None
     compiler.expression(tree, '1')
     Objects.expression.assert_called_with(tree.expression)
     args = [Objects.expression()]
-    lines.append.assert_called_with('expression', tree.line(), args=args,
-                                    parent='1')
-
-
-def test_compiler_expression_absolute_mutation(patch, compiler, lines, tree):
-    """
-    Ensures that absolute expressions with mutations are compiled correctly
-    """
-    patch.many(Objects, ['mutation', 'entity'])
-    compiler.expression(tree, '1')
-    Objects.mutation.assert_called_with(tree.expression.mutation)
-    Objects.entity.assert_called_with(tree.expression.entity)
-    args = [Objects.entity(), Objects.mutation()]
     lines.append.assert_called_with('expression', tree.line(), args=args,
                                     parent='1')
 

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -136,7 +136,7 @@ def test_compiler_assignment(patch, compiler, lines, tree):
     """
     patch.many(Objects, ['names', 'entity'])
     tree.assignment_fragment.service = None
-    tree.assignment_fragment.expression.number = None
+    tree.assignment_fragment.mutation = None
     compiler.assignment(tree, '1')
     Objects.names.assert_called_with(tree.path)
     fragment = tree.assignment_fragment
@@ -156,24 +156,23 @@ def test_compiler_assignment_service(patch, compiler, lines, tree):
     lines.set_name.assert_called_with(Objects.names())
 
 
-def test_compiler_assignment_expression_service(patch, compiler, lines, tree):
+def test_compiler_assignment_mutation(patch, compiler, lines, tree):
     """
-    Ensures that assignments like 'x = a mutation' are compiled correctly.
-    This works by checking that 'a' was infact previously assigned, thus
-    it's not a service but a variable.
+    Ensures that assignments to mutations are compiled correctly.
     """
     patch.object(Objects, 'names', return_value='name')
-    patch.object(Compiler, 'expression_assignment')
-    lines.variables = ['name']
+    patch.object(Compiler, 'mutation_block')
+    tree.assignment_fragment.service = None
     compiler.assignment(tree, '1')
-    service = tree.assignment_fragment.service
-    Compiler.expression_assignment.assert_called_with(service, 'name', '1')
+    Compiler.mutation_block.assert_called_with(tree.assignment_fragment, '1')
+    lines.set_name.assert_called_with('name')
 
 
 def test_compiler_assignment_expression(patch, compiler, lines, tree):
     patch.object(Objects, 'names', return_value='name')
     patch.object(Compiler, 'expression_assignment')
     tree.assignment_fragment.service = None
+    tree.assignment_fragment.mutation = None
     tree.assignment_fragment.expression.is_unary.return_value = False
     compiler.assignment(tree, '1')
     fragment = tree.assignment_fragment

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -113,13 +113,12 @@ def test_grammar_expressions(grammar, ebnf):
     assert ebnf.NOT == 'not'
     assert ebnf.AND == 'and'
     assert ebnf.OR == 'or'
-    assert ebnf.mutation == 'name arguments*'
     assert ebnf.factor == '(dash, plus)? entity, op expression cp'
     assert ebnf.exponential == 'factor (power exponential)?'
     assert ebnf.multiplication == ('exponential (( multiplier, bslash, '
                                    'modulus ) exponential)*')
     assert ebnf.expression == ('multiplication ( ( plus, dash ) '
-                               'multiplication)*, entity mutation')
+                               'multiplication)*')
     assert ebnf.absolute_expression == 'expression'
 
 
@@ -131,6 +130,16 @@ def test_grammar_rules(grammar, ebnf):
     rules = ('absolute_expression, assignment, imports, return_statement, '
              'block')
     assert ebnf.rules == rules
+
+
+def test_mutation_block(grammar, ebnf):
+    grammar.mutation_block()
+    assert ebnf._THEN == 'then'
+    assert ebnf.mutation_fragment == 'name arguments*'
+    assert ebnf.chained_mutation == 'then mutation_fragment'
+    assert ebnf.mutation == 'entity (mutation_fragment (chained_mutation)*)'
+    assert ebnf.mutation_block == 'mutation nl (nested_block)?'
+    assert ebnf.indented_chain == 'indent (chained_mutation nl)+ dedent'
 
 
 def test_grammar_if_block(grammar, ebnf):

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -83,7 +83,7 @@ def test_grammar_assignments(grammar, ebnf):
     assert ebnf.path_fragment == path_fragment
     assert ebnf.path == ('name (path_fragment)* | '
                          'inline_expression (path_fragment)*')
-    assignment_fragment = 'equals (expression, service)'
+    assignment_fragment = 'equals (expression, service, mutation)'
     assert ebnf.assignment_fragment == assignment_fragment
     assert ebnf.assignment == 'path assignment_fragment'
 
@@ -219,6 +219,7 @@ def test_grammar_block(grammar, ebnf):
     assert ebnf.when_block == ebnf.simple_block()
     assert ebnf.indented_arguments == 'indent (arguments nl)+ dedent'
     block = ('rules nl, if_block, foreach_block, function_block, arguments, '
+             'indented_chain, chained_mutation, mutation_block, '
              'service_block, when_block, try_block, indented_arguments, '
              'while_block, raise_statement')
     assert ebnf.block == block
@@ -227,9 +228,9 @@ def test_grammar_block(grammar, ebnf):
 
 def test_grammar_build(patch, call_count, grammar, ebnf):
     methods = ['macros', 'types', 'values', 'assignments', 'imports',
-               'service', 'expressions', 'rules', 'if_block', 'foreach_block',
-               'function_block', 'try_block', 'block', 'while_block',
-               'raise_statement']
+               'service', 'expressions', 'rules', 'mutation_block', 'if_block',
+               'foreach_block', 'function_block', 'try_block', 'block',
+               'while_block', 'raise_statement']
     patch.many(Grammar, methods)
     result = grammar.build()
     assert ebnf._WS == '(" ")+'

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -95,15 +95,6 @@ def test_grammar_imports(grammar, ebnf):
     assert ebnf.imports == 'import string as name'
 
 
-def test_grammar_service(grammar, ebnf):
-    grammar.service()
-    assert ebnf.command == 'name'
-    assert ebnf.arguments == 'name? colon entity'
-    assert ebnf.output == '(as name (comma name)*)'
-    assert ebnf.service_fragment == '(command arguments*|arguments+) output?'
-    assert ebnf.service == 'path service_fragment'
-
-
 def test_grammar_expressions(grammar, ebnf):
     grammar.expressions()
     assert ebnf.PLUS == '+'
@@ -146,6 +137,16 @@ def test_mutation_block(grammar, ebnf):
     assert ebnf.mutation == 'entity (mutation_fragment (chained_mutation)*)'
     assert ebnf.mutation_block == 'mutation nl (nested_block)?'
     assert ebnf.indented_chain == 'indent (chained_mutation nl)+ dedent'
+
+
+def test_grammar_service_block(grammar, ebnf):
+    grammar.service_block()
+    assert ebnf.command == 'name'
+    assert ebnf.arguments == 'name? colon entity'
+    assert ebnf.output == '(as name (comma name)*)'
+    assert ebnf.service_fragment == '(command arguments*|arguments+) output?'
+    assert ebnf.service == 'path service_fragment'
+    assert ebnf.service_block == 'service nl (nested_block)?'
 
 
 def test_grammar_if_block(grammar, ebnf):
@@ -214,7 +215,6 @@ def test_grammar_try_block(grammar, ebnf):
 def test_grammar_block(grammar, ebnf):
     grammar.block()
     assert ebnf._WHEN == 'when'
-    assert ebnf.service_block == 'service nl (nested_block)?'
     ebnf.simple_block.assert_called_with('when (path output|service)')
     assert ebnf.when_block == ebnf.simple_block()
     assert ebnf.indented_arguments == 'indent (arguments nl)+ dedent'
@@ -228,9 +228,9 @@ def test_grammar_block(grammar, ebnf):
 
 def test_grammar_build(patch, call_count, grammar, ebnf):
     methods = ['macros', 'types', 'values', 'assignments', 'imports',
-               'service', 'expressions', 'rules', 'mutation_block', 'if_block',
-               'foreach_block', 'function_block', 'try_block', 'block',
-               'while_block', 'raise_statement']
+               'expressions', 'rules', 'mutation_block', 'service_block',
+               'if_block', 'foreach_block', 'function_block', 'try_block',
+               'block', 'while_block', 'raise_statement']
     patch.many(Grammar, methods)
     result = grammar.build()
     assert ebnf._WS == '(" ")+'

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -145,7 +145,7 @@ def test_grammar_service_block(grammar, ebnf):
     assert ebnf.arguments == 'name? colon entity'
     assert ebnf.output == '(as name (comma name)*)'
     assert ebnf.service_fragment == '(command arguments*|arguments+) output?'
-    assert ebnf.service == 'path service_fragment'
+    assert ebnf.service == 'path service_fragment chained_mutation*'
     assert ebnf.service_block == 'service nl (nested_block)?'
 
 

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -122,13 +122,19 @@ def test_grammar_expressions(grammar, ebnf):
     assert ebnf.absolute_expression == 'expression'
 
 
+def test_grammar_raise_statement(grammar, ebnf):
+    grammar.raise_statement()
+    assert ebnf.RAISE == 'raise'
+    assert ebnf.raise_statement == 'raise entity?'
+
+
 def test_grammar_rules(grammar, ebnf):
     grammar.rules()
     assert ebnf._RETURN == 'return'
     assert ebnf.entity == 'values, path'
     assert ebnf.return_statement == 'return entity'
     rules = ('absolute_expression, assignment, imports, return_statement, '
-             'block')
+             'raise_statement, block')
     assert ebnf.rules == rules
 
 
@@ -205,12 +211,6 @@ def test_grammar_try_block(grammar, ebnf):
     assert ebnf.try_block == try_block
 
 
-def test_grammar_raise_statement(grammar, ebnf):
-    grammar.raise_statement()
-    assert ebnf.RAISE == 'raise'
-    assert ebnf.raise_statement == 'raise entity?'
-
-
 def test_grammar_block(grammar, ebnf):
     grammar.block()
     assert ebnf._WHEN == 'when'
@@ -221,7 +221,7 @@ def test_grammar_block(grammar, ebnf):
     block = ('rules nl, if_block, foreach_block, function_block, arguments, '
              'indented_chain, chained_mutation, mutation_block, '
              'service_block, when_block, try_block, indented_arguments, '
-             'while_block, raise_statement')
+             'while_block')
     assert ebnf.block == block
     assert ebnf.nested_block == 'indent block+ dedent'
 


### PR DESCRIPTION
closes #239

**- What I did**
Implement chains of mutation using `then` as connector. Both inline and nested syntaxes are supported. Here's an example:

```coffee
message = ['merry', 'christmas'] join separator:' '
   then uppercase only:1
   then format template:'{}!'
```