### PR TITLE
fix(compiler) - Compile code inside a try block

### DIFF
--- a/storyscript/Api.py
+++ b/storyscript/Api.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from .Bundle import Bundle
 from .Story import Story
+from .exceptions import StoryError
 
 
 class Api:
@@ -8,23 +9,47 @@ class Api:
     Exposes functionalities for external use
     """
     @staticmethod
-    def loads(string):
+    def loads(string, debug=False):
         """
         Load story from a string.
         """
-        return Story(string).process(debug=True)
+        try:
+            return Story(string).process()
+        except StoryError as e:
+            raise e
+        except Exception as e:
+            if debug:
+                raise e
+            else:
+                raise StoryError.internal_error(e)
 
     @staticmethod
-    def load(stream):
+    def load(stream, debug=False):
         """
         Load story from a file stream.
         """
-        story = Story.from_stream(stream).process(debug=True)
-        return {stream.name: story, 'services': story['services']}
+        try:
+            story = Story.from_stream(stream).process()
+            return {stream.name: story, 'services': story['services']}
+        except StoryError as e:
+            raise e
+        except Exception as e:
+            if debug:
+                raise e
+            else:
+                raise StoryError.internal_error(e)
 
     @staticmethod
-    def load_map(files):
+    def load_map(files, debug=False):
         """
         Load multiple stories from a file mapping
         """
-        return Bundle(story_files=files).bundle(debug=True)
+        try:
+            return Bundle(story_files=files).bundle()
+        except StoryError as e:
+            raise e
+        except Exception as e:
+            if debug:
+                raise e
+            else:
+                raise StoryError.internal_error(e)

--- a/storyscript/App.py
+++ b/storyscript/App.py
@@ -11,20 +11,20 @@ class App:
     """
 
     @staticmethod
-    def parse(path, ignored_path=None, ebnf=None, debug=None):
+    def parse(path, ignored_path=None, ebnf=None):
         """
         Parses stories found in path, returning their trees
         """
         bundle = Bundle.from_path(path, ignored_path=ignored_path)
-        return bundle.bundle_trees(ebnf=ebnf, debug=debug)
+        return bundle.bundle_trees(ebnf=ebnf)
 
     @staticmethod
-    def compile(path, ignored_path=None, ebnf=None, debug=False):
+    def compile(path, ignored_path=None, ebnf=None):
         """
         Parses and compiles stories found in path, returning JSON
         """
         bundle = Bundle.from_path(path, ignored_path=ignored_path)
-        return json.dumps(bundle.bundle(ebnf=ebnf, debug=debug), indent=2)
+        return json.dumps(bundle.bundle(ebnf=ebnf), indent=2)
 
     @staticmethod
     def lex(path, ebnf=None):

--- a/storyscript/Bundle.py
+++ b/storyscript/Bundle.py
@@ -96,48 +96,48 @@ class Bundle:
         services.sort()
         return services
 
-    def compile_modules(self, stories, ebnf, debug):
-        self.compile(stories, ebnf, debug)
+    def compile_modules(self, stories, ebnf):
+        self.compile(stories, ebnf)
 
-    def parse_modules(self, stories, ebnf, debug):
-        self.parse(stories, ebnf, debug)
+    def parse_modules(self, stories, ebnf):
+        self.parse(stories, ebnf)
 
-    def parse(self, stories, ebnf, debug):
+    def parse(self, stories, ebnf):
         """
         Parse stories.
         """
         for storypath in stories:
             story = self.load_story(storypath)
-            story.parse(ebnf=ebnf, debug=debug)
-            self.parse_modules(story.modules(), ebnf, debug)
+            story.parse(ebnf=ebnf)
+            self.parse_modules(story.modules(), ebnf)
             self.stories[storypath] = story.tree
 
-    def compile(self, stories, ebnf, debug):
+    def compile(self, stories, ebnf):
         """
         Reads and parses a story, then compiles its modules and finally
         compiles the story itself.
         """
         for storypath in stories:
             story = self.load_story(storypath)
-            story.parse(ebnf=ebnf, debug=debug)
-            self.compile_modules(story.modules(), ebnf, debug)
-            story.compile(debug=debug)
+            story.parse(ebnf=ebnf)
+            self.compile_modules(story.modules(), ebnf)
+            story.compile()
             self.stories[storypath] = story.compiled
 
