### PR TITLE
refactor(preprocessor): transform the preprocessor into a generic visitor

### DIFF
--- a/tests/unittests/compiler/Preprocessor.py
+++ b/tests/unittests/compiler/Preprocessor.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
+
 from pytest import fixture
 
 from storyscript.compiler import FakeTree, Preprocessor
 
 
 @fixture
-def fake_tree(patch):
-    patch.object(Preprocessor, 'fake_tree')
-    return Preprocessor.fake_tree
+def preprocessor(patch):
+    patch.init(FakeTree)
+    patch.object(Preprocessor, 'fake_tree', return_value=FakeTree(None))
+    return Preprocessor()
 
 
 def test_preprocessor_fake_tree(patch):
@@ -17,167 +20,261 @@ def test_preprocessor_fake_tree(patch):
     assert isinstance(result, FakeTree)
 
 
-def test_preprocessor_replace_expression(magic, tree):
-    parent = magic()
-    expression = magic()
-    Preprocessor.replace_expression(tree, parent, expression)
-    tree.add_assignment.assert_called_with(expression.service)
-    assignment = tree.add_assignment().path.child()
-    entity = parent.expression.multiplication.exponential.factor.entity
+def test_preprocessor_replace_expression(magic, preprocessor):
+    """
+    Check that the new assignment is inserted above the tree
+    """
+    node = magic()
+    entity = magic()
+    entity.line = lambda: 42
+    entity.path.line = lambda: 123
+    fake_tree = magic()
+    preprocessor.replace_expression(node, fake_tree, entity)
+    fake_tree.add_assignment.assert_called_with(node.service)
+    assignment = fake_tree.add_assignment().path.child()
     entity.path.replace.assert_called_with(0, assignment)
+    assert entity.path.children[0].line == 42
+    assert entity.path.line() == 123
 
 
-def test_preprocessor_replace_expression_argument(magic, tree):
-    parent = magic(expression=None)
-    expression = magic()
-    Preprocessor.replace_expression(tree, parent, expression)
-    tree.add_assignment.assert_called_with(expression.service)
-    assignment = tree.add_assignment().path.child()
-    parent.entity.path.replace.assert_called_with(0, assignment)
-
-
-def test_preprocessor_replace_in_entity(magic, tree, block, fake_tree):
-    path_value = magic()
-    Preprocessor.replace_in_entity(block, tree, path_value)
-    fake_tree.assert_called_with(block)
-    service = path_value.path.inline_expression.service
-    fake_tree().add_assignment.assert_called_with(service)
-    path_value.replace.assert_called_with(0, fake_tree().add_assignment().path)
-    assert path_value.path.children[0].line == tree.line()
-
-
-def test_preprocessor_service_arguments(patch, magic, tree, fake_tree):
-    patch.object(Preprocessor, 'replace_expression')
-    argument = magic()
-    tree.find_data.return_value = [argument]
-    Preprocessor.service_arguments('block', tree)
-    fake_tree.assert_called_with('block')
-    tree.find_data.assert_called_with('arguments')
-    argument.node.assert_called_with('entity.path.inline_expression')
-    args = (fake_tree(), argument, argument.node())
-    Preprocessor.replace_expression.assert_called_with(*args)
-
-
-def test_preprocessor_service_arguments_no_expression(patch, magic, tree):
-    patch.many(Preprocessor, ['fake_tree', 'replace_expression'])
-    argument = magic(inline_expression=None)
-    tree.service_fragment.find_data.return_value = [argument]
-    Preprocessor.service_arguments(magic(), tree)
-    assert Preprocessor.replace_expression.call_count == 0
-
-
-def test_preprocessor_assignment_expression(patch, magic, tree, fake_tree):
-    patch.object(Preprocessor, 'replace_expression')
-    block = magic()
-    Preprocessor.assignment_expression(block, tree)
-    fake_tree.assert_called_with(block)
-    parent = block.rules.assignment.assignment_fragment
-    args = (fake_tree(), parent, tree.inline_expression)
-    Preprocessor.replace_expression.assert_called_with(*args)
-
-
-def test_preprocessor_assignments(patch, magic, tree):
+def test_preprocessor_process(patch, magic, preprocessor):
     """
-    Ensures Preprocessor.assignments can process lines like
-    a = alpine echo text:(random value)
+    Check that process initializes the visitor correctly
     """
