### PR TITLE
Fix: The compiler should create reproducible builds

### DIFF
--- a/storyscript/compiler/Faketree.py
+++ b/storyscript/compiler/Faketree.py
@@ -22,7 +22,10 @@ class FakeTree:
         parts = line.split('.')
         if len(parts) > 1:
             line = '.'.join(parts[:-1])
-        fake_line = f'{line}.{len(self.new_lines)}'
+        # We start at .1, s.t. lines from L1 are called L1.1 and not L1.0
+        # to avoid any potential confusion
+        new_suffix = len(self.new_lines) + 1
+        fake_line = f'{line}.{new_suffix}'
         self.new_lines[fake_line] = None
         return fake_line
 

--- a/storyscript/compiler/Faketree.py
+++ b/storyscript/compiler/Faketree.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import random
-import uuid
 
 from lark.lexer import Token
 
@@ -41,10 +40,10 @@ class FakeTree:
         """
         Creates a fake tree path.
         """
-        if name is None:
-            name = '${}'.format(uuid.uuid4().hex[:8])
         if line is None:
             line = self.line()
+        if name is None:
+            name = f'p-{line}'
         return Tree('path', [Token('NAME', name, line=line)])
 
     def assignment(self, value):

--- a/storyscript/compiler/Faketree.py
+++ b/storyscript/compiler/Faketree.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import random
-
 from lark.lexer import Token
 
 from ..parser import Tree
@@ -12,27 +10,27 @@ class FakeTree:
     """
     def __init__(self, block):
         self.block = block
-        self.original_line = block.line()
-        self.new_lines = []
+        self.original_line = str(block.line())
+        self.new_lines = {}
 
     def line(self):
         """
-        Creates fake line numbers. The numbers are decreasing, so that the
-        resulting tree is compiled correctly.
+        Creates fake line numbers. The strings are decreasingly sorted,
+        so that the resulting tree is compiled correctly.
         """
-        lower_bound = float(self.original_line) - 1.0
-        upper_bound = float(self.original_line)
-        if len(self.new_lines) > 0:
-            lower_bound = self.new_lines[-1]
-        fake_line = random.uniform(lower_bound, upper_bound)
-        self.new_lines.append(fake_line)
-        return str(fake_line)
+        line = self.original_line
+        parts = line.split('.')
+        if len(parts) > 1:
+            line = '.'.join(parts[:-1])
+        fake_line = f'{line}.{len(self.new_lines)}'
+        self.new_lines[fake_line] = None
+        return fake_line
 
     def get_line(self, tree):
         """
         Gets the tree line if it's a new one, otherwise creates it.
         """
-        if float(tree.line()) in self.new_lines:
+        if tree.line() in self.new_lines:
             return tree.line()
         return self.line()
 

--- a/storyscript/compiler/Lines.py
+++ b/storyscript/compiler/Lines.py
@@ -17,8 +17,13 @@ class Lines:
     def sort(self):
         """
         Returns ordered line numbers
+        Inserted fake lines ('.' suffix) must appear before their inserted
+        line, but after their original's line previous line.
         """
-        return sorted(self.lines.keys(), key=lambda x: float(x))
+        # Generates this sorting: 0, 1.0.9, 1.0, 1.1, 1, 2
+        return sorted(self.lines.keys(), reverse=True,
+                      key=lambda x: list(map(
+                          lambda i: -int(i), x.split('.'))))
 
     def first(self):
         """

--- a/tests/unittests/compiler/Faketree.py
+++ b/tests/unittests/compiler/Faketree.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import random
-
 from lark.lexer import Token
 
 from pytest import fixture
@@ -16,30 +14,27 @@ def fake_tree(block):
 
 def test_faketree_init(block, fake_tree):
     assert fake_tree.block == block
-    assert fake_tree.original_line == block.line()
-    assert fake_tree.new_lines == []
+    assert fake_tree.original_line == str(block.line())
+    assert fake_tree.new_lines == {}
 
 
 def test_faketree_line(patch, fake_tree):
     """
     Ensures FakeTree.line can create a fake line number
     """
-    patch.object(random, 'uniform')
-    fake_tree.original_line = '1.2'
+    fake_tree.original_line = '1'
     result = fake_tree.line()
-    random.uniform.assert_called_with(1.2 - 1, 1.2)
-    assert fake_tree.new_lines == [random.uniform()]
-    assert result == str(random.uniform())
+    assert fake_tree.new_lines == {'1.0': None}
+    assert result == '1.0'
 
 
 def test_faketree_line_successive(patch, fake_tree):
     """
     Ensures FakeTree.line takes into account FakeTree.new_lines
     """
-    patch.object(random, 'uniform')
-    fake_tree.new_lines = [0.2]
-    fake_tree.line()
-    random.uniform.assert_called_with(0.2, 1)
+    fake_tree.original_line = '1.0'
+    fake_tree.new_lines = {'1.0': None}
+    assert fake_tree.line() == '1.1'
 
 
 def test_faketree_get_line(patch, tree, fake_tree):
@@ -55,7 +50,7 @@ def test_faketree_get_line_existing(tree, fake_tree):
     """
     Ensures FakeTree.get_line gets the existing line when appropriate.
     """
-    fake_tree.new_lines = [0.1]
+    fake_tree.new_lines = {'0.1': None}
     tree.line.return_value = '0.1'
     assert fake_tree.get_line(tree) == tree.line()
 

--- a/tests/unittests/compiler/Faketree.py
+++ b/tests/unittests/compiler/Faketree.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import random
-import uuid
 
 from lark.lexer import Token
 
