### PR TITLE
feat(CLI): allow optional preprocessing of the AST

### DIFF
--- a/storyscript/App.py
+++ b/storyscript/App.py
@@ -2,6 +2,7 @@
 import json
 
 from .Bundle import Bundle
+from .compiler.Preprocessor import Preprocessor
 from .parser import Grammar
 
 
@@ -11,12 +12,16 @@ class App:
     """
 
     @staticmethod
-    def parse(path, ignored_path=None, ebnf=None):
+    def parse(path, ignored_path=None, ebnf=None, preprocess=False):
         """
         Parses stories found in path, returning their trees
         """
         bundle = Bundle.from_path(path, ignored_path=ignored_path)
-        return bundle.bundle_trees(ebnf=ebnf)
+        stories = bundle.bundle_trees(ebnf=ebnf)
+        if preprocess:
+            for story, tree in stories.items():
+                stories[story] = Preprocessor.process(tree)
+        return stories
 
     @staticmethod
     def compile(path, ignored_path=None, ebnf=None):

--- a/storyscript/Cli.py
+++ b/storyscript/Cli.py
@@ -39,14 +39,16 @@ class Cli:
     @click.option('--debug', is_flag=True)
     @click.option('--ebnf', help=ebnf_help)
     @click.option('--raw', is_flag=True)
+    @click.option('--preprocess', is_flag=True)
     @click.option('--ignore', default=None,
                   help='Specify path of ignored files')
-    def parse(path, debug, ebnf, raw, ignore):
+    def parse(path, debug, ebnf, raw, ignore, preprocess):
         """
         Parses stories, producing the abstract syntax tree.
         """
         try:
-            trees = App.parse(path, ignored_path=ignore, ebnf=ebnf)
+            trees = App.parse(path, ignored_path=ignore, ebnf=ebnf,
+                              preprocess=preprocess)
             for story, tree in trees.items():
                 click.echo('File: {}'.format(story))
                 if raw:

--- a/tests/unittests/App.py
+++ b/tests/unittests/App.py
@@ -5,6 +5,7 @@ from pytest import fixture
 
 from storyscript.App import App
 from storyscript.Bundle import Bundle
+from storyscript.compiler.Preprocessor import Preprocessor
 from storyscript.parser import Grammar
 
 
@@ -34,6 +35,20 @@ def test_app_parse_ebnf(bundle):
     """
     App.parse('path', ebnf='ebnf')
     Bundle.from_path().bundle_trees.assert_called_with(ebnf='ebnf')
+
+
+def test_app_parse_preprocess(patch, bundle, magic):
+    """
+    Ensures App.parse applies the preprocessor
+    """
+    patch.object(Preprocessor, 'process')
+    story = magic()
+    Bundle.from_path().bundle_trees.return_value = {'foo.story': story}
+    result = App.parse('path', preprocess=True)
+    assert Preprocessor.process.call_count == 1
+    Bundle.from_path.assert_called_with('path', ignored_path=None)
+    Bundle.from_path().bundle_trees.assert_called_with(ebnf=None)
+    assert result == {'foo.story': Preprocessor.process(story)}
 
 
 def test_app_compile(patch, bundle):

--- a/tests/unittests/Cli.py
+++ b/tests/unittests/Cli.py
@@ -107,7 +107,8 @@ def test_cli_parse_with_ignore_option(runner, app):
     runner.invoke(Cli.parse, ['path/fake.story', '--ignore',
                               'path/sub_dir/my_fake.story'])
     App.parse.assert_called_with('path/fake.story', ebnf=None,
-                                 ignored_path='path/sub_dir/my_fake.story')
+                                 ignored_path='path/sub_dir/my_fake.story',
+                                 preprocess=False)
 
 
 def test_cli_parse(runner, echo, app, tree):
@@ -117,7 +118,7 @@ def test_cli_parse(runner, echo, app, tree):
     App.parse.return_value = {'path': tree}
     runner.invoke(Cli.parse, [])
     App.parse.assert_called_with(os.getcwd(), ebnf=None,
-                                 ignored_path=None)
+                                 ignored_path=None, preprocess=False)
     click.echo.assert_called_with(tree.pretty())
 
 
@@ -136,7 +137,7 @@ def test_cli_parse_path(runner, echo, app):
     """
     runner.invoke(Cli.parse, ['/path'])
     App.parse.assert_called_with('/path', ebnf=None,
-                                 ignored_path=None)
+                                 ignored_path=None, preprocess=False)
 
 
 def test_cli_parse_ebnf(runner, echo, app):
@@ -145,7 +146,16 @@ def test_cli_parse_ebnf(runner, echo, app):
     """
     runner.invoke(Cli.parse, ['--ebnf', 'test.ebnf'])
     App.parse.assert_called_with(os.getcwd(), ebnf='test.ebnf',
-                                 ignored_path=None)
+                                 ignored_path=None, preprocess=False)
+
+
+def test_cli_parse_preprocess(runner, echo, app):
+    """
+    Ensures the parse command supports preprocessing
+    """
+    runner.invoke(Cli.parse, ['--preprocess'])
+    App.parse.assert_called_with(os.getcwd(), ebnf=None,
+                                 ignored_path=None, preprocess=True)
 
 
 def test_cli_parse_debug(runner, echo, app):


### PR DESCRIPTION
Closes https://github.com/storyscript/storyscript/issues/505

**- What I did**

Just applied the diff from https://github.com/storyscript/storyscript/issues/505, propagated to App and added tests.
I was needing this for two PRs now (the preprocessor is tricky), so instead of applying my diff every time, it, it's not too much work to get this in master.

**- Description for the changelog**

`--preprocess` has been added to `storyscript parse`, which allows to run the preprocessor on the AST as well. A similar flag has been ade