### PR TITLE
Fix: Do not allow function redeclaring

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -58,6 +58,9 @@ class ErrorCodes:
         'You have defined a chained mutation, but not a mutation')
     compiler_error_no_operator = ('E0040', 'No operator provided')
     invalid_token = ('E0041', '`{}` is not allowed here')
+    function_already_declared = (
+        'E0042',
+        '`{}` has already been declared at line {}')
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -232,7 +232,13 @@ class Compiler:
         args = Objects.function_arguments(function)
         output = self.function_output(function)
         nested_block = tree.nested_block
-        self.lines.append('function', line, function=function.child(1).value,
+        function_name = function.child(1).value
+        if function_name in self.lines.functions:
+            raise CompilerError(
+                'function_already_declared', token=function.child(1),
+                function_name=function_name,
+                previous_line=self.lines.functions[function_name])
+        self.lines.append('function', line, function=function_name,
                           output=output, args=args, enter=nested_block.line(),
                           parent=parent)
         self.subtree(nested_block, parent=line)

--- a/storyscript/exceptions/CompilerError.py
+++ b/storyscript/exceptions/CompilerError.py
@@ -3,14 +3,27 @@ from .ProcessingError import ProcessingError
 from ..ErrorCodes import ErrorCodes
 
 
+class ConstDict:
+    """
+    Like a dict, but as constant attributes
+    """
+
+    def __init__(self, data):
+        self.data = data
+
+    def __getattr__(self, attr):
+        return self.data[attr]
+
+
 class CompilerError(ProcessingError):
     """
     A compiler error that occurs despite the syntax being correct, for example
     a return outside of a function.
     """
-    def __init__(self, error, token=None, tree=None, message=''):
+    def __init__(self, error, token=None, tree=None, message='', **kwargs):
         super().__init__(error, token=token, tree=tree)
         self._message = message
+        self.extra = ConstDict(kwargs)
 
     def __str__(self):
         if len(self._message) > 0:

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -91,6 +91,10 @@ class StoryError(SyntaxError):
         if self.error_tuple == ErrorCodes.invalid_token:
             return self.error_tuple[1].format(
                     self.get_line()[self.error.column - 1])
+        elif self.error_tuple == ErrorCodes.function_already_declared:
+            extra = self.error.extra
+            return self.error_tuple[1].format(extra.function_name,
+                                              extra.previous_line)
         return self.error_tuple[1]
 
     def identify(self):

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -86,3 +86,13 @@ def test_exception_dollar(capsys):
     assert lines[0] == 'Error: syntax error in story at line 1, column 5'
     assert lines[2] == '1|    x = $'
     assert lines[5] == 'E0041: `$` is not allowed here'
+
+
+def test_exception_function_redeclared(capsys):
+    with raises(StoryError) as e:
+        Story('function f1\n\treturn 42\nfunction f1\n\treturn 42\n').process()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
+    assert lines[0] == 'Error: syntax error in story at line 3, column 10'
+    assert lines[2] == '3|    function f1'
+    assert lines[5] == 'E0042: `f1` has already been declared at line 1'

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -413,6 +413,20 @@ def test_compiler_function_block(patch, compiler, lines, tree):
     compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
+def test_compiler_function_block_redeclared(patch, compiler, lines, tree):
+    patch.object(Objects, 'function_arguments')
+    patch.many(Compiler, ['subtree', 'function_output'])
+    compiler.lines.functions = {'.function.': '0'}
+    statement = tree.function_statement
+    statement.child(1).value = '.function.'
+    with raises(CompilerError) as e:
+        compiler.function_block(tree, '1')
+
+    e.value.extra.function_name = '.function.'
+    e.value.extra.previous_line = '0'
+    e.value.extra.error = 'function_already_declared'
+
+
 def test_compiler_raise_statement(patch, compiler, lines, tree):
     tree.children = [Token('RAISE', 'raise')]
     compiler.raise_statement(tree, '1')

--- a/tests/unittests/exceptions/CompilerError.py
+++ b/tests/unittests/exceptions/CompilerError.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+from pytest import raises
+
 from storyscript.ErrorCodes import ErrorCodes
-from storyscript.exceptions import CompilerError, ProcessingError
+from storyscript.exceptions import ProcessingError
+from storyscript.exceptions.CompilerError import CompilerError, ConstDict
 
 
 def test_compilererror():
@@ -20,3 +23,17 @@ def test_error_message(patch):
     ErrorCodes.is_error.return_value = False
     e3 = CompilerError(None)
     assert str(e3) == 'Unknown compiler error'
+
+
+def test_const_dict():
+    d = ConstDict({'foo': 'bar', 'f2': 'b2'})
+    assert d.foo == 'bar'
+    assert d.f2 == 'b2'
+    with raises(Exception):
+        d.bar
+
+
+def test_compiler_error_extra_parameters():
+    e2 = CompilerError('my_custom_error', my_param='p1', my_param2='p2')
+    assert e2.extra.my_param == 'p1'
+    assert e2.extra.my_param2 == 'p2'

--- a/tests/unittests/exceptions/StoryError.py
+++ b/tests/unittests/exceptions/StoryError.py
@@ -145,6 +145,17 @@ def test_storyerror_hint_invalid_token(patch, storyerror):
     assert storyerror.hint() == '`$` is not allowed here'
 
 
+def test_storyerror_hint_redeclared(patch, storyerror, magic):
+    patch.object(storyerror, 'get_line', return_value='foo')
+    storyerror.error = UnexpectedCharacters('seq', 0, line=1, column=5)
+    storyerror.error = magic()
+    storyerror.error.extra.function_name = '.function_name.'
+    storyerror.error.extra.previous_line = '.previous.line.'
+    storyerror.error_tuple = ErrorCodes.function_already_declared
+    assert storyerror.hint() == \
+        '`.function_name.` has already been declared at line .previous.line.'
+
+
 def test_storyerror_identify(storyerror):
     storyerror.error.error = 'none'
     assert storyerror.identify() == ErrorCodes.unidentified_error


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/508

**- What I did**

- added support for storing extra arguments in the CompilerError
- check whether a function has already been declared (and yield a CompilerError)

## Example

```coffee
function foo
	return 1

function foo
	return 2
```

```
Error: syntax error in story at line 4, column 10

4|    function foo
               ^^^

E0042: `foo` has already been declared at line 1
```

**- Description for the changelog**

Function can't be redeclared within the same story. Previously they would silently overwrite their previous declaration, now the Compiler will throw an Error.
