### PR TITLE
Add syntax for break

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -62,6 +62,7 @@ class ErrorCodes:
         'E0042',
         '`{}` has already been declared at line {}')
     unexpected_token = ('E0042', '`{}` is not allowed here. Allowed: {}')
+    break_outside = ('E00043', '`break` is allowed only inside loops')
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -340,6 +340,8 @@ class Compiler:
         self.subtree(nested_block, parent=line)
 
     def break_statement(self, tree, parent):
+        if parent is None:
+            raise CompilerError('break_outside', tree=tree)
         self.lines.append('break', tree.line(), parent=parent)
 
     def subtrees(self, *trees, parent=None):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -339,6 +339,9 @@ class Compiler:
                           parent=parent)
         self.subtree(nested_block, parent=line)
 
+    def break_statement(self, tree, parent):
+        self.lines.append('break', tree.line(), parent=parent)
+
     def subtrees(self, *trees, parent=None):
         """
         Parses many subtrees
@@ -356,7 +359,7 @@ class Compiler:
                          'foreach_block', 'function_block', 'when_block',
                          'try_block', 'return_statement', 'arguments',
                          'imports', 'while_block', 'raise_statement',
-                         'mutation_block', 'indented_chain']
+                         'break_statement', 'mutation_block', 'indented_chain']
         if tree.data in allowed_nodes:
             getattr(self, tree.data)(tree, parent)
             return

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -113,10 +113,12 @@ class Grammar:
 
     def rules(self):
         self.ebnf._RETURN = 'return'
+        self.ebnf.BREAK = 'break'
         self.ebnf.return_statement = 'return entity'
+        self.ebnf.break_statement = 'break'
         self.ebnf.entity = 'values, path'
         rules = ('absolute_expression, assignment, imports, return_statement, '
-                 'raise_statement, block')
+                 'raise_statement, break_statement, block')
         self.ebnf.rules = rules
 
     def mutation_block(self):

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -368,3 +368,11 @@ def test_compiler_service_with_zero_args(parser):
     assert result['tree']['1']['service'] == 'foo'
     assert result['tree']['1']['args'] == []
     assert result['services'] == ['foo']
+
+
+def test_compiler_break(parser):
+    source = 'while true\n\tbreak'
+    tree = parser.parse(source)
+    result = Compiler.compile(tree)
+    assert result['tree']['2']['method'] == 'break'
+    assert result['tree']['2']['parent'] == '1'

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -63,7 +63,8 @@ from storyscript.ErrorCodes import ErrorCodes
         '`mock` is reserved for future use')),
     ('arguments_nomutation', (
         'E0039',
-        'You have defined a chained mutation, but not a mutation'))
+        'You have defined a chained mutation, but not a mutation')),
+    ('break_outside', ('E00043', '`break` is allowed only inside loops'))
 ])
 def test_errorcodes(name, definition):
     assert ErrorCodes.get_error(name) == definition

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -598,9 +598,16 @@ def test_compiler_finally_block(patch, compiler, lines, tree):
     Compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
-def test_compiler_break_statement(patch, compiler, lines, tree):
+def test_compiler_break_statement(compiler, lines, tree):
     compiler.break_statement(tree, '1')
     lines.append.assert_called_with('break', tree.line(), parent='1')
+
+
+def test_compiler_break_statement_outside(patch, compiler, lines, tree):
+    patch.init(CompilerError)
+    with raises(CompilerError):
+        compiler.break_statement(tree, None)
+    CompilerError.__init__.assert_called_with('break_outside', tree=tree)
 
 
 @mark.parametrize('method_name', [

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -598,11 +598,16 @@ def test_compiler_finally_block(patch, compiler, lines, tree):
     Compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
+def test_compiler_break_statement(patch, compiler, lines, tree):
+    compiler.break_statement(tree, '1')
+    lines.append.assert_called_with('break', tree.line(), parent='1')
+
+
 @mark.parametrize('method_name', [
     'service_block', 'absolute_expression', 'assignment', 'if_block',
     'elseif_block', 'else_block', 'foreach_block', 'function_block',
     'when_block', 'try_block', 'return_statement', 'arguments', 'imports',
-    'mutation_block', 'indented_chain'
+    'mutation_block', 'indented_chain', 'break_statement'
 ])
 def test_compiler_subtree(patch, compiler, method_name):
     patch.object(Compiler, method_name)

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -122,10 +122,11 @@ def test_grammar_raise_statement(grammar, ebnf):
 def test_grammar_rules(grammar, ebnf):
     grammar.rules()
     assert ebnf._RETURN == 'return'
+    assert ebnf.BREAK == 'break'
     assert ebnf.entity == 'values, path'
     assert ebnf.return_statement == 'return entity'
     rules = ('absolute_expression, assignment, imports, return_statement, '
-             'raise_statement, block')
+             'raise_statement, break_statement, block')
     assert ebnf.rules == rules
 
 


### PR DESCRIPTION
closes #391

**- What I did**
Added `break` to the syntax and the `break_outside` error for when a break is outside of a block