-    patch.object(Preprocessor, 'service_arguments')
-    assignment = magic()
-    tree.find_data.return_value = [assignment]
-    Preprocessor.assignments(tree)
-    args = (tree, assignment.assignment_fragment.service)
-    Preprocessor.service_arguments.assert_called_with(*args)
-
-
-def test_preprocessor_assignments_to_expression(patch, magic, tree):
-    """
-    Ensures Preprocessor.assignments can process lines like
-    a = (alpine echo message:'text')
-    """
-    patch.object(Preprocessor, 'assignment_expression')
-    assignment = magic()
-    assignment.assignment_fragment.service = None
-    tree.find_data.return_value = [assignment]
-    Preprocessor.assignments(tree)
-    fragment = assignment.assignment_fragment
-    factor = fragment.expression.multiplication.exponential.factor
-    args = (tree, factor.entity.path)
-    Preprocessor.assignment_expression.assert_called_with(*args)
-
-
-def test_preprocessor_assignments_no_expression(patch, magic, tree):
-    patch.object(Preprocessor, 'assignment_expression')
-    assignment = magic()
-    assignment.assignment_fragment.service = None
-    fragment = assignment.assignment_fragment
-    factor = fragment.expression.multiplication.exponential.factor
-    factor.entity.path.inline_expression = None
-    tree.find_data.return_value = [assignment]
-    Preprocessor.assignments(tree)
-    assert Preprocessor.assignment_expression.call_count == 0
-
-
-def test_preprocessor_service(patch, magic, tree):
-    patch.object(Preprocessor, 'service_arguments')
-    Preprocessor.service(tree)
-    tree.node.assert_called_with('service_block.service')
-    Preprocessor.service_arguments.assert_called_with(tree, tree.node())
-
-
-def test_preprocessor_service_no_service(patch, magic, tree):
-    patch.object(Preprocessor, 'service_arguments')
-    tree.node.return_value = None
-    Preprocessor.service(tree)
-    assert Preprocessor.service_arguments.call_count == 0
-
-
-def test_preprocessor_flow_statement(patch, magic, tree):
-    """
-    Ensures flow_statement replaces inline expressions inside if statements
-    """
-    patch.object(Preprocessor, 'replace_in_entity')
-    statement = magic()
-    statement.child.return_value = None
-    tree.find_data.return_value = [statement]
-    Preprocessor.flow_statement('statement', tree)
-    tree.find_data.assert_called_with('statement')
-    statement.node.assert_called_with('entity.path.inline_expression')
-    args = (tree, statement, statement.entity)
-    Preprocessor.replace_in_entity.assert_called_with(*args)
-
-
-def test_preprocessor_flow_statement_rhs(patch, magic, tree):
-    """
-    Ensures flow_statement replaces inline expressions on the right hand-side
-    of statements
-    """
-    patch.object(Preprocessor, 'replace_in_entity')
-    statement = magic()
-    statement.node.return_value = None
-    tree.find_data.return_value = [statement]
-    Preprocessor.flow_statement('statement', tree)
-    args = (tree, statement, statement.child())
-    Preprocessor.replace_in_entity.assert_called_with(*args)
-
-
-def test_preprocessor_flow_statement_no_expression(patch, magic, tree):
-    """
-    Ensures flow_statement ignores statements without inline expressions
-    """
-    patch.object(Preprocessor, 'replace_in_entity')
-    statement = magic()
-    statement.child.return_value = None
-    statement.node.return_value = None
-    tree.find_data.return_value = [statement]
-    Preprocessor.flow_statement('statement', tree)
-    assert Preprocessor.replace_in_entity.call_count == 0
-
-
-def test_preprocessor_process(patch, magic, tree, block):
-    patch.many(Preprocessor, ['assignments', 'service', 'flow_statement'])
-    tree.find_data.return_value = [block]
-    result = Preprocessor.process(tree)
-    Preprocessor.assignments.assert_called_with(block)
-    Preprocessor.service.assert_called_with(block)
-    Preprocessor.flow_statement.assert_called_with('elseif_statement', block)
+    patch.object(Preprocessor, 'visit')
+    tree = magic()
+    result = preprocessor.process(tree)
     assert result == tree
