### PR TITLE
fix(compiler): do not nest exponential expressions unnecessarily

### DIFF
--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -469,3 +469,14 @@ def test_compiler_expression_signed_float_complex(parser):
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['expression'] == 'sum'
     assert result['tree']['1']['args'][0]['values'] == [-2.5, 3.5]
+
+
+def test_compiler_expression_exponential_flat(parser):
+    """
+    Ensures that exponential expressions are not nested
+    """
+    result = Compiler.compile(parser.parse('2 ^ 3'))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'][0]['$OBJECT'] == 'expression'
+    assert result['tree']['1']['args'][0]['expression'] == 'exponential'
+    assert result['tree']['1']['args'][0]['values'] == [2, 3]


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/433

**- What I did**

Added a test for https://github.com/storyscript/storyscript/issues/433

**- How I did it**

https://github.com/storyscript/storyscript/pull/542 already did the hard work to fix this.

**- Description for the changelog**

- Exponential expressions are no longer unnecessarily nested