### PR TITLE
feat(compiler): allow arbitrary expressions for return

### DIFF
--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -180,8 +180,8 @@ class Compiler:
             raise CompilerError('return_outside', tree=tree)
         line = tree.line()
         args = None
-        if tree.entity:
-            args = [Objects.entity(tree.entity)]
+        if tree.expression:
+            args = [Objects.expression(tree.expression)]
         self.lines.append('return', line, args=args, parent=parent)
 
     def if_block(self, tree, parent):

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -143,7 +143,7 @@ class Grammar:
     def rules(self):
         self.ebnf.RETURN = 'return'
         self.ebnf.BREAK = 'break'
-        self.ebnf.return_statement = 'return entity?'
+        self.ebnf.return_statement = 'return expression?'
         self.ebnf.break_statement = 'break'
         self.ebnf.entity = 'values, path'
         rules = ('absolute_expression, assignment, imports, return_statement, '

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -1738,3 +1738,75 @@ def test_compiler_mutation_expression_object(parser):
           ]
         }
     ]
+
+
+def test_compiler_return_complex_expression(parser):
+    """
+    Ensures that return accepts arbitrary expressions
+    """
+    source = 'function name key:int\n\treturn 2 + 2'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'function'
+    assert result['tree']['1']['function'] == 'name'
+    assert result['tree']['2']['method'] == 'return'
+    assert result['tree']['2']['args'] == [{
+      '$OBJECT': 'expression',
+      'expression': 'sum',
+      'values': [
+        2,
+        2
+      ]
+    }]
+
+
+def test_compiler_return_complex_expression_2(parser):
+    """
+    Ensures that return accepts arbitrary expressions
+    """
+    source = 'function name key:int\n\treturn a / b + c or d'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'function'
+    assert result['tree']['1']['function'] == 'name'
+    assert result['tree']['2']['method'] == 'return'
+    assert result['tree']['2']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'or',
+        'values': [
+          {
+            '$OBJECT': 'expression',
+            'expression': 'sum',
+            'values': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'division',
+                'values': [
+                  {
+                    '$OBJECT': 'path',
+                    'paths': [
+                      'a'
+                    ]
+                  },
+                  {
+                    '$OBJECT': 'path',
+                    'paths': [
+                      'b'
+                    ]
+                  }
+                ]
+              },
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  'c'
+                ]
+              }
+            ]
+          },
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'd'
+            ]
+          }
+        ]
+    }]

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -333,7 +333,7 @@ def test_compiler_return_statement(patch, compiler, lines, tree):
     """
     Ensures Compiler.return_statement can compile return statements.
     """
-    tree.entity = None
+    tree.expression = None
     compiler.return_statement(tree, '1')
     line = tree.line()
     kwargs = {'args': None, 'parent': '1'}
@@ -345,11 +345,11 @@ def test_compiler_return_statement_entity(patch, compiler, lines, tree):
     Ensures Compiler.return_statement can compile return statements that return
     entities.
     """
-    patch.object(Objects, 'entity')
+    patch.object(Objects, 'expression')
     compiler.return_statement(tree, '1')
     line = tree.line()
-    Objects.entity.assert_called_with(tree.entity)
-    kwargs = {'args': [Objects.entity()], 'parent': '1'}
+    Objects.expression.assert_called_with(tree.expression)
+    kwargs = {'args': [Objects.expression()], 'parent': '1'}
     lines.append.assert_called_with('return', line, **kwargs)
 
 

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -157,7 +157,7 @@ def test_grammar_rules(grammar, ebnf):
     assert ebnf.RETURN == 'return'
     assert ebnf.BREAK == 'break'
     assert ebnf.entity == 'values, path'
-    assert ebnf.return_statement == 'return entity?'
+    assert ebnf.return_statement == 'return expression?'
     rules = ('absolute_expression, assignment, imports, return_statement, '
              'raise_statement, break_statement, block')
     assert ebnf.rules == rules


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/568

**- What I did**

- `return` now accepts an arbitrary expression

**- How to verify it**

```coffee
function name key:int
	return 2 + 2
```

now compiles

```json
{
  "stories": {
    "foo.story": {
      "tree": {
        "1": {
          "method": "function",
          "ln": "1",
          "output": [],
          "name": null,
          "service": null,
          "command": null,
          "function": "name",
          "args": [
            {
              "$OBJECT": "argument",
              "name": "key",
              "argument": {
                "$OBJECT": "type",
                "type": "int"
              }
            }
          ],
          "enter": "2",
          "exit": null,
          "parent": null,
          "next": "2"
        },
        "2": {
          "method": "return",
          "ln": "2",
          "output": null,
          "name": null,
          "service": null,
          "command": null,
          "function": null,
          "args": [
            {
              "$OBJECT": "expression",
              "expression": "sum",
              "values": [
                2,
                2
              ]
            }
          ],
          "enter": null,
          "exit": null,
          "parent": "1"
        }
      },
      "services": [],
      "entrypoint": "1",
      "modules": {},
      "functions": {
        "name": "1"
      },
      "version": "0.9.3"
    }
  },
  "services": [],
  "entrypoint": [
    "foo.story"
  ]
}
```

More examples are in the attached tests.

**- Description for the changelog**

`return` statements now accept arbitrary expressions