+    preprocessor.visit.assert_called_with(
+        tree, None, None, preprocessor.is_inline_expression,
+        preprocessor.replace_expression)
+
+
+def test_preprocessor_is_inline_expression(magic):
+    """
+    Check that inline_expressions are correctly detected
+    """
+    n = magic()
+    assert not Preprocessor.is_inline_expression(n)
+    n.data = 'foo'
+    assert not Preprocessor.is_inline_expression(n)
+    n.data = 'inline_expression'
+    assert Preprocessor.is_inline_expression(n)
+
+
+def test_preprocessor_visit_empty(patch, magic, preprocessor):
+    """
+    Check that no inline_expression is found
+    """
+    patch.object(Preprocessor, 'replace_expression')
+    tree = magic()
+    preprocessor.process(tree)
+    assert not preprocessor.replace_expression.called
+
+
+def test_preprocessor_visit_no_children(patch, magic, preprocessor):
+    """
+    Check that no inline_expression is found
+    """
+    patch.object(Preprocessor, 'replace_expression')
+    tree = magic()
+    tree.children = []
+    preprocessor.process(tree)
+    assert not preprocessor.replace_expression.called
+
+
+def test_preprocessor_visit_one_children(patch, magic, preprocessor):
+    """
+    Check that a single inline_expression is found
+    """
+    tree = magic()
+    c1 = magic()
+    replace = magic()
+    c1.children = [magic()]
+    tree.children = [c1]
+
+    def is_inline(n):
+        return n == c1
+    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.fake_tree.assert_called_with('.block.')
+    replace.assert_called_with(c1, preprocessor.fake_tree(), '.entity.')
+    assert replace.call_count == 1
+
+
+def test_preprocessor_visit_two_children(patch, magic, preprocessor):
+    """
+    Check that all inline_expressions are found
+    """
+    tree = magic()
+    tree.children = cs = [magic(), magic()]
+    replace = magic()
+    for c in cs:
+        c.children = [magic()]
+
+    def is_inline(n):
+        return n == cs[0] or n == cs[1]
+
+    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    replace.mock_calls = [
+        mock.call(cs[0], preprocessor.fake_tree(), '.entity.'),
+        mock.call(cs[1], preprocessor.fake_tree(), '.entity.'),
+    ]
+
+
+def test_preprocessor_visit_nested_multiple(patch, magic, preprocessor):
+    """
+    Check that all inline_expressions are found (even if they are nested)
+    """
+    tree = magic()
+    replace = magic()
+    cs = [magic(), magic()]
+    for c in cs:
+        c.children = [magic()]
+
+    tree.children = [cs[0]]
+    cs[0].children = [cs[1]]
+
+    def is_inline(n):
+        return n == cs[0] or n == cs[1]
+
+    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    replace.mock_calls = [
+        mock.call(cs[1], preprocessor.fake_tree(), '.entity.'),
+        mock.call(cs[0], preprocessor.fake_tree(), '.entity.'),
+    ]
+
+
+def test_preprocessor_visit_nested_inner(patch, magic, preprocessor):
+    """
+    Check that a nested inline_expression is called if it's deeper in the tree
+    """
+    tree = magic()
+    replace = magic()
+    cs = [magic(), magic()]
+    for c in cs:
+        c.children = [magic()]
+
+    tree.children = [cs[0]]
+    cs[0].children = [cs[1]]
+
+    def is_inline(n):
+        return n == cs[1]
+
+    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    replace.mock_calls = [
+        mock.call(cs[1], preprocessor.fake_tree(), '.entity.'),
+    ]
+
+
+def test_preprocessor_visit_nested_multiple_block(patch, magic, preprocessor):
+    """
+    Check that the fake tree is always generated from the nearest block
+    """
+    tree = magic()
+    tree.data = 'block'
+    replace = magic()
+    cs = [magic(), magic()]
+    for c in cs:
+        c.children = [magic()]
+
+    tree.children = [cs[0]]
+    cs[0].children = [cs[1]]
+
+    def is_inline(n):
+        return n == cs[0] or n == cs[1]
+
+    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.fake_tree.mock_calls = [
+        mock.call(tree),
+        mock.call(tree),
+    ]
+    replace.mock_calls = [
+        mock.call(cs[1], preprocessor.fake_tree(), '.entity.'),
+        mock.call(cs[0], preprocessor.fake_tree(), '.entity.'),
+    ]
+
+
+def test_preprocessor_visit_nested_multiple_block_nearest(patch,
+                                                          magic, preprocessor):
+    """
+    Check that the fake tree is always generated from the nearest block
+    """
+    patch.object(Preprocessor, 'fake_tree')
+    tree = magic()
+    tree.data = 'block'
+    replace = magic()
+    cs = [magic(), magic()]
+    for c in cs:
+        c.children = [magic()]
+
+    tree.children = [cs[0]]
+    cs[0].children = [cs[1]]
+    cs[0].data = 'block'
+
+    def is_inline(n):
+        return n == cs[0] or n == cs[1]
+
+    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    replace.mock_calls = [
+        mock.call(cs[1], preprocessor.fake_tree(cs[0]), '.entity.'),
+        mock.call(cs[0], preprocessor.fake_tree(cs[1]), '.entity.'),
+    ]
+
+
+def test_preprocessor_visit_nested_parent(patch, magic, preprocessor):
+    """
+    Check that the parent is always from the taken from the parent entity
+    """
+    tree = magic()
+    tree.data = 'entity'
+    replace = magic()
+    cs = [magic(), magic()]
+    for c in cs:
+        c.children = [magic()]
+
+    tree.children = [cs[0]]
+    cs[0].children = [cs[1]]
+    cs[0].children = 'entity'
+
+    def is_inline(n):
+        return n == cs[0] or n == cs[1]
+
+    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.fake_tree.mock_calls = [
+        mock.call(tree),
+        mock.call(tree),
+    ]
+    replace.mock_calls = [
+        mock.call(cs[1], preprocessor.fake_tree(), cs[0]),
+        mock.call(cs[0], preprocessor.fake_tree(), tree),
+    ]
+
+
+def test_preprocessor_visit_nested_same_fake_tree(patch, magic, preprocessor):
+    """
+    Check that multiple nested statements are inserted in the same fake_tree
+    """
+    patch.object(Preprocessor, 'fake_tree')
+    tree = magic()
+    tree.data = 'service_block'
+    replace = magic()
+    cs = [magic(), magic()]
+    for c in cs:
+        c.children = [magic()]
+
+    tree.children = [cs[0]]
+    cs[0].children = [cs[1]]
+    cs[0].children = 'entity'
+
+    def is_inline(n):
+        return n == cs[0] or n == cs[1]
+
+    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    # fake_tree is only called once
+    preprocessor.fake_tree.mock_calls = [
+        mock.call(tree),
+    ]
+    replace.mock_calls = [
+        mock.call(cs[1], preprocessor.fake_tree(tree), cs[0]),
+        mock.call(cs[0], preprocessor.fake_tree(tree), tree),
+    ]


