### PR TITLE
fix(Compiler): error codes should be four digits long

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -62,7 +62,7 @@ class ErrorCodes:
         'E0042',
         '`{}` has already been declared at line {}')
     unexpected_token = ('E0043', '`{}` is not allowed here. Allowed: {}')
-    break_outside = ('E00044', '`break` is allowed only inside loops')
+    break_outside = ('E0044', '`break` is allowed only inside loops')
 
     @staticmethod
     def is_error(error_name):

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -69,7 +69,7 @@ from storyscript.ErrorCodes import ErrorCodes
     ('function_already_declared',
         ('E0042', '`{}` has already been declared at line {}')),
     ('unexpected_token', ('E0043', '`{}` is not allowed here. Allowed: {}')),
-    ('break_outside', ('E00044', '`break` is allowed only inside loops'))
+    ('break_outside', ('E0044', '`break` is allowed only inside loops'))
 ])
 def test_errorcodes(name, definition):
     assert ErrorCodes.get_error(name) == definition


### PR DESCRIPTION
Introduced in https://github.com/storyscript/storyscript/pull/531.
On of the reasons why peer-review is a good idea.