### PR TITLE
feat(compiler): allow expression in service, mutation and function arguments

### DIFF
--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -189,7 +189,7 @@ class Objects:
         Compiles an argument tree to the corresponding object.
         """
         name = tree.child(0).value
-        value = cls.entity(tree.child(1))
+        value = cls.expression(tree.child(1))
         return {'$OBJECT': 'argument', 'name': name, 'argument': value}
 
     @classmethod

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -160,7 +160,7 @@ class Grammar:
 
     def service_block(self):
         self.ebnf.command = 'name'
-        self.ebnf.arguments = 'name? colon entity'
+        self.ebnf.arguments = 'name? colon expression'
         self.ebnf.output = '(as name (comma name)*)'
         self.ebnf.service_fragment = '(command arguments*|arguments+) output?'
         self.ebnf.service = 'path service_fragment chained_mutation*'

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -1367,3 +1367,163 @@ def test_compiler_mutation_assignment(parser):
           'arguments': []
         }
     ]
+
+
+def test_compiler_mutation_expression(parser):
+    """
+    Ensures that mutations with expressions are compiled correctly
+    """
+    source = ('a = ["opened", "labeled"]\n'
+              'a contains item: req.body["action"] == false')
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['name'] == ['a']
+    assert result['tree']['2']['method'] == 'mutation'
+    assert result['tree']['2']['args'] == [
+        {
+          '$OBJECT': 'path',
+          'paths': [
+            'a'
+          ]
+        },
+        {
+          '$OBJECT': 'mutation',
+          'mutation': 'contains',
+          'arguments': [
+            {
+              '$OBJECT': 'argument',
+              'name': 'item',
+              'argument': {
+                '$OBJECT': 'expression',
+                'expression': 'equals',
+                'values': [
+                  {
+                    '$OBJECT': 'path',
+                    'paths': [
+                      'req',
+                      'body',
+                      {
+                        '$OBJECT': 'string',
+                        'string': 'action'
+                      }
+                    ]
+                  },
+                  False
+                ]
+              }
+            }
+          ]
+        }
+    ]
+
+
+def test_compiler_service_expression(parser):
+    """
+    Ensures that mutations with expressions are compiled correctly
+    """
+    source = 'my_service my_command k1: 2 + 2 k2: a == b'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'execute'
+    assert result['tree']['1']['command'] == 'my_command'
+    assert result['tree']['1']['service'] == 'my_service'
+    assert result['tree']['1']['args'] == [
+        {
+          '$OBJECT': 'argument',
+          'name': 'k1',
+          'argument': {
+            '$OBJECT': 'expression',
+            'expression': 'sum',
+            'values': [
+              2,
+              2
+            ]
+          }
+        },
+        {
+          '$OBJECT': 'argument',
+          'name': 'k2',
+          'argument': {
+            '$OBJECT': 'expression',
+            'expression': 'equals',
+            'values': [
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  'a'
+                ]
+              },
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  'b'
+                ]
+              }
+            ]
+          }
+        }
+    ]
+
+
+def test_compiler_function_expression(parser):
+    """
+    Ensures that function calls with expressions are compiled correctly
+    """
+    source = 'my_function k1: 2 + 2 % 4 k2: a / b - c'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'execute'
+    assert result['tree']['1']['service'] == 'my_function'
+    assert result['tree']['1']['args'] == [
+        {
+          '$OBJECT': 'argument',
+          'name': 'k1',
+          'argument': {
+            '$OBJECT': 'expression',
+            'expression': 'sum',
+            'values': [
+              2,
+              {
+                '$OBJECT': 'expression',
+                'expression': 'modulus',
+                'values': [
+                  2,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          '$OBJECT': 'argument',
+          'name': 'k2',
+          'argument': {
+            '$OBJECT': 'expression',
+            'expression': 'subtraction',
+            'values': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'division',
+                'values': [
+                  {
+                    '$OBJECT': 'path',
+                    'paths': [
+                      'a'
+                    ]
+                  },
+                  {
+                    '$OBJECT': 'path',
+                    'paths': [
+                      'b'
+                    ]
+                  }
+                ]
+              },
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  'c'
+                ]
+              }
+            ]
+          }
+        }
+    ]

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -78,7 +78,8 @@ def test_parser_assignment_indented_arguments(parser):
     correctly
     """
     result = parser.parse('x = alpine echo\n\tmessage:"hello"')
-    values = result.child(1).indented_arguments.arguments.entity.values
+    exp = result.child(1).indented_arguments.arguments.expression
+    values = get_entity(arith_exp(Tree('an_exp', [exp]))).values
     assert values.string.child(0) == Token('DOUBLE_QUOTED', '"hello"')
 
 
@@ -111,7 +112,7 @@ def test_parser_service_arguments(parser):
     result = parser.parse('container key:"value"\n')
     args = result.block.service_block.service.service_fragment.arguments
     assert args.child(0) == Token('NAME', 'key')
-    entity = args.entity
+    entity = get_entity(arith_exp(Tree('an_exp', [args.expression])))
     assert entity.values.string.child(0) == Token('DOUBLE_QUOTED', '"value"')
 
 

--- a/tests/unittests/compiler/Objects.py
+++ b/tests/unittests/compiler/Objects.py
@@ -270,12 +270,12 @@ def test_objects_values_path(patch, magic):
 
 
 def test_objects_argument(patch, tree):
-    patch.object(Objects, 'entity')
+    patch.object(Objects, 'expression')
     result = Objects.argument(tree)
     assert tree.child.call_count == 2
-    Objects.entity.assert_called_with(tree.child())
+    Objects.expression.assert_called_with(tree.child())
     expected = {'$OBJECT': 'argument', 'name': tree.child().value,
-                'argument': Objects.entity()}
+                'argument': Objects.expression()}
     assert result == expected
 
 

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -177,7 +177,7 @@ def test_mutation_block(grammar, ebnf):
 def test_grammar_service_block(grammar, ebnf):
     grammar.service_block()
     assert ebnf.command == 'name'
-    assert ebnf.arguments == 'name? colon entity'
+    assert ebnf.arguments == 'name? colon expression'
     assert ebnf.output == '(as name (comma name)*)'
     assert ebnf.service_fragment == '(command arguments*|arguments+) output?'
     assert ebnf.service == 'path service_fragment chained_mutation*'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/560

**- Description for the changelog**

Service, mutation and function arguments now accept arbitrary expressions.
