### PR TITLE
feat(exceptions): return error code with message 

### DIFF
--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -66,6 +66,12 @@ class StoryError(SyntaxError):
         line = self.error.line
         return '{}|    {}\n{}'.format(line, self.get_line(), highlight)
 
+    def error_code(self):
+        """
+        Provides the error code for the current error.
+        """
+        return self.error_tuple[0]
+
     def hint(self):
         """
         Provides an hint for the current error.
@@ -101,8 +107,9 @@ class StoryError(SyntaxError):
         Creates a friendly error message.
         """
         self.process()
-        args = (self.header(), self.highlight(), self.hint())
-        return '{}\n\n{}\n\n{}'.format(*args)
+        args = (self.header(), self.highlight(),
+                self.error_code(), self.hint())
+        return '{}\n\n{}\n\n{}: {}'.format(*args)
 
     def echo(self):
         """

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -20,7 +20,7 @@ class StoryError(SyntaxError):
         self.error = error
         self.story = story
         self.path = path
-        self.error_code = None
+        self.error_tuple = None
 
     def name(self):
         """
@@ -70,7 +70,7 @@ class StoryError(SyntaxError):
         """
         Provides an hint for the current error.
         """
-        return self.error_code[1]
+        return self.error_tuple[1]
 
     def identify(self):
         """
@@ -94,7 +94,7 @@ class StoryError(SyntaxError):
         Process the error, assigning the error code and performing other
         operations when necessary.
         """
-        self.error_code = self.identify()
+        self.error_tuple = self.identify()
 
     def message(self):
         """

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -11,7 +11,7 @@ def test_exception_service_name(capsys):
     lines = output.splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    al.pine echo'
-    assert lines[5] == "A service name can't contain `.`"
+    assert lines[5] == "E0002: A service name can't contain `.`"
 
 
 def test_exception_arguments_noservice(capsys):
@@ -21,7 +21,7 @@ def test_exception_arguments_noservice(capsys):
     lines = output.splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    length:10'
-    assert lines[5] == 'You have defined an argument, but not a service'
+    assert lines[5] == 'E0003: You have defined an argument, but not a service'
 
 
 def test_exception_variables_backslash(capsys):
@@ -31,7 +31,7 @@ def test_exception_variables_backslash(capsys):
     lines = output.splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    a/b = 0'
-    assert lines[5] == "A variable name can't contain `/`"
+    assert lines[5] == "E0005: A variable name can't contain `/`"
 
 
 def test_exception_variables_dash(capsys):
@@ -41,7 +41,7 @@ def test_exception_variables_dash(capsys):
     lines = output.splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    a-b = 0'
-    assert lines[5] == "A variable name can't contain `-`"
+    assert lines[5] == "E0006: A variable name can't contain `-`"
 
 
 def test_exception_return_outside(capsys):
@@ -51,7 +51,7 @@ def test_exception_return_outside(capsys):
     lines = output.splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 8'
     assert lines[2] == '1|    return 0'
-    assert lines[5] == '`return` is allowed only inside functions'
+    assert lines[5] == 'E0004: `return` is allowed only inside functions'
 
 
 def test_exception_missing_value(capsys):
@@ -61,4 +61,4 @@ def test_exception_missing_value(capsys):
     lines = output.splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 5'
     assert lines[2] == '1|    a = '
-    assert lines[5] == 'Missing value after `=`'
+    assert lines[5] == 'E0007: Missing value after `=`'

--- a/tests/unittests/exceptions/StoryError.py
+++ b/tests/unittests/exceptions/StoryError.py
@@ -26,7 +26,7 @@ def test_storyerror_init(storyerror, error):
     assert storyerror.error == error
     assert storyerror.story == 'story'
     assert storyerror.path is None
-    assert storyerror.error_code is None
+    assert storyerror.error_tuple is None
     assert issubclass(StoryError, SyntaxError)
 
 
@@ -114,7 +114,7 @@ def test_storyerror_highlight(patch, storyerror, error):
 
 
 def test_storyerror_hint(storyerror):
-    storyerror.error_code = ('code', 'hint')
+    storyerror.error_tuple = ('code', 'hint')
     assert storyerror.hint() == 'hint'
 
 
@@ -152,7 +152,7 @@ def test_storyerror_identify_unexpected_characters(patch, storyerror):
 def test_storyerror_process(patch, storyerror):
     patch.object(StoryError, 'identify')
     storyerror.process()
-    assert storyerror.error_code == storyerror.identify()
+    assert storyerror.error_tuple == storyerror.identify()
 
 
 def test_storyerror_message(patch, storyerror):

--- a/tests/unittests/exceptions/StoryError.py
+++ b/tests/unittests/exceptions/StoryError.py
@@ -113,6 +113,11 @@ def test_storyerror_highlight(patch, storyerror, error):
     assert result == '{}|    {}\n{}'.format(*args)
 
 
+def test_storyerror_error_code(storyerror):
+    storyerror.error_tuple = ('code', 'hint')
+    assert storyerror.error_code() == 'code'
+
+
 def test_storyerror_hint(storyerror):
     storyerror.error_tuple = ('code', 'hint')
     assert storyerror.hint() == 'hint'
@@ -156,11 +161,13 @@ def test_storyerror_process(patch, storyerror):
 
 
 def test_storyerror_message(patch, storyerror):
-    patch.many(StoryError, ['process', 'header', 'highlight', 'hint'])
+    patch.many(StoryError,
+               ['process', 'header', 'highlight', 'error_code', 'hint'])
     result = storyerror.message()
     assert storyerror.process.call_count == 1
-    args = (storyerror.header(), storyerror.highlight(), storyerror.hint())
-    assert result == '{}\n\n{}\n\n{}'.format(*args)
+    args = (storyerror.header(), storyerror.highlight(),
+            storyerror.error_code(), storyerror.hint())
+    assert result == '{}\n\n{}\n\n{}: {}'.format(*args)
 
 
 def test_storyerror_echo(patch, storyerror):


### PR DESCRIPTION
Closes https://github.com/storyscript/storyscript/issues/462
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/asyncy/storyscript/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- renamed `error_code` to `error_tuple` as it is a better name, containing both the error code and hint.
- added a new `error_code` function to extract error code from `error_tuple`
- changed the format string to print the code with the message.
- Changed and Added tests to reflect changes

**- How to verify it**
As mentioned in the original issue.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Feature: Errors now print error code as well as hint.