### PR TITLE
feat(compiler): allow function calls with zero arguments

### DIFF
--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -93,5 +93,25 @@ class Transformer(LarkTransformer):
         cls.implicit_output(matches[0])
         return Tree('when_block', matches)
 
+    expected_nodes_abs_exp_zero_args = [
+        'entity', 'factor', 'exponential', 'multiplication', 'expression'
+    ]
+
+    @classmethod
+    def absolute_expression(cls, matches):
+        """
+        Transform zero-argument expression into service blocks
+        """
+        if len(matches) == 1:
+            path = matches[0].follow_node_chain([
+                'expression', 'multiplication', 'exponential', 'factor',
+                'entity', 'path'
+            ])
+            if path is not None:
+                service_fragment = Tree('service_fragment', [])
+                service = Tree('service', [path, service_fragment])
+                return Tree('service_block', [service])
+        return Tree('absolute_expression', matches)
+
     def __getattr__(self, attribute, *args):
         return lambda matches: Tree(attribute, matches)

--- a/storyscript/parser/Tree.py
+++ b/storyscript/parser/Tree.py
@@ -133,5 +133,29 @@ class Tree(LarkTree):
         if not cond:
             raise CompilerError(error, tree=self)
 
+    def follow_node_chain(self, expected_nodes):
+        """
+        Checks whether all expected nodes can seen in the tree
+        Returns the lowest expected node if all expected nodes and
+        no other nodes have been observed, `None` otherwise.
+        """
+        if len(self.children) != 1:
+            return None
+        it = self.iter_subtrees()
+        exp = reversed(expected_nodes)
+        # save path for efficiency
+        path = next(it)
+        if path.data != next(exp):
+            return None
+        while True:
+            p = next(it, None)
+            e = next(exp, None)
+            if p is None and e is None:
+                return path
+            if p is None or e is None:
+                return None
+            if p.data != e:
+                return None
+
     def __getattr__(self, attribute):
         return self.node(attribute)

--- a/tests/integration/Api.py
+++ b/tests/integration/Api.py
@@ -13,10 +13,10 @@ def test_api_load_map_compiling_try_block():
     """
     Ensures Api.load functions return errors
     """
-    files = {'asd': 'foo'}
+    files = {'asd': 'foo ='}
     with raises(StoryError) as e:
         Api.load_map(files)
-    assert e.value.short_message() == 'E0040: No operator provided'
+    assert e.value.short_message() == 'E0007: Missing value after `=`'
 
 
 def test_api_load_map_compiling_try_block_loads():
@@ -24,16 +24,16 @@ def test_api_load_map_compiling_try_block_loads():
     Ensures Api.load functions return errors
     """
     with raises(StoryError) as e:
-        Api.loads('foo')
-    assert e.value.short_message() == 'E0040: No operator provided'
+        Api.loads('foo =')
+    assert e.value.short_message() == 'E0007: Missing value after `=`'
     e.value.with_color = False
     assert e.value.message() == \
-        """Error: syntax error in story at line 1, column 1
+        """Error: syntax error in story at line 1, column 6
 
-1|    foo
-      ^^^
+1|    foo =
+           ^
 
-E0040: No operator provided"""
+E0007: Missing value after `=`"""
 
 
 def test_api_load_map_syntax_error():

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -358,3 +358,13 @@ def test_compiler_try_nested_raise_error(parser):
     assert result['tree']['5']['method'] == 'raise'
     assert result['tree']['5']['parent'] == '4'
     assert result['tree']['5']['args'] == args
+
+
+def test_compiler_service_with_zero_args(parser):
+    source = 'foo'
+    tree = parser.parse(source)
+    result = Compiler.compile(tree)
+    assert result['tree']['1']['method'] == 'execute'
+    assert result['tree']['1']['service'] == 'foo'
+    assert result['tree']['1']['args'] == []
+    assert result['services'] == ['foo']

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -154,3 +154,31 @@ def test_transformer_rules(rule):
     assert isinstance(result, Tree)
     assert result.data == rule
     assert result.children == ['matches']
+
+
+def test_transformer_absolute_expression(patch, tree):
+    """
+    Ensures absolute_expression are untouched when they don't contain
+    just a path
+    """
+    patch.object(Tree, 'follow_node_chain')
+    tree.follow_node_chain.return_value = None
+    result = Transformer.absolute_expression([tree])
+    assert result == Tree('absolute_expression', [tree])
+    result = Transformer.absolute_expression([tree, tree])
+    assert result == Tree('absolute_expression', [tree, tree])
+
+
+def test_transformer_absolute_expression_zero(patch, tree, magic):
+    """
+    Ensures absolute_expression are untouched when they don't contain
+    just a path
+    """
+    patch.object(Tree, 'follow_node_chain')
+    m = magic()
+    tree.follow_node_chain.return_value = m
+    result = Transformer.absolute_expression([tree])
+    expected = Tree('service_block', [
+        Tree('service', [m, Tree('service_fragment', [])])
+    ])
+    assert result == expected


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/377

**- What I did**

- Added a transformer for zero-argument function calls (as `absolute_expression`) to `service`s

**- Description for the changelog**

Functions and services without arguments can now be called.