### PR TITLE
Lock the version of Lark to 0.6.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ classifiers = [
 requirements = [
     'click==7.0',
     'delegator.py>=0.1.1',
-    'lark-parser>=0.6.5',
+    'lark-parser==0.6.5',
     'click-alias==0.1.1a2'
 ]
 


### PR DESCRIPTION
Currently master is failing because a new version of lark breaks a few tests in Storyscript. I will go ahead and merge this for now, s.t. master is green and we can take more time to look into the failures when we decide to upgrade Lark.

**- What I did**

Locked the version of Lark to 0.6.5.