### PR TITLE
feat(compiler): allow escaping curly braces in strings

### DIFF
--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -100,7 +100,7 @@ class Objects:
         are processed and compiled.
         """
         item = {'$OBJECT': 'string', 'string': cls.unescape_string(tree)}
-        matches = re.findall(r'{([^}]*)}', item['string'])
+        matches = re.findall(r'(?<!\\){(.*?)(?<!\\)}', item['string'])
         if matches == []:
             return item
         item['values'] = cls.fillers_values(matches)

--- a/tests/unittests/compiler/Objects.py
+++ b/tests/unittests/compiler/Objects.py
@@ -143,15 +143,16 @@ def test_objects_string(patch, tree):
     patch.object(re, 'findall', return_value=[])
     result = Objects.string(tree)
     Objects.unescape_string.assert_called_with(tree)
-    re.findall.assert_called_with(r'{([^}]*)}', Objects.unescape_string())
+    re.findall.assert_called_with(r'(?<!\\){(.*?)(?<!\\)}',
+                                  Objects.unescape_string())
     assert result == {'$OBJECT': 'string', 'string': Objects.unescape_string()}
 
 
 def test_objects_string_templating(patch):
     patch.many(Objects, ['unescape_string', 'fillers_values',
                          'replace_fillers'])
-    patch.object(re, 'findall', return_value=['color'])
-    tree = Tree('string', [Token('DOUBLE_QUOTED', '"{color}"')])
+    patch.object(re, 'findall', return_value=['var'])
+    tree = Tree('string', [Token('DOUBLE_QUOTED', '"{var} is \\{notvar\\}"')])
     result = Objects.string(tree)
     Objects.fillers_values.assert_called_with(re.findall())
     Objects.replace_fillers.assert_called_with(Objects.unescape_string(),


### PR DESCRIPTION
**- What I did**
- Changed the string regex to ignore `{` and `}` if they are preceded by `\`

**- How to verify it**
Check the tree with the following story
```
a = "{this} is a variable \{that\} is not"
```
The tree will consider `this` as a variable and `that` as not.

**- Description for the changelog**
feat(compiler): made escaping curly braces possible

Closes https://github.com/storyscript/storyscript/issues/442