-    def bundle(self, ebnf=None, debug=False):
+    def bundle(self, ebnf=None):
         """
         Makes the bundle
         """
         entrypoint = self.find_stories()
-        self.compile(entrypoint, ebnf, debug)
+        self.compile(entrypoint, ebnf)
         return {'stories': self.stories, 'services': self.services(),
                 'entrypoint': entrypoint}
 
-    def bundle_trees(self, ebnf=None, debug=None):
+    def bundle_trees(self, ebnf=None):
         """
         Makes a bundle of syntax trees
         """
-        self.parse(self.find_stories(), ebnf, debug)
+        self.parse(self.find_stories(), ebnf)
         return self.stories
 
     def lex(self, ebnf=None):

--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -56,3 +56,18 @@ class ErrorCodes:
     arguments_nomutation = (
         'E0039',
         'You have defined a chained mutation, but not a mutation')
+    compiler_error_no_operator = ('E0040', 'No operator provided')
+
+    @staticmethod
+    def is_error(error_name):
+        """
+        Checks whether a given error name is a valid error.
+        """
+        return isinstance(error_name, str) and hasattr(ErrorCodes, error_name)
+
+    @staticmethod
+    def get_error(error_name):
+        """
+        Retrieve the error object for a valid error name.
+        """
+        return getattr(ErrorCodes, error_name)

--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -210,12 +210,13 @@ class Objects:
         return arguments
 
     @staticmethod
-    def expression_type(operator):
+    def expression_type(operator, tree):
         types = {'+': 'sum', '-': 'subtraction', '^': 'exponential',
                  '*': 'multiplication', '/': 'division', '%': 'modulus',
                  'and': 'and', 'or': 'or', 'not': 'not', '==': 'equals',
                  '>': 'greater', '<': 'less', '!=': 'not_equal',
                  '>=': 'greater_equal', '<=': 'less_equal'}
+        tree.expect(operator in types, 'compiler_error_no_operator')
         return types[operator]
 
     @classmethod
@@ -258,7 +259,7 @@ class Objects:
             values = cls.expression_values(tree.child(0).children)
         else:
             values = cls.expression_values(tree.children)
-        expression_type = Objects.expression_type(tree.find_operator())
+        expression_type = Objects.expression_type(tree.find_operator(), tree)
         return {'$OBJECT': 'expression', 'expression': expression_type,
                 'values': values}
 
@@ -272,6 +273,6 @@ class Objects:
         if operator is None:
             return [lhs]
         rhs = cls.values(tree.child(2).child(0))
-        assertion = Objects.expression_type(operator.child(0))
+        assertion = Objects.expression_type(operator.child(0), tree)
         return [{'$OBJECT': 'assertion', 'assertion': assertion,
                  'values': [lhs, rhs]}]

--- a/storyscript/exceptions/CompilerError.py
+++ b/storyscript/exceptions/CompilerError.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .ProcessingError import ProcessingError
+from ..ErrorCodes import ErrorCodes
 
 
 class CompilerError(ProcessingError):
@@ -7,4 +8,17 @@ class CompilerError(ProcessingError):
     A compiler error that occurs despite the syntax being correct, for example
     a return outside of a function.
     """
-    pass
+    def __init__(self, error, token=None, tree=None, message=''):
+        super().__init__(error, token=token, tree=tree)
+        self._message = message
+
+    def __str__(self):
+        if len(self._message) > 0:
+            return self._message
+        elif hasattr(self, 'error') and ErrorCodes.is_error(self.error):
+            return ErrorCodes.get_error(self.error)[1]
+        else:
+            return 'Unknown compiler error'
+
+    def message(self):
+        return str(self)

--- a/storyscript/parser/Parser.py
+++ b/storyscript/parser/Parser.py
@@ -44,7 +44,7 @@ class Parser:
         """
         return Lark(self.grammar(), parser=self.algo, postlex=self.indenter())
 
-    def parse(self, source, debug=False):
+    def parse(self, source):
         """
         Parses the source string.
         """

--- a/storyscript/parser/Tree.py
+++ b/storyscript/parser/Tree.py
@@ -2,6 +2,8 @@
 from lark.lexer import Token
 from lark.tree import Tree as LarkTree
 
