### PR TITLE
Assignment errors

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -57,6 +57,7 @@ class ErrorCodes:
         'E0039',
         'You have defined a chained mutation, but not a mutation')
     compiler_error_no_operator = ('E0040', 'No operator provided')
+    invalid_token = ('E0041', '`{}` is not allowed here')
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -84,7 +84,10 @@ class StoryError(SyntaxError):
         Provides an hint for the current error.
         """
         if self.error_tuple == ErrorCodes.unidentified_error:
-            return self.error.message()
+            if hasattr(self.error, 'message'):
+                return self.error.message()
+            else:
+                return str(self.error)
         else:
             return self.error_tuple[1]
 

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -88,8 +88,10 @@ class StoryError(SyntaxError):
                 return self.error.message()
             else:
                 return str(self.error)
-        else:
-            return self.error_tuple[1]
+        if self.error_tuple == ErrorCodes.invalid_token:
+            return self.error_tuple[1].format(
+                    self.get_line()[self.error.column - 1])
+        return self.error_tuple[1]
 
     def identify(self):
         """
@@ -108,6 +110,7 @@ class StoryError(SyntaxError):
         elif isinstance(self.error, UnexpectedCharacters):
             if intention.is_function():
                 return ErrorCodes.function_misspell
+            return ErrorCodes.invalid_token
         return ErrorCodes.unidentified_error
 
     def process(self):

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -76,3 +76,13 @@ def test_exception_file_not_found(capsys):
         Story.from_file('this-file-does-not-exist')
     message = e.value.message()
     assert 'File "this-file-does-not-exist" not found at' in message
+
+
+def test_exception_dollar(capsys):
+    with raises(StoryError) as e:
+        Story('x = $').process()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
+    assert lines[0] == 'Error: syntax error in story at line 1, column 5'
+    assert lines[2] == '1|    x = $'
+    assert lines[5] == 'E0041: `$` is not allowed here'

--- a/tests/unittests/exceptions/StoryError.py
+++ b/tests/unittests/exceptions/StoryError.py
@@ -126,6 +126,18 @@ def test_storyerror_hint(storyerror):
     assert storyerror.hint() == 'hint'
 
 
+def test_storyerror_hint_unidentified_error(storyerror):
+    storyerror.error_tuple = ErrorCodes.unidentified_error
+    storyerror.error = Exception('Custom.Error')
+    assert storyerror.hint() == 'Custom.Error'
+
+
+def test_storyerror_hint_unidentified_compiler_error(storyerror):
+    storyerror.error_tuple = ErrorCodes.unidentified_error
+    storyerror.error = CompilerError(None, message='Custom.Compiler.Error')
+    assert storyerror.hint() == 'Custom.Compiler.Error'
+
+
 def test_storyerror_identify(storyerror):
     storyerror.error.error = 'none'
     assert storyerror.identify() == ErrorCodes.unidentified_error
@@ -155,6 +167,16 @@ def test_storyerror_identify_unexpected_characters(patch, storyerror):
     patch.object(StoryError, 'get_line')
     storyerror.error = UnexpectedCharacters('seq', 'lex', 0, 0)
     assert storyerror.identify() == ErrorCodes.function_misspell
+
+
+def test_storyerror_identify_unexpected_characters_unidentified(
+        patch, storyerror):
+    patch.init(UnexpectedCharacters)
+    patch.init(Intention)
+    patch.object(Intention, 'is_function', return_value=False)
+    patch.object(StoryError, 'get_line')
+    storyerror.error = UnexpectedCharacters('seq', 'lex', 0, 0)
+    assert storyerror.identify() == ErrorCodes.unidentified_error
 
 
 def test_storyerror_process(patch, storyerror):

--- a/tests/unittests/exceptions/StoryError.py
+++ b/tests/unittests/exceptions/StoryError.py
@@ -138,6 +138,13 @@ def test_storyerror_hint_unidentified_compiler_error(storyerror):
     assert storyerror.hint() == 'Custom.Compiler.Error'
 
 
+def test_storyerror_hint_invalid_token(patch, storyerror):
+    patch.object(storyerror, 'get_line', return_value='x = $')
+    storyerror.error = UnexpectedCharacters('seq', 0, line=1, column=5)
+    storyerror.error_tuple = ErrorCodes.invalid_token
+    assert storyerror.hint() == '`$` is not allowed here'
+
+
 def test_storyerror_identify(storyerror):
     storyerror.error.error = 'none'
     assert storyerror.identify() == ErrorCodes.unidentified_error
@@ -176,7 +183,7 @@ def test_storyerror_identify_unexpected_characters_unidentified(
     patch.object(Intention, 'is_function', return_value=False)
     patch.object(StoryError, 'get_line')
     storyerror.error = UnexpectedCharacters('seq', 'lex', 0, 0)
-    assert storyerror.identify() == ErrorCodes.unidentified_error
+    assert storyerror.identify() == ErrorCodes.invalid_token
 
 
 def test_storyerror_process(patch, storyerror):


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/372

**What I did**
- Added E0041 as generic, formattable error message for invalid tokens

**Example**

```coffee
x = $
```

Before:

```
Error: syntax error in 372.story at line 1, column 6

1|    x = 3$
           ^
```

Now:

```
Error: syntax error in story at line 1, column 5

1|    x = $
          ^

E0041: `$` is not allowed here
```

Note that  when we can detect no intention here, displaying the `invalid_token` message is always correct as the parser didn't allow the token here and we're just translating the Lark exception. It's also a bit better than an unidentified error.


(this needs https://github.com/storyscript/storyscript/pull/473 which is why ca389f1 is included here too).