### PR TITLE
refactor(Compiler): be explicit about handling of 'null'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,15 @@ jobs:
                 #paths:
                     #- ./venv
                 #key: v1-dependencies-{{ checksum "setup.py" }}
+            - run:
+                name: Apply CodeCov workaround for excluding lines
+                command: |
+                  # Workaround for https://github.com/codecov/codecov-python/issues/107
+                  sed 's/internal_assert(0)/# ignored for CodeCov/' \
+                  -i $(find storyscript -type f -name '*.py')
+                  sed 's/from.*internal_assert/# ignored for CodeCov/' \
+                  -i $(find storyscript -type f -name '*.py' \
+                    -not -name '*__init__.py')
 
             - run:
                 name: run unit tests

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,5 @@ omit =
   setup.py
   venv/*
   .tox/*
+exclude_lines =
+    internal_assert(0)

--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -3,6 +3,7 @@ import re
 
 from lark.lexer import Token
 
+from ..exceptions import internal_assert
 from ..parser import Tree
 
 
@@ -174,8 +175,11 @@ class Objects:
                 return cls.regular_expression(subtree)
             elif subtree.data == 'types':
                 return cls.types(subtree)
+            elif subtree.data == 'void':
+                return None
         if subtree.type == 'NAME':
             return cls.path(tree)
+        internal_assert(0)
 
     @classmethod
     def argument(cls, tree):

--- a/storyscript/exceptions/InternalCompilerError.py
+++ b/storyscript/exceptions/InternalCompilerError.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+
+class InternalCompilerError(BaseException):
+    """
+    An internal compiler error is unrecoverable and fatal.
+    It should never happen for any user input.
+    """
+
+    def __init__(self, message=''):
+        self.message = message
+        pass
+
+    def __str__(self):
+        return self.message
+
+
+def internal_assert(a, b=None):
+    """
+    Make assertions about the compiler logic.
+    Their failure will result in a hard InternalCompilerError.
+    """
+    if b is None:
+        if not a:
+            message = 'Internal Error'
+            raise InternalCompilerError(message)
+    elif a != b:
+        message = f'{str(a)} != {str(b)}'
+        raise InternalCompilerError(message)

--- a/storyscript/exceptions/__init__.py
+++ b/storyscript/exceptions/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from .CompilerError import CompilerError
+from .InternalCompilerError import InternalCompilerError, internal_assert
 from .ProcessingError import ProcessingError
 from .StoryError import StoryError
 from .StorySyntaxError import StorySyntaxError
 
-__all__ = ['CompilerError', 'ProcessingError', 'StoryError',
-           'StorySyntaxError']
+__all__ = ['CompilerError', 'InternalCompilerError', 'internal_assert',
+           'ProcessingError', 'StoryError', 'StorySyntaxError']

--- a/tests/unittests/exceptions/InternalCompilerError.py
+++ b/tests/unittests/exceptions/InternalCompilerError.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from pytest import raises
+
+from storyscript.exceptions import InternalCompilerError, internal_assert
+
+
+def test_internal_assert_0():
+    with raises(InternalCompilerError) as e:
+        internal_assert(0)
+    assert e.value.message == 'Internal Error'
+
+
+def test_internal_assert_equal():
+    with raises(InternalCompilerError) as e:
+        internal_assert(1, 2)
+    assert e.value.message == '1 != 2'


### PR DESCRIPTION
Found this one while debugging the Compiler. Explicitness would have helped quite a bit here.

**- What I did**

Made sure that no unhandled types are getting passed to `values` and get silently swollen.