+from ..exceptions import CompilerError
+
 
 class Tree(LarkTree):
     """
@@ -123,6 +125,13 @@ class Tree(LarkTree):
                 if isinstance(self.multiplication.exponential.child(1), Token):
                     return self.multiplication.exponential.child(1)
         return self.multiplication.exponential.factor.child(0)
+
+    def expect(self, cond, error):
+        """
+        Throws a compiler error with message if the condition is falsy.
+        """
+        if not cond:
+            raise CompilerError(error, tree=self)
 
     def __getattr__(self, attribute):
         return self.node(attribute)

--- a/tests/integration/Api.py
+++ b/tests/integration/Api.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch
+
+from pytest import raises
+
+from storyscript.Api import Api
+from storyscript.Bundle import Bundle
+from storyscript.Story import Story
+from storyscript.exceptions import StoryError
+
+
+def test_api_load_map_compiling_try_block():
+    """
+    Ensures Api.load functions return errors
+    """
+    files = {'asd': 'foo'}
+    with raises(StoryError) as e:
+        Api.load_map(files)
+    assert e.value.short_message() == 'E0040: No operator provided'
+
+
+def test_api_load_map_compiling_try_block_loads():
+    """
+    Ensures Api.load functions return errors
+    """
+    with raises(StoryError) as e:
+        Api.loads('foo')
+    assert e.value.short_message() == 'E0040: No operator provided'
+    e.value.with_color = False
+    assert e.value.message() == \
+        """Error: syntax error in story at line 1, column 1
+
+1|    foo
+      ^^^
+
+E0040: No operator provided"""
+
+
+def test_api_load_map_syntax_error():
+    """
+    Ensures Api.load functions return errors
+    """
+    files = {'asd': 'foo ='}
+    with raises(StoryError) as e:
+        Api.load_map(files)
+    assert e.value.short_message() == 'E0007: Missing value after `=`'
+    e.value.with_color = False
+    assert e.value.message() == \
+        """Error: syntax error in story at line 1, column 6
+
+1|    foo =
+           ^
+
+E0007: Missing value after `=`"""
+
+
+def test_api_load_map_ice():
+    """
+    Simulate an ICE during load_map
+    """
+    with patch.object(Bundle, 'bundle') as p:
+        p.side_effect = Exception('ICE')
+        with raises(StoryError) as e:
+            Api.load_map({})
+        assert e.value.message() == \
+            """Internal error occured: ICE
+Please report at https://github.com/storyscript/storyscript/issues"""
+
+
+def test_api_loads_ice():
+    """
+    Simulate an ICE during loads
+    """
+    with patch.object(Story, 'process') as p:
+        p.side_effect = Exception('ICE')
+        with raises(StoryError) as e:
+            Api.loads('foo')
+        assert e.value.message() == \
+            """Internal error occured: ICE
+Please report at https://github.com/storyscript/storyscript/issues"""
+
+
+def test_api_load_ice():
+    """
+    Simulate an ICE during load
+    """
+    with patch.object(Story, 'from_stream') as p:
+        p.side_effect = Exception('ICE')
+        with raises(StoryError) as e:
+            Api.load('foo')
+        assert e.value.message() == \
+            """Internal error occured: ICE
+Please report at https://github.com/storyscript/storyscript/issues"""

