### PR TITLE
feat(storyerror): return a better error message when a block should start

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -66,7 +66,10 @@ class ErrorCodes:
     unnecessary_colon = (
         'E0045',
         'There is an unnecessary colon at the end of the line')
-    block_expected = ('E0045', 'An indented block is required to follow here')
+    block_expected_after = ('E0045',
+                            'An indented block is required to follow here')
+    block_expected_before = ('E0046',
+                             'An indented block is required to be before here')
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -66,6 +66,7 @@ class ErrorCodes:
     unnecessary_colon = (
         'E0045',
         'There is an unnecessary colon at the end of the line')
+    block_expected = ('E0045', 'An indented block is required to follow here')
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -110,6 +110,8 @@ class StoryError(SyntaxError):
             return ErrorCodes.assignment_incomplete
         elif intention.unnecessary_colon():
             return ErrorCodes.unnecessary_colon
+        elif self.error.expected == ['_INDENT']:
+            return ErrorCodes.block_expected
         return ErrorCodes.unexpected_token
 
     def unexpected_characters_code(self):

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -111,18 +111,28 @@ class StoryError(SyntaxError):
         elif intention.unnecessary_colon():
             return ErrorCodes.unnecessary_colon
         elif self.error.expected == ['_INDENT']:
-            return ErrorCodes.block_expected
+            return ErrorCodes.block_expected_after
         return ErrorCodes.unexpected_token
+
+    @staticmethod
+    def is_valid_name_start(token):
+        return token.isalpha() or token == '_'
 
     def unexpected_characters_code(self):
         """
         Finds the error code when the error is UnexpectedCharacters
         """
-        intention = Intention(self.get_line())
+        line = self.get_line()
+        error_column = line[self.error.column - 1]
+        intention = Intention(line)
         if intention.is_function():
             return ErrorCodes.function_misspell
         elif intention.unnecessary_colon():
             return ErrorCodes.unnecessary_colon
+        elif self.error.allowed is None and \
+                self.is_valid_name_start(error_column):
+            return ErrorCodes.block_expected_before
+
         return ErrorCodes.invalid_character
 
     def identify(self):

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -96,3 +96,13 @@ def test_exceptions_function_redeclared(capsys):
     assert lines[0] == 'Error: syntax error in story at line 3, column 10'
     assert lines[2] == '3|    function f1'
     assert lines[5] == 'E0042: `f1` has already been declared at line 1'
+
+
+def test_exceptions_block_expected(capsys):
+    with raises(StoryError) as e:
+        Story('while true').process()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
+    assert lines[0] == 'Error: syntax error in story at line 1, column 11'
+    assert lines[2] == '1|    while true'
+    assert lines[5] == 'E0045: An indented block is required to follow here'

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -98,7 +98,7 @@ def test_exceptions_function_redeclared(capsys):
     assert lines[5] == 'E0042: `f1` has already been declared at line 1'
 
 
-def test_exceptions_block_expected(capsys):
+def test_exceptions_block_expected_before(capsys):
     with raises(StoryError) as e:
         Story('while true').process()
     e.value.with_color = False
@@ -106,3 +106,13 @@ def test_exceptions_block_expected(capsys):
     assert lines[0] == 'Error: syntax error in story at line 1, column 11'
     assert lines[2] == '1|    while true'
     assert lines[5] == 'E0045: An indented block is required to follow here'
+
+
+def test_exceptions_block_expected_after(capsys):
+    with raises(StoryError) as e:
+        Story('while true\na = 2').process()
+    e.value.with_color = False
+    lines = e.value.message().splitlines()
+    assert lines[0] == 'Error: syntax error in story at line 2, column 1'
+    assert lines[2] == '2|    a = 2'
+    assert lines[5] == 'E0046: An indented block is required to be before here'

--- a/tests/unittests/exceptions/StoryError.py
+++ b/tests/unittests/exceptions/StoryError.py
@@ -189,13 +189,14 @@ def test_storyerror_unexpected_token_code_colon(patch, storyerror):
     assert storyerror.unexpected_token_code() == ErrorCodes.unnecessary_colon
 
 
-def test_storyerror_unexpected_token_expected_block(patch, storyerror):
+def test_storyerror_unexpected_token_expected_block_after(patch, storyerror):
     patch.init(Intention)
     patch.object(storyerror, 'get_line')
     patch.object(Intention, 'assignment', return_value=False)
     patch.object(Intention, 'unnecessary_colon', return_value=False)
     storyerror.error = UnexpectedToken(token='and', expected=['_INDENT'])
-    assert storyerror.unexpected_token_code() == ErrorCodes.block_expected
+    assert storyerror.unexpected_token_code() == \
+        ErrorCodes.block_expected_after
 
 
 def test_storyerror_unexpected_characters_code(patch, call_count, storyerror):
@@ -221,6 +222,32 @@ def test_storyerror_unexpected_characters_code_colon(patch, storyerror):
     patch.object(Intention, 'unnecessary_colon')
     result = storyerror.unexpected_characters_code()
     assert result == ErrorCodes.unnecessary_colon
+
+
+def test_storyerror_unexpected_characters_expected_block_before(patch,
+                                                                storyerror):
+    patch.init(Intention)
+    patch.object(Intention, 'is_function', return_value=False)
+    patch.object(StoryError, 'is_valid_name_start', return_value=True)
+    patch.object(Intention, 'unnecessary_colon', return_value=False)
+    storyerror.error = UnexpectedCharacters(seq='abc', lex_pos=0, line=0,
+                                            column=0, allowed=None)
+    result = storyerror.unexpected_characters_code()
+    assert result == ErrorCodes.block_expected_before
+
+
+@mark.parametrize('name_char', [
+    'a', 'c', 'z', 'A', 'G', 'Z', '_',
+])
+def test_storyerror_is_valid_name_start(storyerror, name_char):
+    assert storyerror.is_valid_name_start(name_char)
+
+
+@mark.parametrize('name_char', [
+    '.', '$', ':', '+', '/', '%', '-', '0', '5', '9'
+])
+def test_storyerror_is_invalid_name_start(storyerror, name_char):
+    assert not storyerror.is_valid_name_start(name_char)
 
 
 def test_storyerror_identify(storyerror):

--- a/tests/unittests/exceptions/StoryError.py
+++ b/tests/unittests/exceptions/StoryError.py
@@ -189,6 +189,15 @@ def test_storyerror_unexpected_token_code_colon(patch, storyerror):
     assert storyerror.unexpected_token_code() == ErrorCodes.unnecessary_colon
 
 
+def test_storyerror_unexpected_token_expected_block(patch, storyerror):
+    patch.init(Intention)
+    patch.object(storyerror, 'get_line')
+    patch.object(Intention, 'assignment', return_value=False)
+    patch.object(Intention, 'unnecessary_colon', return_value=False)
+    storyerror.error = UnexpectedToken(token='and', expected=['_INDENT'])
+    assert storyerror.unexpected_token_code() == ErrorCodes.block_expected
+
+
 def test_storyerror_unexpected_characters_code(patch, call_count, storyerror):
     patch.init(Intention)
     patch.object(Intention, 'is_function', return_value=False)


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/485

**- Description for the changelog**

A more helpful error message is now triggered when a block is required and none is provided (e.g. after `while true`)