### PR TITLE
 fix(parse): allow numbers and floats with a plus/minus sign

### DIFF
--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -51,6 +51,8 @@ class Objects:
         Compiles a number tree
         """
         token = tree.child(0)
+        if token.value[0] == '+':
+            token.value = token.value[1:]
         if token.type == 'FLOAT':
             return float(token.value)
         return int(token.value)

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -44,8 +44,10 @@ class Grammar:
         self.ebnf.TRUE = 'true'
         self.ebnf.FALSE = 'false'
         self.ebnf.NULL = 'null'
-        self.ebnf.set_token('INT.2', r'/[0-9]+/')
-        self.ebnf.set_token('FLOAT.2', 'INT "." INT? | "." INT')
+        self.ebnf.set_token('RAW_INT.2', r'/[0-9]+/')
+        self.ebnf.set_token('INT.2', '("+"|"-")? RAW_INT')
+        self.ebnf.set_token('FLOAT.2', '("+"|"-")? INT "." RAW_INT? | '
+                            '"." RAW_INT')
         self.ebnf.SINGLE_QUOTED = "/'([^']*)'/"
         self.ebnf.DOUBLE_QUOTED = '/"([^"]*)"/'
         self.ebnf.set_token('REGEXP.2', r'/\/([^\/]*)\//')
@@ -99,7 +101,7 @@ class Grammar:
         self.ebnf.NOT = 'not'
         self.ebnf.AND = 'and'
         self.ebnf.OR = 'or'
-        self.ebnf.factor = '(dash, plus)? entity, op expression cp'
+        self.ebnf.factor = 'entity, op expression cp'
         self.ebnf.exponential = 'factor (power exponential)?'
         self.ebnf.multiplication = ('exponential (( multiplier, bslash, '
                                     'modulus ) exponential)*')

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -383,3 +383,85 @@ def test_compiler_empty_files(parser):
     result = Compiler.compile(tree)
     assert result['tree'] == {}
     assert result['entrypoint'] is None
+
+
+def test_compiler_expression_signed_number(parser):
+    """
+    Ensures that signed numbers are compiled correctly
+    """
+    result = Compiler.compile(parser.parse('a = -2'))
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['args'] == [-2]
+
+    result = Compiler.compile(parser.parse('a = +2'))
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['args'] == [2]
+
+
+def test_compiler_expression_signed_number_complex(parser):
+    """
+    Ensures that signed numbers are compiled correctly
+    """
+    result = Compiler.compile(parser.parse('a = 2 + -3'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'][0]['expression'] == 'sum'
+    assert result['tree']['1']['args'][0]['values'] == [2, -3]
+
+    result = Compiler.compile(parser.parse('a = -2 + 3'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'][0]['expression'] == 'sum'
+    assert result['tree']['1']['args'][0]['values'] == [-2, 3]
+
+
+def test_compiler_expression_signed_number_absolute(parser):
+    """
+    Ensures that absolute signed numbers are compiled correctly
+    """
+    result = Compiler.compile(parser.parse('-2'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [-2]
+
+    result = Compiler.compile(parser.parse('+2'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [2]
+
+
+def test_compiler_expression_signed_float(parser):
+    """
+    Ensures that signed numbers are compiled correctly
+    """
+    result = Compiler.compile(parser.parse('a = -5.5'))
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['args'] == [-5.5]
+
+    result = Compiler.compile(parser.parse('a = +5.5'))
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['args'] == [5.5]
+
+
+def test_compiler_expression_signed_float_absolute(parser):
+    """
+    Ensures that absolute signed numbers are compiled correctly
+    """
+    result = Compiler.compile(parser.parse('-5.5'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [-5.5]
+
+    result = Compiler.compile(parser.parse('+5.5'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [5.5]
+
+
+def test_compiler_expression_signed_float_complex(parser):
+    """
+    Ensures that signed numbers are compiled correctly
+    """
+    result = Compiler.compile(parser.parse('a = 2.5 + -3.5'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'][0]['expression'] == 'sum'
+    assert result['tree']['1']['args'][0]['values'] == [2.5, -3.5]
+
+    result = Compiler.compile(parser.parse('a = -2.5 + 3.5'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'][0]['expression'] == 'sum'
+    assert result['tree']['1']['args'][0]['values'] == [-2.5, 3.5]

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -196,3 +196,19 @@ def test_parser_try_raise_error_message(parser):
     assert raise_statement.child(0) == 'raise'
     token = Token('DOUBLE_QUOTED', '"error"')
     assert raise_statement.entity.values.string.child(0) == token
+
+
+@mark.parametrize('number', ['+10', '-10'])
+def test_parser_number_int(parser, number):
+    result = parser.parse(number)
+    f = result.block.rules.absolute_expression.expression.multiplication. \
+        exponential.factor.entity.values.number
+    assert f.child(0) == Token('INT', number)
+
+
+@mark.parametrize('number', ['+10.0', '-10.0'])
+def test_parser_number_float(parser, number):
+    result = parser.parse(number)
+    f = result.block.rules.absolute_expression.expression.multiplication. \
+        exponential.factor.entity.values.number
+    assert f.child(0) == Token('FLOAT', number)

--- a/tests/integration/parser/Values.py
+++ b/tests/integration/parser/Values.py
@@ -42,8 +42,7 @@ def test_values_int_negative(parser):
     result = parser.parse('-3\n')
     expression = result.block.rules.absolute_expression.expression
     factor = expression.multiplication.exponential.factor
-    assert factor.child(0) == '-'
-    assert factor.entity.values.number.child(0) == Token('INT', 3)
+    assert factor.entity.values.number.child(0) == Token('INT', '-3')
 
 
 def test_values_float(parser):
@@ -63,8 +62,7 @@ def test_values_float_negative(parser):
     result = parser.parse('-3.14\n')
     expression = result.block.rules.absolute_expression.expression
     factor = expression.multiplication.exponential.factor
-    assert factor.child(0) == '-'
-    assert factor.entity.values.number.child(0) == Token('FLOAT', 3.14)
+    assert factor.entity.values.number.child(0) == Token('FLOAT', '-3.14')
 
 
 def test_values_single_quoted_string(parser):

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -98,17 +98,45 @@ def test_compiler_expression(patch, compiler, lines, tree):
                                     parent='1')
 
 
-def test_compiler_expression_assignment(patch, compiler, lines, tree):
-    patch.object(Compiler, 'expression')
-    compiler.expression_assignment(tree, 'name', '1')
-    Compiler.expression.assert_called_with(tree, '1')
-    lines.set_name.assert_called_with('name')
+def test_compiler_unary_expression(patch, compiler, lines, tree):
+    patch.object(Lines, 'append')
+    patch.object(Objects, 'entity')
+    method = 'set.method'
+    parent = '.parent.'
+    compiler.unary_expression(tree, parent, method)
+    args = [Objects.entity(tree.expression.multiplication.exponential.
+                           factor.entity)]
+    lines.append.assert_called_with(method, tree.line(), args=args,
+                                    parent=parent)
+
+
+def test_compiler_unary_expression_name(patch, compiler, lines, tree):
+    patch.object(Lines, 'append')
+    patch.object(Objects, 'entity')
+    method = 'set.method'
+    parent = '.parent.'
+    name = '.name.'
+    line = '.line.'
+    compiler.unary_expression(tree, parent, method, name=name, line=line)
+    args = [Objects.entity(tree.expression.multiplication.exponential.
+                           factor.entity)]
+    lines.append.assert_called_with(method, line, args=args, parent=parent,
+                                    name=name)
 
 
 def test_compiler_absolute_expression(patch, compiler, lines, tree):
     patch.object(Compiler, 'expression')
+    tree.expression.is_unary.return_value = False
     compiler.absolute_expression(tree, '1')
     Compiler.expression.assert_called_with(tree, '1')
+
+
+def test_compiler_absolute_expression_unary(patch, compiler, lines, tree):
+    patch.object(Compiler, 'unary_expression')
+    tree.expression.is_unary.return_value = True
+    compiler.absolute_expression(tree, '1')
+    Compiler.unary_expression.assert_called_with(tree, '1',
+                                                 method='expression')
 
 
 def test_compiler_assignment(patch, compiler, lines, tree):
@@ -151,13 +179,14 @@ def test_compiler_assignment_mutation(patch, compiler, lines, tree):
 
 def test_compiler_assignment_expression(patch, compiler, lines, tree):
     patch.object(Objects, 'names', return_value='name')
-    patch.object(Compiler, 'expression_assignment')
+    patch.object(Compiler, 'expression')
     tree.assignment_fragment.service = None
     tree.assignment_fragment.mutation = None
     tree.assignment_fragment.expression.is_unary.return_value = False
     compiler.assignment(tree, '1')
     fragment = tree.assignment_fragment
-    Compiler.expression_assignment.assert_called_with(fragment, 'name', '1')
+    Compiler.expression.assert_called_with(fragment, '1')
+    lines.set_name.assert_called_with('name')
 
 
 def test_compiler_arguments(patch, compiler, lines, tree):

--- a/tests/unittests/compiler/Objects.py
+++ b/tests/unittests/compiler/Objects.py
@@ -97,6 +97,10 @@ def test_objects_number():
     """
     tree = Tree('number', [Token('INT', '1')])
     assert Objects.number(tree) == 1