--- a/tests/integration/Cli.py
+++ b/tests/integration/Cli.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+from unittest import mock
+
+from click.testing import CliRunner
+
+from storyscript.Cli import Cli
+
+
+def test_cli_exit_code():
+    """
+    Ensures that compiler exits with a non-zero exit code on errors
+    """
+    runner = CliRunner()
+    m = mock.mock_open(read_data='foo =')
+    e = None
+    with mock.patch('io.open', m):
+        e = runner.invoke(Cli.compile, ['/path'])
+
+    assert e.exit_code == 1
+    assert e.output == \
+        """Error: syntax error in story at line 1, column 6
+
+1|    foo =
+           ^
+
+E0007: Missing value after `=`
+"""
+
+
+def test_cli_exit_file_not_found():
+    """
+    Ensures that compiler exits with a non-zero exit code
+    on a file not found error
+    """
+    runner = CliRunner()
+    e = runner.invoke(Cli.compile, ['this-path-will-never-ever-exist-123456'])
+
+    assert e.exit_code == 1
+    # the error message contains the absolute path too
+    assert 'File "this-path-will-never-ever-exist-123456" not found' \
+        in e.output
+
+
+def test_cli_parse_exit_file_not_found():
+    """
+    Ensures that compiler exits with a non-zero exit code
+    on a file not found error
+    """
+    runner = CliRunner()
+    e = runner.invoke(Cli.parse, ['this-path-will-never-ever-exist-123456'])
+
+    assert e.exit_code == 1
+    # the error message contains the absolute path too
+    assert 'File "this-path-will-never-ever-exist-123456" not found' \
+        in e.output
+
+
+def test_cli_lex_exit_file_not_found():
+    """
+    Ensures that compiler exits with a non-zero exit code
+    on a file not found error
+    """
+    runner = CliRunner()
+    e = runner.invoke(Cli.parse, ['this-path-will-never-ever-exist-123456'])
+
+    assert e.exit_code == 1
+    # the error message contains the absolute path too
+    assert 'File "this-path-will-never-ever-exist-123456" not found' \
+        in e.output

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -1,64 +1,78 @@
 # -*- coding: utf-8 -*-
+import re
+
 from pytest import raises
 
 from storyscript.Story import Story
+from storyscript.exceptions.StoryError import StoryError
+
+ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
 
 
 def test_exception_service_name(capsys):
-    with raises(SystemExit):
+    with raises(StoryError) as e:
         Story('al.pine echo').process()
-    output, error = capsys.readouterr()
-    lines = output.splitlines()
+
+    message = e.value.message()
+    # test with coloring once, but we representing ANSI color codes is tricky
+    lines = ansi_escape.sub('', message).splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    al.pine echo'
     assert lines[5] == "E0002: A service name can't contain `.`"
 
 
 def test_exception_arguments_noservice(capsys):
-    with raises(SystemExit):
+    with raises(StoryError) as e:
         Story('length:10').process()
-    output, error = capsys.readouterr()
-    lines = output.splitlines()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    length:10'
     assert lines[5] == 'E0003: You have defined an argument, but not a service'
 
 
 def test_exception_variables_backslash(capsys):
-    with raises(SystemExit):
+    with raises(StoryError) as e:
         Story('a/b = 0').process()
-    output, error = capsys.readouterr()
-    lines = output.splitlines()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    a/b = 0'
     assert lines[5] == "E0005: A variable name can't contain `/`"
 
 
 def test_exception_variables_dash(capsys):
-    with raises(SystemExit):
+    with raises(StoryError) as e:
         Story('a-b = 0').process()
-    output, error = capsys.readouterr()
-    lines = output.splitlines()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    a-b = 0'
     assert lines[5] == "E0006: A variable name can't contain `-`"
 
 
 def test_exception_return_outside(capsys):
-    with raises(SystemExit):
+    with raises(StoryError) as e:
         Story('return 0').process()
-    output, error = capsys.readouterr()
-    lines = output.splitlines()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 8'
     assert lines[2] == '1|    return 0'
     assert lines[5] == 'E0004: `return` is allowed only inside functions'
 
 
 def test_exception_missing_value(capsys):
-    with raises(SystemExit):
+    with raises(StoryError) as e:
         Story('a = ').process()
-    output, error = capsys.readouterr()
-    lines = output.splitlines()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 5'
     assert lines[2] == '1|    a = '
     assert lines[5] == 'E0007: Missing value after `=`'
+
+
+def test_exception_file_not_found(capsys):
+    with raises(StoryError) as e:
+        Story.from_file('this-file-does-not-exist')
+    message = e.value.message()
+    assert 'File "this-file-does-not-exist" not found at' in message

--- a/tests/unittests/Api.py
+++ b/tests/unittests/Api.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+from pytest import raises
+
 from storyscript.Api import Api
 from storyscript.Bundle import Bundle
 from storyscript.Story import Story
+from storyscript.exceptions import StoryError
 
 
 def test_api_loads(patch):
@@ -12,7 +15,7 @@ def test_api_loads(patch):
     patch.object(Story, 'process')
     result = Api.loads('string')
     Story.__init__.assert_called_with('string')
