### PR TITLE
fix(story): comments don't alter the line number

### DIFF
--- a/storyscript/Story.py
+++ b/storyscript/Story.py
@@ -27,12 +27,21 @@ class Story:
         """
         return re.sub(r'#[^#\n]+', '', source)
 
+    @staticmethod
+    def delete_line(match):
+        """
+        Clears the contents of a line.
+        """
+        return re.sub(r'.*', '', match.group())
+
     @classmethod
     def clean_source(cls, source):
         """
         Cleans a story by removing all comments.
         """
-        return re.sub(r'###[^#]+###', '', cls.remove_comments(source))
+        return re.sub(
+            r'###[^#]+###', cls.delete_line, cls.remove_comments(source)
+        )
 
     @classmethod
     def read(cls, path):

--- a/tests/integration/Story.py
+++ b/tests/integration/Story.py
@@ -25,13 +25,13 @@ def test_story_comments_indented():
 def test_story_comments_multiline():
     stream = StringIO('###\nmultiline\n###')
     story = Story.from_stream(stream)
-    assert story.story == ''
+    assert story.story == '\n\n'
 
 
 def test_story_comments_multiline_idented():
     stream = StringIO('function test\n\t###\nmultiline\n\t###\n\tx = 0')
     story = Story.from_stream(stream)
-    assert story.story == 'function test\n\t\n\tx = 0'
+    assert story.story == 'function test\n\t\n\n\n\tx = 0'
 
 
 def test_story_comments_multiline_catastrophic():
@@ -41,10 +41,10 @@ def test_story_comments_multiline_catastrophic():
     """
     stream = StringIO('###\nFiller filler filler filler\n\n###\nx = 0')
     story = Story.from_stream(stream)
-    assert story.story == '\nx = 0'
+    assert story.story == '\n\n\n\nx = 0'
 
 
 def test_story_comments_nested():
     stream = StringIO('###\nmultiline\n# nested\n###')
     story = Story.from_stream(stream)
-    assert story.story == ''
+    assert story.story == '\n\n\n'

--- a/tests/unittests/Story.py
+++ b/tests/unittests/Story.py
@@ -50,14 +50,28 @@ def test_story_remove_comments(patch):
     assert result == re.sub()
 
 
+def test_story_delete_line(patch):
+    """
+    Ensures that delete_line can delete lines.
+    """
+    patch.object(re, 'sub')
+    patch.object(re, 'match')
+    result = Story.delete_line(re.match())
+    re.sub.assert_called_with(r'.*', '', re.match().group())
+    assert result == re.sub()
+
+
 def test_story_clean_source(patch):
     """
     Ensures that a story is cleaned correctly
     """
     patch.object(re, 'sub')
     patch.object(Story, 'remove_comments')
+    patch.object(Story, 'delete_line')
     result = Story.clean_source('source')
-    re.sub.assert_called_with(r'###[^#]+###', '', Story.remove_comments())
+    re.sub.assert_called_with(
+        r'###[^#]+###', Story.delete_line, Story.remove_comments()
+    )
     assert result == re.sub()
 
 


### PR DESCRIPTION
Fixes #451

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/asyncy/storyscript/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Every match in multiline comments is now further passed through `re.sub` and all lines are cleared (replaced with blank lines)
The function handling inline comments (`remove_comments`) already ignores `\n` while finding a match to clear

**- How to verify it**
It should work if you compile a story:
```
$ cat test.story
###
abc
###
a=1 ###
a comment
###
z=1 # abc
###
abc
def
ghi
###
# this is
# my first PR
# to storyscript
zzz = 11$ # <-- error
# this story will not compile successfully

$ storyscript compile test.story
Error: syntax error in story at line 16, column 9

16|    zzz = 11$ 

```

**- Description for the changelog**
Fix bug: comments alter the line number