### PR TITLE
fix(compiler): arithmetic expressions shouldn't be whitespace sensitive

### DIFF
--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -106,12 +106,12 @@ class Grammar:
         self.ebnf.NOT_EQUAL = '!='
         self.ebnf.EQUAL = '=='
 
-        self.ebnf.BSLASH = '/'
+        self.ebnf.set_token('BSLASH.5', '/')
         self.ebnf.MULTIPLIER = '*'
-        self.ebnf.MODULUS = '%'
+        self.ebnf.set_token('MODULUS.5', '%')
 
-        self.ebnf.PLUS = '+'
-        self.ebnf.set_token('DASH.4', '-')
+        self.ebnf.set_token('PLUS.5', '+')
+        self.ebnf.set_token('DASH.5', '-')
 
         self.ebnf.cmp_operator = ('GREATER, GREATER_EQUAL, LESSER, '
                                   'LESSER_EQUAL, NOT_EQUAL, EQUAL')

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -1367,3 +1367,63 @@ def test_compiler_mutation_assignment(parser):
           'arguments': []
         }
     ]
+
+
+def path(name):
+    """
+    Generate a path object
+    """
+    return {'$OBJECT': 'path', 'paths': [name]}
+
+
+@mark.parametrize('source_pair', [
+    ('1+2', 'sum', [1, 2]),
+    ('1+-2', 'sum', [1, -2]),
+    ('1-3', 'subtraction', [1, 3]),
+    ('1--3', 'subtraction', [1, -3]),
+    ('0*2', 'multiplication', [0, 2]),
+    ('0*-2', 'multiplication', [0, -2]),
+    ('1/6', 'division', [1, 6]),
+    ('1/-6', 'division', [1, -6]),
+    ('0%2', 'modulus', [0, 2]),
+    ('0%-2', 'modulus', [0, -2]),
+    ('1==2', 'equals', [1, 2]),
+    ('1==-2', 'equals', [1, -2]),
+    ('1!=2', 'not_equal', [1, 2]),
+    ('1!=-2', 'not_equal', [1, -2]),
+    ('1<2', 'less', [1, 2]),
+    ('1<-2', 'less', [1, -2]),
+    ('1>2', 'greater', [1, 2]),
+    ('1>-2', 'greater', [1, -2]),
+    ('1<=2', 'less_equal', [1, 2]),
+    ('1<=-2', 'less_equal', [1, -2]),
+    ('1>=2', 'greater_equal', [1, 2]),
+    ('-1>=2', 'greater_equal', [-1, 2]),
+    ('1>=-2', 'greater_equal', [1, -2]),
+    ('b+c', 'sum', [path('b'), path('c')]),
+    # Currently a valid entity
+    # ('b-c', 'subtraction', [path('b'), path('c')]),
+    ('b*c', 'multiplication', [path('b'), path('c')]),
+    # Currently a valid entity
+    # ('b/c', 'divison', [path('b'), path('c')]),
+    ('b%c', 'modulus', [path('b'), path('c')]),
+    ('b==c', 'equals', [path('b'), path('c')]),
+    ('b!=c', 'not_equal', [path('b'), path('c')]),
+    ('b<c', 'less', [path('b'), path('c')]),
+    ('b>c', 'greater', [path('b'), path('c')]),
+    ('b<=c', 'less_equal', [path('b'), path('c')]),
+    ('b>=c', 'greater_equal', [path('b'), path('c')]),
+])
+def test_compiler_expression_whitespace(parser, source_pair):
+    """
+    Ensures that expression isn't whitespace sensitive
+    """
+    source, expression, values = source_pair
+    source = 'a=' + source
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['name'] == ['a']
+    assert len(result['tree']['1']['args']) == 1
+    assert result['tree']['1']['args'][0]['$OBJECT'] == 'expression'
+    assert result['tree']['1']['args'][0]['expression'] == expression
+    assert result['tree']['1']['args'][0]['values'] == values

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -101,7 +101,10 @@ def test_grammar_expressions(grammar, ebnf, magic):
     ebnf.set_token = magic()
     grammar.expressions()
     assert ebnf.set_token.call_args_list == [
-        call('DASH.4', '-'),
+        call('BSLASH.5', '/'),
+        call('MODULUS.5', '%'),
+        call('PLUS.5', '+'),
+        call('DASH.5', '-'),
     ]
 
     assert ebnf.POWER == '^'
@@ -117,11 +120,7 @@ def test_grammar_expressions(grammar, ebnf, magic):
     assert ebnf.NOT_EQUAL == '!='
     assert ebnf.EQUAL == '=='
 
-    assert ebnf.BSLASH == '/'
     assert ebnf.MULTIPLIER == '*'
-    assert ebnf.MODULUS == '%'
-
-    assert ebnf.PLUS == '+'
 
     assert ebnf.cmp_operator == ('GREATER, GREATER_EQUAL, LESSER, '
                                  'LESSER_EQUAL, NOT_EQUAL, EQUAL')


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/580

Note that `a-b` and `a/b` are currently valid entity names:

```
NAME.1: /[a-zA-Z-\/_0-9]+/
```

I will open a separate issue for this.

**- What I did**

- Adjusted the operator priority for `+`, `-` and `%`, s.t. Lark will prefer to parse them
- Added a long set of integration tests to prevent further issues

**- Description for the changelog**

- Fix: Arithmetic expressions are no longer white-space sensitive