-    Story.process.assert_called_with(debug=True)
+    Story.process.assert_called_with()
     assert result == Story.process()
 
 
@@ -24,7 +27,7 @@ def test_api_load(patch, magic):
     stream = magic()
     result = Api.load(stream)
     Story.from_stream.assert_called_with(stream)
-    Story.from_stream().process.assert_called_with(debug=True)
+    Story.from_stream().process.assert_called()
     story = Story.from_stream().process()
     assert result == {stream.name: story, 'services': story['services']}
 
@@ -38,5 +41,97 @@ def test_api_load_map(patch, magic):
     files = {'a.story': "import 'b' as b", 'b.story': 'x = 0'}
     result = Api.load_map(files)
     Bundle.__init__.assert_called_with(story_files=files)
-    Bundle.bundle.assert_called_with(debug=True)
+    Bundle.bundle.assert_called()
     assert result == Bundle.bundle()
+
+
+def test_api_loads_internal_error(patch):
+    """
+    Ensures Api.loads handles unknown errors
+    """
+    patch.init(Story)
+    patch.object(Story, 'process')
+    patch.object(StoryError, 'internal_error')
+    StoryError.internal_error.return_value = Exception('ICE')
+    Story.process.side_effect = Exception('An unknown error.')
+    with raises(Exception) as e:
+        Api.loads('string')
+
+    assert str(e.value) == 'ICE'
+
+
+def test_api_loads_internal_error_debug(patch):
+    """
+    Ensures Api.loads handles unknown errors with debug=True
+    """
+    patch.init(Story)
+    patch.object(Story, 'process')
+    patch.object(StoryError, 'internal_error')
+    StoryError.internal_error.return_value = Exception('ICE')
+    Story.process.side_effect = Exception('An unknown error.')
+    with raises(Exception) as e:
+        Api.loads('string', debug=True)
+
+    assert str(e.value) == 'An unknown error.'
+
+
+def test_api_load_internal_error(patch, magic):
+    """
+    Ensures Api.loads handles unknown errors
+    """
+    patch.init(Story)
+    patch.object(Story, 'from_stream')
+    patch.object(StoryError, 'internal_error')
+    StoryError.internal_error.return_value = Exception('ICE')
+    Story.from_stream.side_effect = Exception('An unknown error.')
+    stream = magic()
+    with raises(Exception) as e:
+        Api.load(stream)
+
+    assert str(e.value) == 'ICE'
+
+
+def test_api_load_internal_error_debug(patch, magic):
+    """
+    Ensures Api.load handles unknown errors with debug=True
+    """
+    patch.init(Story)
+    patch.object(Story, 'from_stream')
+    patch.object(StoryError, 'internal_error')
+    StoryError.internal_error.return_value = Exception('ICE')
+    Story.from_stream.side_effect = Exception('An unknown error.')
+    stream = magic()
+    with raises(Exception) as e:
+        Api.load(stream, debug=True)
+
+    assert str(e.value) == 'An unknown error.'
+
+
+def test_api_load_map_internal_error(patch):
+    """
+    Ensures Api.loads handles unknown errors
+    """
+    patch.init(Bundle)
+    patch.object(Bundle, 'bundle')
+    patch.object(StoryError, 'internal_error')
+    StoryError.internal_error.return_value = Exception('ICE')
+    Bundle.bundle.side_effect = Exception('An unknown error.')
+    with raises(Exception) as e:
+        Api.load_map({})
+
+    assert str(e.value) == 'ICE'
+
+
+def test_api_load_map_internal_error_debug(patch):
+    """
+    Ensures Api.loads handles unknown errors with debug=True
+    """
+    patch.init(Bundle)
+    patch.object(Bundle, 'bundle')
+    patch.object(StoryError, 'internal_error')
+    StoryError.internal_error.return_value = Exception('ICE')
+    Bundle.bundle.side_effect = Exception('An unknown error.')
+    with raises(Exception) as e:
+        Api.load_map({}, debug=True)
+
+    assert str(e.value) == 'An unknown error.'

