### PR TITLE
feat(Compiler): support multi-line function arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
                 name: run unit tests
                 command: |
                     . venv/bin/activate
-                    tox -e pep8,py36-unit
+                    tox -e pep8,unit
 
             - run:
                 name: collect unit coverage
@@ -63,7 +63,7 @@ jobs:
                 name: run integration tests
                 command: |
                     . venv/bin/activate
-                    tox -e py36-integration
+                    tox -e integration
 
             - run:
                 name: collect integration coverage

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,5 @@
 [run]
 branch = True
-source =
-    app
 
 [report]
 omit =

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -255,7 +255,7 @@ class Compiler:
         function = tree.function_statement
         args = Objects.function_arguments(function)
         output = self.function_output(function)
-        nested_block = tree.nested_block
+        nested_block = tree.nested_block or tree.block
         function_name = function.child(1).value
         if function_name in self.lines.functions:
             raise CompilerError(

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -195,7 +195,14 @@ class Grammar:
         function_statement = ('function_type name typed_argument* '
                               'function_output?')
         self.ebnf.function_statement = function_statement
-        self.ebnf.function_block = self.ebnf.simple_block('function_statement')
+        self.ebnf._DOUBLE_DEDENT = '<DOUBLE_DEDENT>'
+        self.ebnf.indented_typed_arguments = \
+            'indent (typed_argument+ nl)+ dedent _DOUBLE_DEDENT'
+        self.ebnf.function_block = (
+            'function_statement nl '
+            '(indented_typed_arguments? block+ _DEDENT | '
+            'nested_block)'
+        )
 
     def try_block(self):
         self.ebnf.TRY = 'try'

--- a/storyscript/parser/Indenter.py
+++ b/storyscript/parser/Indenter.py
@@ -1,5 +1,66 @@
 # -*- coding: utf-8 -*-
-from lark.indenter import Indenter
+from lark.lexer import Token
+
+# Improved from https://github.com/lark-parser/lark/
+# blob/9b0672fda646c6bbe662e4e51d2d5e3bdc700d77/lark/indenter.py
+
+
+class Indenter:
+    def __init__(self):
+        self.paren_level = 0
+        self.indent_level = [0]
+
+    def handle_nl(self, token):
+        if self.paren_level > 0:
+            return
+
+        yield token
+
+        indent_str = token.rsplit('\n', 1)[1]  # Tabs and spaces
+        indent = indent_str.count(' ') + indent_str.count('\t') * self.tab_len
+
+        if indent > self.indent_level[-1]:
+            self.indent_level.append(indent)
+            yield Token.new_borrow_pos(self.INDENT_type, indent_str, token)
+        else:
+            last_pop = None
+            while indent < self.indent_level[-1]:
+                last_pop = self.indent_level.pop()
+                yield Token.new_borrow_pos(self.DEDENT_type, indent_str, token)
+
+            if indent != self.indent_level[-1]:
+                if indent > self.indent_level[-1]:
+                    self.indent_level.append(last_pop)
+                    yield Token.new_borrow_pos('_DOUBLE_DEDENT',
+                                               indent_str, token)
+                else:
+                    assert indent == self.indent_level[-1], \
+                        '%s != %s' % (indent, self.indent_level[-1])
+
+    def process(self, stream):
+        for token in stream:
+            if token.type == self.NL_type:
+                for t in self.handle_nl(token):
+                    yield t
+            else:
+                yield token
+
+            if token.type in self.OPEN_PAREN_types:
+                self.paren_level += 1
+            elif token.type in self.CLOSE_PAREN_types:
+                self.paren_level -= 1
+                assert self.paren_level >= 0
+
+        while len(self.indent_level) > 1:
+            self.indent_level.pop()
+            yield Token(self.DEDENT_type, '')
+
+        assert self.indent_level == [0], self.indent_level
+
+    # XXX Hack for ContextualLexer. Maybe there's a more elegant solution?
+    @property
+    def always_accept(self):
+        return (self.NL_type,)
 
 
 class CustomIndenter(Indenter):

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -111,5 +111,18 @@ class Transformer(LarkTransformer):
                 return Tree('service_block', [service])
         return Tree('absolute_expression', matches)
 
+    @classmethod
+    def function_block(cls, matches):
+        """
+        Transforms function blocks, moving indented arguments back to the first
+        node.
+        """
+        if len(matches) > 1:
+            if matches[1].data == 'indented_typed_arguments':
+                for argument in matches.pop(1).find_data('typed_argument'):
+                    matches[0].children.append(argument)
+
+        return Tree('function_block', matches)
+
     def __getattr__(self, attribute, *args):
         return lambda matches: Tree(attribute, matches)

--- a/tests/e2e/multi_line_function_arguments.json
+++ b/tests/e2e/multi_line_function_arguments.json
@@ -1,0 +1,93 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [],
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": "name",
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "key",
+          "argument": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "key2",
+          "argument": {
+            "$OBJECT": "type",
+            "type": "string"
+          }
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "key3",
+          "argument": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "key4",
+          "argument": {
+            "$OBJECT": "type",
+            "type": "string"
+          }
+        }
+      ],
+      "enter": "4",
+      "exit": null,
+      "parent": null,
+      "next": "4"
+    },
+    "4": {
+      "method": "set",
+      "ln": "4",
+      "output": null,
+      "name": [
+        "a"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1",
+      "next": "5"
+    },
+    "5": {
+      "method": "set",
+      "ln": "5",
+      "output": null,
+      "name": [
+        "b"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        1
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {
+    "name": "1"
+  },
+  "version": null
+}

--- a/tests/e2e/multi_line_function_arguments.story
+++ b/tests/e2e/multi_line_function_arguments.story
@@ -1,0 +1,5 @@
+function name key:int
+		key2:string key3:int
+		key4:string
+	a =0
+b=1

--- a/tests/e2e/multi_line_function_arguments2.error
+++ b/tests/e2e/multi_line_function_arguments2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 3, column 4
+
+3|    	a =0
+         ^
+
+E0041: `=` is not allowed here

--- a/tests/e2e/multi_line_function_arguments2.story
+++ b/tests/e2e/multi_line_function_arguments2.story
@@ -1,0 +1,4 @@
+function name key:int
+	key2:string key3:int
+	a =0
+b=1

--- a/tests/e2e/multi_line_function_arguments3.error
+++ b/tests/e2e/multi_line_function_arguments3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 3, column 1
+
+3|    b=1
+      ^
+
+E0046: An indented block is required to be before here

--- a/tests/e2e/multi_line_function_arguments3.story
+++ b/tests/e2e/multi_line_function_arguments3.story
@@ -1,0 +1,3 @@
+function name key:int
+	    key2:string key3:int
+b=1

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -5,10 +5,12 @@ import json
 from glob import glob
 from os import path
 
+from click import unstyle
+
 from pytest import mark
 
-from storyscript.compiler import Compiler
-from storyscript.parser import Parser
+from storyscript.Api import Api
+from storyscript.exceptions import StoryError
 
 test_dir = path.dirname(path.realpath(__file__))
 # make the test_file paths relative, s.t. the tests are nice to read
@@ -18,27 +20,56 @@ test_files = list(map(lambda e: path.relpath(e, test_dir),
 
 # compile a story and compare its tree with the expected tree
 def run_test_story(source, expected_story):
-    result = Compiler.compile(Parser().parse(source))
+    result = Api.loads(source)
     del result['version']
     del expected_story['version']
     assert result == expected_story
 
 
+# compile a story which should fail and compare its output text with the
+# expectation
+def run_fail_story(source, expected_output):
+    try:
+        Api.loads(source)
+    except StoryError as e:
+        result = unstyle(e.message())
+        assert result == expected_output
+        return
+
+    assert 0, 'The story was expected to fail, but did not fail.'
+
+
 # load a story from the file system and load its expected result file (.json)
 def run_test(story_path):
     story_string = None
-    expected_story = None
     with io.open(story_path, 'r') as f:
         story_string = f.read()
 
-    expected_path = path.splitext(story_path)[0] + '.json'
-    with io.open(expected_path, 'r') as f:
-        expected_story = f.read()
+    expected_path = path.splitext(story_path)[0]
+    if path.isfile(expected_path + '.json'):
+        expected_story = None
+        with io.open(expected_path + '.json', 'r') as f:
+            expected_story = f.read()
 
-    # deserialize the expected story
-    expected_story = json.loads(expected_story)
+        # deserialize the expected story
+        expected_story = json.loads(expected_story)
+        return run_test_story(story_string, expected_story)
 
-    run_test_story(story_string, expected_story)
+    if path.isfile(expected_path + '.error'):
+        expected_output = None
+        with io.open(expected_path + '.error', 'r') as f:
+            expected_output = f.read().strip()
+
+        # deserialize the expected story
+        return run_fail_story(story_string, expected_output)
+
+    # If no expected file has been found, print the current output to the user
+    # (for handy copy&paste)
+    try:
+        print(Api.loads(story_string))
+    except StoryError as e:
+        e.echo()
+    assert 0, f'{story_path} has no expected result file.'
 
 
 @mark.parametrize('test_file', test_files)

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
-import re
+from click import unstyle
 
 from pytest import raises
 
 from storyscript.Story import Story
 from storyscript.exceptions.StoryError import StoryError
-
-ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
 
 
 def test_exceptions_service_name(capsys):
@@ -15,7 +13,7 @@ def test_exceptions_service_name(capsys):
 
     message = e.value.message()
     # test with coloring once, but we representing ANSI color codes is tricky
-    lines = ansi_escape.sub('', message).splitlines()
+    lines = unstyle(message).splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 1'
     assert lines[2] == '1|    al.pine echo'
     assert lines[5] == "E0002: A service name can't contain `.`"

--- a/tests/integration/parser/Indenter.py
+++ b/tests/integration/parser/Indenter.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from lark.lexer import Token
+
+from storyscript.parser.Indenter import CustomIndenter
+
+
+A = Token('A', 'A')
+B = Token('B', 'B')
+C = Token('C', 'C')
+NL = Token('_NL', '\n')
+WHILE = Token('_WHILE', 'while')
+DEDENT = Token('_DEDENT', '')
+
+
+def indent_token(level, ws_type=' '):
+    ws = ''.join(ws_type for _ in range(level))
+    return Token('_NL', '\n' + ws), Token('_INDENT', ws)
+
+
+def indent_token_dedent(level, ws_type=' '):
+    ws = ''.join(ws_type for _ in range(level))
+    return (Token('_NL', '\n' + ws), Token('_INDENT', ws),
+            Token('_DEDENT', ws), Token('_DOUBLE_DEDENT', ws))
+
+
+def test_indenter_one_level():
+    """
+    while
+        a
+    b
+    """
+    indenter = CustomIndenter()
+    nl, indent = indent_token(4)
+    r = list(indenter.process([WHILE, nl, A, NL, B]))
+    assert r == [WHILE, nl, indent, A, NL, DEDENT, B]
+
+
+def test_indenter_one_level_multiple_statements():
+    """
+    while
+        a
+        b
+    c
+    """
+    indenter = CustomIndenter()
+    nl, indent = indent_token(4)
+    r = list(indenter.process([NL, WHILE, nl, A, nl, B, NL, C]))
+    assert r == [NL, WHILE, nl, indent, A, nl, B, NL, DEDENT, C]
+
+
+def test_indenter_two_levels():
+    """
+    while
+        a
+            b
+    c
+    """
+    indenter = CustomIndenter()
+    nl, indent = indent_token(4)
+    nl2, indent2 = indent_token(8)
+    r = list(indenter.process([WHILE, nl,
+                               A, nl2,
+                               B,
+                               NL, C]))
+    assert r == [WHILE, nl,
+                 indent, A, nl2,
+                 indent2, B, NL,
+                 DEDENT, DEDENT, C]
+
+
+def test_indenter_double_indent():
+    """
+    while
+            a
+        b
+    c
+    """
+    indenter = CustomIndenter()
+    nl, indent = indent_token(8)
+    nl2, indent2, dedent, double_dedent = indent_token_dedent(4)
+    r = list(indenter.process([WHILE, nl,
+                               A, nl2,
+                               B,
+                               NL, C]))
+    print(r)
+    assert r == [WHILE, nl, indent,
+                 A, nl2,
+                 dedent, double_dedent, B, NL,
+                 DEDENT, C]

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -218,8 +218,11 @@ def test_grammar_function_block(grammar, ebnf):
     assert ebnf.function_output == 'returns types'
     function_statement = 'function_type name typed_argument* function_output?'
     assert ebnf.function_statement == function_statement
-    ebnf.simple_block.assert_called_with('function_statement')
-    assert ebnf.function_block == ebnf.simple_block()
+    assert ebnf.function_block == (
+        'function_statement nl '
+        '(indented_typed_arguments? block+ _DEDENT | '
+        'nested_block)'
+    )
 
 
 def test_grammar_try_block(grammar, ebnf):

--- a/tests/unittests/parser/Indenter.py
+++ b/tests/unittests/parser/Indenter.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from lark.indenter import Indenter
-
-from storyscript.parser import CustomIndenter
+from storyscript.parser.Indenter import CustomIndenter, Indenter
 
 
 def test_indenter():

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -182,3 +182,29 @@ def test_transformer_absolute_expression_zero(patch, tree, magic):
         Tree('service', [m, Tree('service_fragment', [])])
     ])
     assert result == expected
+
+
+def test_transformer_function_block_empty(patch, tree, magic):
+    """
+    Ensures that indented arguments are added back to the their original node
+    """
+    assert Transformer.function_block([]) == Tree('function_block', [])
+    assert Transformer.function_block([0]) == Tree('function_block', [0])
+    m = magic()
+    m.data = 'some_block'
+    assert Transformer.function_block([m]) == Tree('function_block', [m])
+    assert Transformer.function_block([m, m]) == Tree('function_block', [m, m])
+
+
+def test_transformer_function_block(patch, tree, magic):
+    """
+    Ensures that indented arguments are added back to the their original node
+    """
+    function_block = magic()
+    m = magic()
+    m.data = 'indented_typed_arguments'
+    m.find_data.return_value = ['.indented.node.']
+    r = Transformer.function_block([function_block, m])
+    m.find_data.assert_called_with('typed_argument')
+    function_block.children.append.assert_called_with('.indented.node.')
+    assert r == Tree('function_block', [function_block])

--- a/tox.ini
+++ b/tox.ini
@@ -7,19 +7,21 @@ deps =
     pytest
     pytest-cov
     pytest-mock
+    pytest-parallel
 
 
-[testenv:py36-unit]
+[testenv:unit]
 commands =
     pytest tests/unittests --cov=. --cov-config=.coveragerc --cov-report=term-missing {posargs}
     coverage xml
     mv coverage.xml unittest.xml
 
 
-[testenv:py36-integration]
+[testenv:integration]
 commands =
-    pytest tests/integration --cov=. --cov-config=.coveragerc --cov-report=term-missing {posargs}
-    pytest tests/e2e --cov=. --cov-config=.coveragerc --cov-append --cov-report=term-missing {posargs}
+    coverage run --source . -m py.test tests/integration
+    coverage run --append --source . -m py.test tests/e2e
+    coverage report
     coverage xml
     mv coverage.xml integration.xml
 


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/256

**- What I did**

I had to modify the default indention logic from Lark and I went with choosing to emit a special `_DOUBLE_DEDENT` token (and reset the `indent_level`) if we haven't hit the parent with an indention yet. I preferred this special token over just an `_INDENT` as this is a lot more unique and we thus automatically forbid cases where the function arguments have the same indentation as the nested block.
Think:

```coffee
function name key:int
	key2:string
	a = 0
```

Which in case we would just emit a fresh `_INDENT` would just be sth. like:

```
0 FUNCTION_TYPE function
1 NAME name
2 NAME key
3 _COLON :
4 INT_TYPE int
5 _NL 
			
6 _INDENT 			
7 NAME key2
8 _COLON :
9 STRING_TYPE string
			
10 _DEDENT 	
11 _INDENT 	
12 NAME a
13 EQUALS =
14 INT 0
15 _NL 
16 _DEDENT
```

Apart from that, the changes are pretty straight-forward (slight modification to the Grammar + adding an new function to the Transformer, s.t. the virtual `indented_typed_args` get transformed into `typed_args` before the compiler sees them).

### Why is this WIP?

While it passes the testsuite and shows that this can work in theory, it still needs
- [x] coverage and testing for `Indenter.py`
- [x] more few tests for multi-line arguments (also disallowed cases like the e.g. the above mentioned same indentation case)
- [x] consider the chosen approach with `_DOUBLE_DEDENT` on a fresh day

**- How to verify it**

```
function name key:int
			key2:string key3:int
			key4:string
	a = 0
b = 1
```

```
start
  block
    function_block
      function_statement
        function
        name
        typed_argument
          key
          types	int
        typed_argument
          key2
          types	string
        typed_argument
          key3
          types	int
        typed_argument
          key4
          types	string
      block
        rules
          assignment
            path	a
            assignment_fragment
              =
              expression
                multiplication
                  exponential
                    factor
                      entity
                        values
                          number	0
  block
    rules
      assignment
        path	b
        assignment_fragment
          =
          expression
            multiplication
              exponential
                factor
                  entity
                    values
                      number	1
```

```json
{
  "stories": {
    "foo.story": {
      "tree": {
        "1": {
          "method": "function",
          "ln": "1",
          "output": [],
          "name": null,
          "service": null,
          "command": null,
          "function": "name",
          "args": [
            {
              "$OBJECT": "argument",
              "name": "key",
              "argument": {
                "$OBJECT": "type",
                "type": "int"
              }
            },
            {
              "$OBJECT": "argument",
              "name": "key2",
              "argument": {
                "$OBJECT": "type",
                "type": "string"
              }
            },
            {
              "$OBJECT": "argument",
              "name": "key3",
              "argument": {
                "$OBJECT": "type",
                "type": "int"
              }
            },
            {
              "$OBJECT": "argument",
              "name": "key4",
              "argument": {
                "$OBJECT": "type",
                "type": "string"
              }
            }
          ],
          "enter": "4",
          "exit": null,
          "parent": null,
          "next": "4"
        },
        "4": {
          "method": "set",
          "ln": "4",
          "output": null,
          "name": [
            "a"
          ],
          "service": null,
          "command": null,
          "function": null,
          "args": [
            0
          ],
          "enter": null,
          "exit": null,
          "parent": "1",
          "next": "5"
        },
        "5": {
          "method": "set",
          "ln": "5",
          "output": null,
          "name": [
            "b"
          ],
          "service": null,
          "command": null,
          "function": null,
          "args": [
            1
          ],
          "enter": null,
          "exit": null,
          "parent": null
        }
      },
      "services": [],
      "entrypoint": "1",
      "modules": {},
      "functions": {
        "name": "1"
      },
      "version": "0.9.2"
    }
  },
  "services": [],
  "entrypoint": [
    "foo.story"
  ]
}
```

**- Description for the changelog**

Storyscript now supports multi-line function arguments.