### PR DESCRIPTION
**- What I did**

Refactored the Preprocessor into an understandable visitor as it was super-hard to debug it while I was working on introducing complex expressions everywhere (https://github.com/storyscript/storyscript/issues/420). 

Motivation:

- it already reduces the code size

```
1 file changed, 34 insertions(+), 74 deletions(-)
```

- this will make it easier to understand the preprocessor (only one behavior now)
- this will make it a lot easier to add new language constructs that use `inline_expression` (i.e. no changes necessary)
- this is faster than iterating over the entire tree multiple times with `find_data` (and the out-of-box iteration in LARK is slow too, which they admit themselves: https://github.com/lark-parser/lark/blob/8cc53379ec498f7d70a45a23a604b36537ac94f6/lark/tree.py#L84)

**- How I did it**

- A visitor goes down from the tree to the children
- Whenever a `block` or `entity` node is found, that's saved to the visitor state
  - `block` is necessary to know where the assignments should be inserted (though we cheat here a bit as the grammar is currently defined in such a way that every line will always be its own `block`)
  - `entity` is the parent where the reference to the new fake line should be replaced into
- All `inline_expression`s are replaced with the current visitor state


I split this up from my upcoming PR for https://github.com/storyscript/storyscript/issues/420 as it can be reviewed independently and I wanted to show that no changes to the integration test suite are required.