--- a/tests/unittests/App.py
+++ b/tests/unittests/App.py
@@ -19,7 +19,7 @@ def test_app_parse(bundle):
     """
     result = App.parse('path')
     Bundle.from_path.assert_called_with('path', ignored_path=None)
-    Bundle.from_path().bundle_trees.assert_called_with(ebnf=None, debug=None)
+    Bundle.from_path().bundle_trees.assert_called_with(ebnf=None)
     assert result == Bundle.from_path().bundle_trees()
 
 
@@ -33,22 +33,14 @@ def test_app_parse_ebnf(bundle):
     Ensures App.parse supports specifying an ebnf
     """
     App.parse('path', ebnf='ebnf')
-    Bundle.from_path().bundle_trees.assert_called_with(ebnf='ebnf', debug=None)
-
-
-def test_app_parse_debug(bundle):
-    """
-    Ensures App.parse can run in debug mode
-    """
-    App.parse('path', debug=True)
-    Bundle.from_path().bundle_trees.assert_called_with(ebnf=None, debug=True)
+    Bundle.from_path().bundle_trees.assert_called_with(ebnf='ebnf')
 
 
 def test_app_compile(patch, bundle):
     patch.object(json, 'dumps')
     result = App.compile('path')
     Bundle.from_path.assert_called_with('path', ignored_path=None)
-    Bundle.from_path().bundle.assert_called_with(ebnf=None, debug=False)
+    Bundle.from_path().bundle.assert_called_with(ebnf=None)
     json.dumps.assert_called_with(Bundle.from_path().bundle(), indent=2)
     assert result == json.dumps()
 
