### PR TITLE
chore(grammar): Remove comments about the raise_statement

### DIFF
--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -108,9 +108,6 @@ class Grammar:
         self.ebnf.absolute_expression = 'expression'
 
     def raise_statement(self):
-        # NOTE(@wilzbach): raise can't be ignored as it is required to infer
-        # the line without children
-        # raise is a statement or a block?????
         self.ebnf.RAISE = 'raise'
         self.ebnf.raise_statement = ('raise entity?')
 


### PR DESCRIPTION
tl;dr: it's a statement - [no need for the five question marks](https://github.com/storyscript/storyscript/blame/master/storyscript/parser/Grammar.py#L113).

Statement: https://en.wikipedia.org/wiki/Statement_(computer_science)

> A program written in such a language is formed by a sequence of one or more statements. A statement may have internal components (e.g., expressions).

Also note that your blocks are typically called compound statements.


In other words: it can only span a single line (like `imports` or `assignments`), "blocks" (aka compound statements) can span multiple statements (lines).