### PR TITLE
feat(cli): add aliases for all commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ classifiers = [
 requirements = [
     'click==7.0',
     'delegator.py>=0.1.1',
-    'lark-parser>=0.6.5'
+    'lark-parser>=0.6.5',
+    'click-alias==0.1.1a2'
 ]
 
 extras = [

--- a/storyscript/Cli.py
+++ b/storyscript/Cli.py
@@ -4,6 +4,8 @@ import os
 
 import click
 
+from click_alias import ClickAliasedGroup
+
 from .App import App
 from .Project import Project
 from .Version import version as app_version
@@ -15,8 +17,8 @@ class Cli:
     silent_help = 'Silent mode. Return syntax errors only.'
     ebnf_help = 'Load the grammar from a file. Useful for development'
 
-    @click.group(invoke_without_command=True)
-    @click.option('--version', is_flag=True, help=version_help)
+    @click.group(invoke_without_command=True, cls=ClickAliasedGroup)
+    @click.option('--version', '-v', is_flag=True, help=version_help)
     @click.pass_context
     def main(context, version):  # noqa N805
         """
@@ -31,7 +33,7 @@ class Cli:
             click.echo(context.get_help())
 
     @staticmethod
-    @main.command()
+    @main.command(aliases=['p'])
     @click.argument('path', default=os.getcwd())
     @click.option('--debug', is_flag=True)
     @click.option('--ebnf', help=ebnf_help)
@@ -51,7 +53,7 @@ class Cli:
                 click.echo(tree.pretty())
 
     @staticmethod
-    @main.command()
+    @main.command(aliases=['c'])
     @click.argument('path', default=os.getcwd())
     @click.argument('output', required=False)
     @click.option('--json', '-j', is_flag=True)
@@ -77,7 +79,7 @@ class Cli:
                 click.echo(click.style('Script syntax passed!', fg='green'))
 
     @staticmethod
-    @main.command()
+    @main.command(aliases=['l'])
     @click.argument('path', default=os.getcwd())
     @click.option('--ebnf', help=ebnf_help)
     def lex(path, ebnf):
@@ -91,7 +93,7 @@ class Cli:
                 click.echo('{} {} {}'.format(n, token.type, token.value))
 
     @staticmethod
-    @main.command()
+    @main.command(aliases=['g'])
     def grammar():
         """
         Prints the grammar specification
@@ -99,7 +101,7 @@ class Cli:
         click.echo(App.grammar())
 
     @staticmethod
-    @main.command()
+    @main.command(aliases=['n'])
     @click.argument('name')
     def new(name):
         """
@@ -108,7 +110,7 @@ class Cli:
         Project.new(name)
 
     @staticmethod
-    @main.command()
+    @main.command(aliases=['h'])
     @click.pass_context
     def help(context):
         """
@@ -117,6 +119,6 @@ class Cli:
         click.echo(context.parent.get_help())
 
     @staticmethod
-    @main.command()
+    @main.command(aliases=['v'])
     def version():
         click.echo(app_version)

--- a/tests/unittests/Cli.py
+++ b/tests/unittests/Cli.py
@@ -35,6 +35,50 @@ def test_cli(runner, echo):
     assert click.echo.call_count == 1
 
 
+def test_cli_alais_parse(runner, app):
+    runner.invoke(Cli.main, ['p'])
+    assert app.parse.call_count == 1
+
+
+def test_cli_alais_compile(runner, app):
+    runner.invoke(Cli.main, ['c'])
+    assert app.compile.call_count == 1
+
+
+def test_cli_alais_lex(runner, app, patch):
+    patch.object(App, 'lex')
+    runner.invoke(Cli.main, 'l')
+    assert app.lex.call_count == 1
+
+
+def test_cli_alais_grammar(runner, app, patch):
+    patch.object(App, 'grammar')
+    runner.invoke(Cli.main, 'g')
+    assert app.grammar.call_count == 1
+
+
+def test_cli_alais_new(patch, runner):
+    patch.object(Project, 'new')
+    runner.invoke(Cli.main, ['n', 'project'])
+    Project.new.assert_called_with('project')
+
+
+def test_cli_alias_help(runner, echo):
+    runner.invoke(Cli.main, 'h')
+    click.echo.assert_called_once()
+
+
+def test_cli_alais_version(runner, echo):
+    runner.invoke(Cli.main, 'v')
+    click.echo.assert_called_with(version)
+
+
+def test_cli_alais_version_flag(runner, echo):
+    runner.invoke(Cli.main, '-v')
+    message = 'StoryScript {} - http://storyscript.org'.format(version)
+    click.echo.assert_called_with(message)
+
+
 def test_cli_version_flag(runner, echo):
     """
     Ensures --version outputs the version


### PR DESCRIPTION
Closes https://github.com/storyscript/storyscript/issues/419
**- What I did**
- Added aliases for all the CLI commands 
- Added alias for `--version` as `-v`
- Added tests for all the aliases
- Added `click-alias` as dependency to `setup.py`

**- How I did it**
- I used the `ClickAliasedGroup` class from `click-alias`

**- How to verify it**
- Try to run commands such as `storyscript h` for help 
```
$ storyscript h
Usage: storyscript [OPTIONS] COMMAND [ARGS]...

  Learn more at http://storyscript.org

Options:
  -v, --version  Prints Storyscript version
  --help         Show this message and exit.

Commands:
  compile (c)
  grammar (g)
  help (h)
  lex (l)
  new (n)
  parse (p)
  version (v)
```
**- Description for the changelog**
Feature: Added aliases for CLI commands