@@ -65,13 +57,7 @@ def test_app_compile_ebnf(patch, bundle):
     """
     patch.object(json, 'dumps')
     App.compile('path', ebnf='ebnf')
-    Bundle.from_path().bundle.assert_called_with(ebnf='ebnf', debug=False)
-
-
-def test_app_compile_debug(patch, bundle):
-    patch.object(json, 'dumps')
-    App.compile('path', debug='debug')
-    Bundle.from_path().bundle.assert_called_with(ebnf=None, debug='debug')
+    Bundle.from_path().bundle.assert_called_with(ebnf='ebnf')
 
 
 def test_app_lex(bundle):

--- a/tests/unittests/Bundle.py
+++ b/tests/unittests/Bundle.py
@@ -175,22 +175,22 @@ def test_bundle_services_no_duplicates(bundle):
 
 def test_bundle_compile_modules(patch, bundle):
     patch.object(Bundle, 'compile')
-    bundle.compile_modules(['stories'], 'ebnf', 'debug')
-    Bundle.compile.assert_called_with(['stories'], 'ebnf', 'debug')
+    bundle.compile_modules(['stories'], 'ebnf')
+    Bundle.compile.assert_called_with(['stories'], 'ebnf')
 
 
 def test_bundle_parse_modules(patch, bundle):
     patch.object(Bundle, 'parse')
-    bundle.parse_modules(['stories'], 'ebnf', 'debug')
-    Bundle.parse.assert_called_with(['stories'], 'ebnf', 'debug')
+    bundle.parse_modules(['stories'], 'ebnf')
+    Bundle.parse.assert_called_with(['stories'], 'ebnf')
 
 
 def test_bundle_parse(patch, bundle):
     patch.many(Bundle, ['parse_modules', 'load_story'])
-    bundle.parse(['one.story'], None, False)
+    bundle.parse(['one.story'], None)
     Bundle.load_story.assert_called_with('one.story')
     story = Bundle.load_story()
-    Bundle.parse_modules.assert_called_with(story.modules(), None, False)
+    Bundle.parse_modules.assert_called_with(story.modules(), None)
     assert bundle.stories['one.story'] == story.tree
 
 
@@ -198,19 +198,19 @@ def test_bundle_compile(mocker, patch, bundle):
     patch.many(Bundle, ['compile_modules', 'load_story'])
     patch.many(Story, ['parse'])
 
-    bundle.compile(['one.story'], None, False)
+    bundle.compile(['one.story'], None)
     Bundle.load_story.assert_called_with('one.story')
 
     story = Bundle.load_story()
-    Bundle.compile_modules.assert_called_with(story.modules(), None, False)
-    story.compile.assert_called_with(debug=False)
+    Bundle.compile_modules.assert_called_with(story.modules(), None)
+    story.compile.assert_called()
     assert bundle.stories['one.story'] == story.compiled
 
 
 def test_bundle_bundle(patch, bundle):
     patch.many(Bundle, ['find_stories', 'services', 'compile'])
     result = bundle.bundle()
-    Bundle.compile.assert_called_with(Bundle.find_stories(), None, False)
+    Bundle.compile.assert_called_with(Bundle.find_stories(), None)
     expected = {'stories': bundle.stories, 'services': Bundle.services(),
                 'entrypoint': Bundle.find_stories()}
     assert result == expected
@@ -219,32 +219,20 @@ def test_bundle_bundle(patch, bundle):
 def test_bundle_bundle_ebnf(patch, bundle):
     patch.many(Bundle, ['find_stories', 'services', 'compile'])
     bundle.bundle(ebnf='ebnf')
-    Bundle.compile.assert_called_with(Bundle.find_stories(), 'ebnf', False)
-
-
-def test_bundle_bundle_debug(patch, bundle):
-    patch.many(Bundle, ['find_stories', 'services', 'compile'])
-    bundle.bundle(debug=True)
-    Bundle.compile.assert_called_with(Bundle.find_stories(), None, True)
+    Bundle.compile.assert_called_with(Bundle.find_stories(), 'ebnf')
 
 
 def test_bundle_bundle_trees(patch, bundle):
     patch.many(Bundle, ['find_stories', 'parse'])
     result = bundle.bundle_trees()
-    Bundle.parse.assert_called_with(Bundle.find_stories(), None, None)
+    Bundle.parse.assert_called_with(Bundle.find_stories(), None)
     assert result == bundle.stories
 
 
 def test_bundle_bundle_trees_ebnf(patch, bundle):
     patch.many(Bundle, ['find_stories', 'parse'])
     bundle.bundle_trees(ebnf='ebnf')
-    Bundle.parse.assert_called_with(Bundle.find_stories(), 'ebnf', None)
-
-
-def test_bundle_bundle_trees_debug(patch, bundle):
-    patch.many(Bundle, ['find_stories', 'parse'])
-    bundle.bundle_trees(debug=True)
-    Bundle.parse.assert_called_with(Bundle.find_stories(), None, True)
+    Bundle.parse.assert_called_with(Bundle.find_stories(), 'ebnf')
 
 
 def test_bundle_lex(patch, bundle):

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -66,4 +66,10 @@ from storyscript.ErrorCodes import ErrorCodes
         'You have defined a chained mutation, but not a mutation'))
 ])
 def test_errorcodes(name, definition):
-    assert getattr(ErrorCodes, name) == definition
+    assert ErrorCodes.get_error(name) == definition
+
+
+def test_is_error():
+    assert not ErrorCodes.is_error(None)
+    assert not ErrorCodes.is_error('foo')
+    assert ErrorCodes.is_error('service_name')

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -646,9 +646,3 @@ def test_compiler_compile(patch):
                 'services': lines.get_services(), 'functions': lines.functions,
                 'entrypoint': lines.first(), 'modules': lines.modules}
     assert result == expected
-
-
-def test_compiler_compile_debug(patch):
-    patch.object(Preprocessor, 'process')
-    patch.many(Compiler, ['parse_tree', 'compiler'])
-    Compiler.compile('tree', debug='debug')

--- a/tests/unittests/compiler/Objects.py
+++ b/tests/unittests/compiler/Objects.py
@@ -304,8 +304,8 @@ def test_objects_function_arguments(patch, tree):
     ('<', 'less'), ('!=', 'not_equal'), ('>=', 'greater_equal'),
     ('<=', 'less_equal')
 ])
-def test_objects_expression_type(operator, expression):
-    assert Objects.expression_type(operator) == expression
+def test_objects_expression_type(operator, expression, tree):
+    assert Objects.expression_type(operator, tree) == expression
 
 
 def test_objects_resolve_operand(patch, tree):
@@ -414,7 +414,7 @@ def test_objects_expression(patch, tree):
     tree.number = None
     result = Objects.expression(tree)
     Objects.expression_values.assert_called_with(tree.children)
-    Objects.expression_type.assert_called_with(tree.find_operator())
+    Objects.expression_type.assert_called_with(tree.find_operator(), tree)
     expected = {'$OBJECT': 'expression',
                 'values': Objects.expression_values(),
                 'expression': Objects.expression_type()}
@@ -430,7 +430,7 @@ def test_objects_expression_one_child(patch, tree):
     tree.children = [1]
     Objects.expression(tree)
     Objects.expression_values.assert_called_with(tree.child().children)
-    Objects.expression_type.assert_called_with(tree.find_operator())
+    Objects.expression_type.assert_called_with(tree.find_operator(), tree)
 
 
 def test_objects_assertion(patch, tree):
@@ -438,7 +438,7 @@ def test_objects_assertion(patch, tree):
     result = Objects.assertion(tree)
     Objects.entity.assert_called_with(tree.entity)
     Objects.values.assert_called_with(tree.child().child())
-    Objects.expression_type.assert_called_with(tree.child().child())
+    Objects.expression_type.assert_called_with(tree.child().child(), tree)
     expected = [
         {'$OBJECT': 'assertion', 'assertion': Objects.expression_type(),
          'values': [Objects.entity(), Objects.values()]}

--- a/tests/unittests/exceptions/CompilerError.py
+++ b/tests/unittests/exceptions/CompilerError.py
@@ -1,6 +1,22 @@
 # -*- coding: utf-8 -*-
+from storyscript.ErrorCodes import ErrorCodes
 from storyscript.exceptions import CompilerError, ProcessingError
 
 
 def test_compilererror():
     assert issubclass(CompilerError, ProcessingError)
+
+
+def test_error_message(patch):
+    patch.many(ErrorCodes, ['is_error', 'get_error'])
+    e = CompilerError(None, message='test error')
+    assert str(e) == 'test error'
+
+    ErrorCodes.is_error.return_value = True
+    ErrorCodes.get_error.return_value = [None, 'foo']
+    e2 = CompilerError('my_custom_error')
+    assert str(e2) == 'foo'
+
+    ErrorCodes.is_error.return_value = False
+    e3 = CompilerError(None)
+    assert str(e3) == 'Unknown compiler error'

--- a/tests/unittests/parser/Tree.py
+++ b/tests/unittests/parser/Tree.py
@@ -2,8 +2,9 @@
 from lark.lexer import Token
 from lark.tree import Tree as LarkTree
 
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
 
+from storyscript.exceptions.CompilerError import CompilerError
 from storyscript.parser import Tree
 
 
@@ -171,3 +172,13 @@ def test_tree_find_operator_depths(tree):
     Ensures find_operator can find operators at various depths
     """
     assert tree.find_operator() == Token('t', 't')