+    tree = Tree('number', [Token('INT', '+1')])
+    assert Objects.number(tree) == 1
+    tree = Tree('number', [Token('INT', '-1')])
+    assert Objects.number(tree) == -1
 
 
 def test_objects_number_float():
@@ -105,6 +109,10 @@ def test_objects_number_float():
     """
     tree = Tree('number', [Token('FLOAT', '1.2')])
     assert Objects.number(tree) == 1.2
+    tree = Tree('number', [Token('FLOAT', '+1.2')])
+    assert Objects.number(tree) == 1.2
+    tree = Tree('number', [Token('FLOAT', '-1.2')])
+    assert Objects.number(tree) == -1.2
 
 
 def test_objects_replace_fillers():

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -104,7 +104,7 @@ def test_grammar_expressions(grammar, ebnf):
     assert ebnf.NOT == 'not'
     assert ebnf.AND == 'and'
     assert ebnf.OR == 'or'
-    assert ebnf.factor == '(dash, plus)? entity, op expression cp'
+    assert ebnf.factor == 'entity, op expression cp'
     assert ebnf.exponential == 'factor (power exponential)?'
     assert ebnf.multiplication == ('exponential (( multiplier, bslash, '
                                    'modulus ) exponential)*')


### PR DESCRIPTION
Closes https://github.com/storyscript/storyscript/issues/501

**- What I did**

- Modified the Grammar to allow plus/minus sign directly with numbers (now `-2` is the actual value, and it's no longer a lost `-` child somewhere up the tree)
- Added integration tests for the compiler
- Modified the Compiler to allow unary expressions in global/absolute_expressions, e.g. `2` triggered an error until, but `2 + 2` was ok.

**- Description for the changelog**

- Negative signs are no longer dropped from numeric values
- Numbers are now valid global expressions