@@ -62,15 +61,16 @@ def test_faketree_get_line_existing(tree, fake_tree):
 
 
 def test_faketree_path(patch, fake_tree):
-    patch.object(uuid, 'uuid4')
     patch.object(FakeTree, 'line')
+    FakeTree.line.return_value = 'fake.line'
     result = fake_tree.path()
-    name = '${}'.format(uuid.uuid4().hex[:8])
+    name = 'p-fake.line'
     assert result == Tree('path', [Token('NAME', name, line=FakeTree.line())])
 
 
 def test_faketree_path_name(patch, fake_tree):
     patch.object(FakeTree, 'line')
+    FakeTree.line.return_value = 'fake.line'
     result = fake_tree.path(name='x')
     assert result.child(0).value == 'x'
 

--- a/tests/unittests/compiler/Faketree.py
+++ b/tests/unittests/compiler/Faketree.py
@@ -24,17 +24,17 @@ def test_faketree_line(patch, fake_tree):
     """
     fake_tree.original_line = '1'
     result = fake_tree.line()
-    assert fake_tree.new_lines == {'1.0': None}
-    assert result == '1.0'
+    assert fake_tree.new_lines == {'1.1': None}
+    assert result == '1.1'
 
 
 def test_faketree_line_successive(patch, fake_tree):
     """
     Ensures FakeTree.line takes into account FakeTree.new_lines
     """
-    fake_tree.original_line = '1.0'
-    fake_tree.new_lines = {'1.0': None}
-    assert fake_tree.line() == '1.1'
+    fake_tree.original_line = '1.1'
+    fake_tree.new_lines = {'1.1': None}
+    assert fake_tree.line() == '1.2'
 
 
 def test_faketree_get_line(patch, tree, fake_tree):

--- a/tests/unittests/compiler/Lines.py
+++ b/tests/unittests/compiler/Lines.py
@@ -21,7 +21,41 @@ def test_lines_init(lines):
 
 def test_lines_sort(lines):
     lines.lines = {'1': '1', '2': '2', '2.1': '2'}
-    assert lines.sort() == ['1', '2', '2.1']
+    assert lines.sort() == ['1', '2.1', '2']
+
+
+def test_lines_sort_complex(lines):
+    lines.lines = {'1': '.', '1.0': '.', '1.1': '.'}
+    assert lines.sort() == ['1.0', '1.1', '1']
+
+
+def test_lines_sort_more_complex(lines):
+    lines.lines = {
+        '1': '.', '1.0': '.', '1.1': '.',
+        '0': '.', '2': '.', '2.1': '.',
+        '1.9.0': '.', '1.6': '.', '1.4.1': '.',
+        '1.1.0': '.', '1.0.0': '.', '1.0.1': '.',
+        '1.1.26': '.', '1.1.3': '.',
+        '1.0.9': '.', '1.0.22': '.',
+    }
+    assert lines.sort() == [
+        '0',
+        '1.0.0',
+        '1.0.1',
+        '1.0.9',
+        '1.0.22',
+        '1.0',
+        '1.1.0',
+        '1.1.3',
+        '1.1.26',
+        '1.1',
+        '1.4.1',
+        '1.6',
+        '1.9.0',
+        '1',
+        '2.1',
+        '2',
+    ]
 
 
 def test_lines_first(patch, lines):


### PR DESCRIPTION
Closes https://github.com/storyscript/storyscript/issues/504

**- What I did**

- generate non-random path (based on the line number), e.g. `p-42`
- generate non-random fake line numbers (based on the original_line + number of insertions), e.g. `1.0.0`
- adjust sorting in `Lines` to sort the stable fake line-numbers correctly
- changed `new_lines` to a dict as its only used for `get_line` and now the lookup is in `O(log n)` and not in `O(n)`

**- How I did it**

- there can only be one name set per fake line number (aka statement) as it's a top-level attribute, thus we can use the line number
- the fake line number was more difficult to get done nicely as `Lines` still constantly resorts the existing lines, but the trick here is to (1) split by the parts (s.t. inserted lines will always be after their insertion), use (2) `int` mapping, s.t. `23` comes before `9`.  Now, of course, I didn't mistype the inserted lines come after their insertion, so the real trick is to use reverse sort on the negative numbers as with negative numbers only the ordering of items with the same number of elements changes, s.t. with by reversing we effectively keep the order of items with the same number of elements, but reverse the order of elements with different number of elements (`[[1], [1, 2]] -> [[1, 2], 1]`).

As this might be a hard to grasp, here's an example:

```
> l = [['1', '0', '21'], ['1', '0', '4'], ['1', '1'], ['1'], ['2']]
> sorted(l)
[['1'], ['1', '0', '21'], ['1', '0', '4'], ['1', '1'], ['2']]
> sorted(l, key=lambda k: list(map(int, k)))
[['1'], ['1', '0', '4'], ['1', '0', '21'], ['1', '1'], ['2']]
> sorted(l, key=lambda k: list(map(lambda x: -int(x), k)))
[['2'], ['1'], ['1', '1'], ['1', '0', '21'], ['1', '0', '4']]
> sorted(l, key=lambda k: list(map(lambda x: -int(x), k)), reverse=True)
[['1', '0', '4'], ['1', '0', '21'], ['1', '1'], ['1'], ['2']]
```

Though on the long-run we should remove really the constant sorting in `Lines`.

**- Description for the changelog**

Path name and line number no longer uses randomness and thus builds are now [reproducible](https://reproducible-builds.org/),