+
+
+def test_tree_expect(tree):
+    """
+    Ensures expect throws an error
+    """
+    with raises(CompilerError) as e:
+        tree.expect(0, 'error')
+
+    assert e.value.message() == 'Unknown compiler error'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/449

**- What I did**

- StoryError no longer exists directly in Story
- Passing `debug` around everywhere is superfluous with this change
- The CLI simply catches the StoryError and is itself in charge of error handling (this is also nice because the CLI class knows whether coloring should be used, sth. the error shouldn't need to know)
- On any error, the compiler now exits with a non-zero exit code (see also: https://en.wikipedia.org/wiki/Exit_status#POSIX).
- For better testing, `SyntaxError` now already supports omitting the coloring (this should be refactored as part of #458 though)
- Errors now are caught and rethrown as `StoryError`s 
- `SyntaxError` gained a `short_message` message which can be used for short one-line messages (e.g. hover error in an editor or asyncy hub and more convenient testing)
- EDIT: Catch all unknown errors in the API and expose them as StoryError's with report instructions (a start of #459)

~~Up for discussion:~~
- using a generic compiler error code for compiler errors [EDIT: no longer using a generic error]
- format of `short_message` (it could contain e.g. the error code) [EDIT: `short_message` now uses the error codes at the beginning]

Future directions:
- whether `Story.parse` should catch all exceptions and wrap them as reportable [ICE](https://en.wikipedia.org/wiki/Compilation_error)s (see also: https://github.com/storyscript/storyscript/issues/459)
- adding a CLI flag to switch between short and long/verbose/context message styles (though we should really start to introduce a per compilation config object, s.t. we don't need to forward arguments on almost every function like it was done with `debug` - see also https://github.com/storyscript/storyscript/issues/460 for the config discussion)
- `--debug` is now superfluous


**- Description for the changelog**

`StoryError` are now thrown from the public API.