### PR TITLE
fix(compiler): compile mutation assignments correctly

### DIFF
--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -100,7 +100,7 @@ class Compiler:
         service = fragment.service
         if service:
             path = Objects.names(service.path)
-            if path not in self.lines.variables:
+            if [path] not in self.lines.variables:
                 self.service(service, None, parent)
                 self.lines.set_name(name)
                 return

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -1237,3 +1237,28 @@ def test_compiler_complex_nested_expression_14(parser):
           }
         ]
     }]
+
+
+def test_compiler_mutation_assignment(parser):
+    """
+    Ensures that mutation assignments compile correctly
+    """
+    source = 'a = "hello world"\nb = a uppercase'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['name'] == ['a']
+    assert result['tree']['2']['method'] == 'mutation'
+    assert result['tree']['2']['name'] == ['b']
+    assert result['tree']['2']['args'] == [
+        {
+          '$OBJECT': 'path',
+          'paths': [
+            'a'
+          ]
+        },
+        {
+          '$OBJECT': 'mutation',
+          'mutation': 'uppercase',
+          'arguments': []
+        }
+    ]


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/575

**- How I did it**

- The problem was that `self.lines.variables` looks like `[['a']]` as at some point `name` must have been changed to an array and not a single string anymore

**- Description for the changelog**

Mutation assignments are now compiled correctly