### PR TITLE
Fix #535 - Files with comments only cause unexpected exception

### DIFF
--- a/storyscript/Story.py
+++ b/storyscript/Story.py
@@ -17,7 +17,7 @@ class Story:
     """
 
     def __init__(self, story, path=None):
-        self.story = story
+        self.story = self.clean_source(story)
         self.path = path
 
     @staticmethod
@@ -51,7 +51,7 @@ class Story:
         msg = None
         try:
             with io.open(path, 'r') as file:
-                return cls.clean_source(file.read())
+                return file.read()
         except FileNotFoundError:
             abspath = os.path.abspath(path)
             msg = 'File "{}" not found at {}'.format(path, abspath)
@@ -71,7 +71,7 @@ class Story:
         """
         Creates a story from a stream source
         """
-        return Story(cls.clean_source(stream.read()))
+        return Story(stream.read())
 
     def error(self, error):
         """

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -220,6 +220,6 @@ class Grammar:
         self.try_block()
         self.raise_statement()
         self.block()
-        self.ebnf.start = 'nl? block+'
+        self.ebnf.start = 'nl? block*'
         self.ebnf.ignore('_WS')
         return self.ebnf.build()

--- a/tests/integration/Api.py
+++ b/tests/integration/Api.py
@@ -91,3 +91,10 @@ def test_api_load_ice():
         assert e.value.message() == \
             """Internal error occured: ICE
 Please report at https://github.com/storyscript/storyscript/issues"""
+
+
+def test_compiler_only_comments(parser):
+    api_result = Api.load_map({'a.story': '# foo\n'})
+    result = api_result['stories']['a.story']
+    assert result['tree'] == {}
+    assert result['entrypoint'] is None

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -376,3 +376,10 @@ def test_compiler_break(parser):
     result = Compiler.compile(tree)
     assert result['tree']['2']['method'] == 'break'
     assert result['tree']['2']['parent'] == '1'
+
+
+def test_compiler_empty_files(parser):
+    tree = parser.parse('\n\n')
+    result = Compiler.compile(tree)
+    assert result['tree'] == {}
+    assert result['entrypoint'] is None

--- a/tests/unittests/Story.py
+++ b/tests/unittests/Story.py
@@ -83,8 +83,18 @@ def test_story_read(patch):
     patch.object(Story, 'clean_source')
     result = Story.read('hello.story')
     io.open.assert_called_with('hello.story', 'r')
-    Story.clean_source.assert_called_with(io.open().__enter__().read())
-    assert result == Story.clean_source()
+    assert result == io.open().__enter__().read()
+
+
+def test_story_init_clean_source(patch):
+    """
+    Ensures Story.clean_source is called for new stories
+    """
+    patch.object(Story, 'clean_source')
+    source = 'my story'
+    story = Story(source)
+    Story.clean_source.assert_called_with(source)
+    assert story.story == Story.clean_source(source)
 
 
 def test_story_read_not_found(patch, capsys):
@@ -109,8 +119,7 @@ def test_story_from_stream(patch, magic):
     patch.object(Story, 'clean_source')
     stream = magic()
     result = Story.from_stream(stream)
-    Story.clean_source.assert_called_with(stream.read())
-    Story.__init__.assert_called_with(Story.clean_source())
+    Story.__init__.assert_called_with(stream.read())
     assert isinstance(result, Story)
 
 

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -236,6 +236,6 @@ def test_grammar_build(patch, call_count, grammar, ebnf):
     result = grammar.build()
     assert ebnf._WS == '(" ")+'
     call_count(Grammar, methods)
-    assert ebnf.start == 'nl? block+'
+    assert ebnf.start == 'nl? block*'
     ebnf.ignore.assert_called_with('_WS')
     assert result == ebnf.build()


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/535

**- What I did**

- allowed files without any statements (aka no blocks)
- changed `Story` to call `clean_source` while it's constructed as e.g. the API caller forgot to call it before

**- Description for the changelog**

Files without any statements are now valid.
