### PR TITLE
Allow mutations to be part of arbitrary expressions

### DIFF
--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -32,8 +32,8 @@ class Compiler:
         """
         if fragment.expression:
             if fragment.expression.mutation:
-                return [Objects.values(fragment.expression.values),
-                        Objects.mutation(fragment.expression.mutation)]
+                m = Objects.mutation_fragment(fragment.expression.mutation)
+                return [Objects.values(fragment.expression.values), m]
             return [Objects.expression(fragment.expression)]
         return [Objects.entity(fragment.child(1))]
 
@@ -44,7 +44,8 @@ class Compiler:
         """
         mutations = []
         for mutation in tree.find_data('chained_mutation'):
-            mutations.append(Objects.mutation(mutation.mutation_fragment))
+            m = Objects.mutation_fragment(mutation.mutation_fragment)
+            mutations.append(m)
         return mutations
 
     @classmethod
@@ -234,7 +235,8 @@ class Compiler:
 
     def while_block(self, tree, parent):
         line = tree.line()
-        args = [Objects.expression(tree.while_statement.expression)]
+        exp = tree.while_statement.expression_mutation
+        args = [Objects.expression_mutation(exp)]
         nested_block = tree.nested_block
         self.lines.set_scope(line, parent)
         self.lines.append('while', line, args=args, enter=nested_block.line(),
@@ -268,13 +270,13 @@ class Compiler:
         if tree.path:
             args = [
                 Objects.path(tree.path),
-                Objects.mutation(tree.service_fragment)
+                Objects.mutation_fragment(tree.service_fragment)
             ]
             args = args + self.chained_mutations(tree)
         else:
             args = [
                 Objects.entity(tree.mutation.entity),
-                Objects.mutation(tree.mutation.mutation_fragment)
+                Objects.mutation_fragment(tree.mutation.mutation_fragment)
             ]
             args = args + self.chained_mutations(tree.mutation)
         if tree.nested_block:

--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -32,6 +32,12 @@ class Objects:
 
     @classmethod
     def mutation(cls, tree):
+        entity = Objects.entity(tree.entity)
+        args = Objects.mutation_fragment(tree.mutation_fragment)
+        return {'method': 'mutation', 'name': [entity], 'args': [args]}
+
+    @classmethod
+    def mutation_fragment(cls, tree):
         """
         Compiles a mutation object, either from a mutation or a
         service_fragment tree.
@@ -215,6 +221,19 @@ class Objects:
             arguments.append(cls.typed_argument(argument))
         return arguments
 
+    @classmethod
+    def expression_mutation(cls, tree):
+        """
+        Compiles an expression or mutation object with the given tree.
+        """
+        assert len(tree.children) > 0
+        child = tree.child(0)
+        if child.data == 'expression':
+            return cls.expression(child)
+        elif child.data == 'mutation':
+            return cls.mutation(child)
+        internal_assert(0)
+
     @staticmethod
     def expression_type(operator, tree):
         types = {'PLUS': 'sum', 'DASH': 'subtraction', 'POWER': 'exponential',
@@ -269,6 +288,8 @@ class Objects:
         """
         if tree.child(0).data == 'entity':
             return cls.entity(tree.entity)
+        elif tree.child(0).data == 'mutation':
+            return cls.mutation(tree.mutation)
         else:
             assert tree.child(0).data == 'or_expression'
             return cls.or_expression(tree.child(0))
@@ -388,7 +409,7 @@ class Objects:
         """
         Compiles an assertion object.
         """
-        e = Objects.expression(tree.expression)
+        e = Objects.expression_mutation(tree.expression_mutation)
         if not hasattr(e, 'get') or e.get('expression', None) is None:
             return [e]
         # Do we really need this special case here?

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -119,7 +119,8 @@ class Grammar:
         self.ebnf.unary_operator = 'NOT'
         self.ebnf.mul_operator = 'MULTIPLIER, BSLASH, MODULUS'
 
-        self.ebnf.primary_expression = 'entity , op or_expression cp'
+        self.ebnf.primary_expression = 'entity , op or_expression cp, ' \
+                                       'op mutation cp'
         self.ebnf.pow_expression = ('primary_expression (POWER '
                                     'unary_expression)?')
         self.ebnf.unary_expression = ('unary_operator unary_expression , '
@@ -134,6 +135,7 @@ class Grammar:
         self.ebnf.or_expression = '(or_expression OR)? and_expression'
 
         self.ebnf.expression = 'or_expression'
+        self.ebnf.expression_mutation = 'expression, mutation'
         self.ebnf.absolute_expression = 'expression'
 
     def raise_statement(self):
@@ -169,8 +171,8 @@ class Grammar:
     def if_block(self):
         self.ebnf._IF = 'if'
         self.ebnf._ELSE = 'else'
-        self.ebnf.if_statement = 'if expression'
-        elseif_statement = 'else if expression'
+        self.ebnf.if_statement = 'if expression_mutation'
+        elseif_statement = 'else if expression_mutation'
         self.ebnf.elseif_statement = elseif_statement
         self.ebnf.elseif_block = self.ebnf.simple_block('elseif_statement')
         self.ebnf.set_rule('!else_statement', 'else')
@@ -180,7 +182,7 @@ class Grammar:
 
     def while_block(self):
         self.ebnf._WHILE = 'while'
-        self.ebnf.while_statement = 'while expression'
+        self.ebnf.while_statement = 'while expression_mutation'
         self.ebnf.while_block = self.ebnf.simple_block('while_statement')
 
     def foreach_block(self):

--- a/tests/e2e/expression_mutation_nested.json
+++ b/tests/e2e/expression_mutation_nested.json
@@ -1,0 +1,74 @@
+{
+  "stories": {
+    "tests/e2e/expression_mutation_nested.story": {
+      "tree": {
+        "1": {
+          "method": "expression",
+          "ln": "1",
+          "output": null,
+          "name": [
+            "b"
+          ],
+          "service": null,
+          "command": null,
+          "function": null,
+          "args": [
+            {
+              "$OBJECT": "expression",
+              "expression": "and",
+              "values": [
+                1,
+                {
+                  "method": "mutation",
+                  "name": [
+                    {
+                      "$OBJECT": "list",
+                      "items": [
+                        {
+                          "$OBJECT": "string",
+                          "string": "opened"
+                        },
+                        {
+                          "$OBJECT": "string",
+                          "string": "labeled"
+                        }
+                      ]
+                    }
+                  ],
+                  "args": [
+                    {
+                      "$OBJECT": "mutation",
+                      "mutation": "contains",
+                      "arguments": [
+                        {
+                          "$OBJECT": "argument",
+                          "name": "item",
+                          "argument": {
+                            "$OBJECT": "string",
+                            "string": "a"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "enter": null,
+          "exit": null,
+          "parent": null
+        }
+      },
+      "services": [],
+      "entrypoint": "1",
+      "modules": {},
+      "functions": {},
+      "version": "0.9.7-1-g2d7e27e"
+    }
+  },
+  "services": [],
+  "entrypoint": [
+    "tests/e2e/expression_mutation_nested.story"
+  ]
+}

--- a/tests/e2e/expression_mutation_nested.story
+++ b/tests/e2e/expression_mutation_nested.story
@@ -1,0 +1,1 @@
+b = 1 and (["opened", "labeled"] contains item: "a")

--- a/tests/e2e/expression_mutation_while.json
+++ b/tests/e2e/expression_mutation_while.json
@@ -1,0 +1,71 @@
+{
+  "stories": {
+    "tests/e2e/expression_mutation_while.story": {
+      "tree": {
+        "1": {
+          "method": "while",
+          "ln": "1",
+          "output": null,
+          "name": null,
+          "service": null,
+          "command": null,
+          "function": null,
+          "args": [
+            {
+              "method": "mutation",
+              "name": [
+                {
+                  "$OBJECT": "list",
+                  "items": [
+                    1,
+                    2,
+                    3
+                  ]
+                }
+              ],
+              "args": [
+                {
+                  "$OBJECT": "mutation",
+                  "mutation": "contains",
+                  "arguments": [
+                    {
+                      "$OBJECT": "argument",
+                      "name": "item",
+                      "argument": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "enter": "2",
+          "exit": null,
+          "parent": null,
+          "next": "2"
+        },
+        "2": {
+          "method": "return",
+          "ln": "2",
+          "output": null,
+          "name": null,
+          "service": null,
+          "command": null,
+          "function": null,
+          "args": null,
+          "enter": null,
+          "exit": null,
+          "parent": "1"
+        }
+      },
+      "services": [],
+      "entrypoint": "1",
+      "modules": {},
+      "functions": {},
+      "version": "0.9.7-5-gbbd6c76-dirty"
+    }
+  },
+  "services": [],
+  "entrypoint": [
+    "tests/e2e/expression_mutation_while.story"
+  ]
+}

--- a/tests/e2e/expression_mutation_while.story
+++ b/tests/e2e/expression_mutation_while.story
@@ -1,0 +1,2 @@
+while [1, 2, 3] contains item:1
+	return

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -96,7 +96,7 @@ def test_parser_foreach_block(parser):
 def test_parser_while_block(parser):
     result = parser.parse('while cond\n\tvar=3\n')
     block = result.block.while_block
-    exp = arith_exp(block.while_statement)
+    exp = arith_exp(block.while_statement.expression_mutation)
     entity = get_entity(exp)
     assert entity.path.child(0) == Token('NAME', 'cond')
     assert block.nested_block.data == 'nested_block'
@@ -127,7 +127,7 @@ def test_parser_service_output(parser):
 def test_parser_if_block(parser):
     result = parser.parse('if expr\n\tvar=3\n')
     if_block = result.block.if_block
-    ar_exp = arith_exp(if_block.if_statement)
+    ar_exp = arith_exp(if_block.if_statement.expression_mutation)
     entity = get_entity(ar_exp)
     path = entity.path
     assignment = if_block.nested_block.block.rules.assignment
@@ -138,7 +138,7 @@ def test_parser_if_block(parser):
 def test_parser_if_block_nested(parser):
     result = parser.parse('if expr\n\tif things\n\t\tvar=3\n')
     if_block = result.block.if_block.nested_block.block.if_block
-    ar_exp = arith_exp(if_block.if_statement)
+    ar_exp = arith_exp(if_block.if_statement.expression_mutation)
     entity = get_entity(ar_exp)
     path = entity.path
     assignment = if_block.nested_block.block.rules.assignment

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -65,20 +65,20 @@ def test_compiler_extract_values_expression(patch, tree):
 
 
 def test_compiler_extract_values_mutation(patch, tree):
-    patch.many(Objects, ['values', 'mutation'])
+    patch.many(Objects, ['values', 'mutation_fragment'])
     result = Compiler.extract_values(tree)
     Objects.values.assert_called_with(tree.expression.values)
-    Objects.mutation.assert_called_with(tree.expression.mutation)
-    assert result == [Objects.values(), Objects.mutation()]
+    Objects.mutation_fragment.assert_called_with(tree.expression.mutation)
+    assert result == [Objects.values(), Objects.mutation_fragment()]
 
 
 def test_compiler_chained_mutations(patch, magic, tree):
-    patch.object(Objects, 'mutation')
+    patch.object(Objects, 'mutation_fragment')
     mutation = magic()
     tree.find_data.return_value = [mutation]
     result = Compiler.chained_mutations(tree)
-    Objects.mutation.assert_called_with(mutation.mutation_fragment)
-    assert result == [Objects.mutation()]
+    Objects.mutation_fragment.assert_called_with(mutation.mutation_fragment)
+    assert result == [Objects.mutation_fragment()]
 
 
 def test_compiler_function_output(patch, tree):
@@ -439,10 +439,10 @@ def test_compiler_foreach_block(patch, compiler, lines, tree):
 
 def test_compiler_while_block(patch, compiler, lines, tree):
     patch.init(Tree)
-    patch.object(Objects, 'expression')
+    patch.object(Objects, 'expression_mutation')
     patch.many(Compiler, ['subtree'])
     compiler.while_block(tree, '1')
-    args = [Objects.expression()]
+    args = [Objects.expression_mutation()]
     lines.set_scope.assert_called_with(tree.line(), '1')
     lines.append.assert_called_with('while', tree.line(), args=args,
                                     enter=tree.nested_block.line(),
@@ -497,39 +497,41 @@ def test_compiler_raise_name_statement(patch, compiler, lines, tree):
 
 
 def test_compiler_mutation_block(patch, compiler, lines, tree):
-    patch.many(Objects, ['entity', 'mutation'])
+    patch.many(Objects, ['entity', 'mutation_fragment'])
     patch.object(Compiler, 'chained_mutations', return_value=['chained'])
     tree.path = None
     tree.nested_block = None
     compiler.mutation_block(tree, None)
     Objects.entity.assert_called_with(tree.mutation.entity)
-    Objects.mutation.assert_called_with(tree.mutation.mutation_fragment)
+    Objects.mutation_fragment.assert_called_with(
+        tree.mutation.mutation_fragment)
     Compiler.chained_mutations.assert_called_with(tree.mutation)
-    args = [Objects.entity(), Objects.mutation(), 'chained']
+    args = [Objects.entity(), Objects.mutation_fragment(), 'chained']
     kwargs = {'args': args, 'parent': None}
     lines.append.assert_called_with('mutation', tree.line(), **kwargs)
 
 
 def test_compiler_mutation_block_nested(patch, compiler, lines, tree):
-    patch.many(Objects, ['entity', 'mutation'])
+    patch.many(Objects, ['entity', 'mutation_fragment'])
     patch.object(Compiler, 'chained_mutations', return_value=['chained'])
     tree.path = None
     compiler.mutation_block(tree, None)
     Compiler.chained_mutations.assert_called_with(tree.nested_block)
-    args = [Objects.entity(), Objects.mutation(), 'chained', 'chained']
+    args = [Objects.entity(), Objects.mutation_fragment(), 'chained',
+            'chained']
     kwargs = {'args': args, 'parent': None}
     lines.append.assert_called_with('mutation', tree.line(), **kwargs)
 
 
 def test_compiler_mutation_block_from_service(patch, compiler, lines, tree):
-    patch.many(Objects, ['path', 'mutation'])
+    patch.many(Objects, ['path', 'mutation_fragment'])
     patch.object(Compiler, 'chained_mutations', return_value=['chained'])
     tree.nested_block = None
     compiler.mutation_block(tree, None)
     Objects.path.assert_called_with(tree.path)
-    Objects.mutation.assert_called_with(tree.service_fragment)
+    Objects.mutation_fragment.assert_called_with(tree.service_fragment)
     Compiler.chained_mutations.assert_called_with(tree)
-    args = [Objects.path(), Objects.mutation(), 'chained']
+    args = [Objects.path(), Objects.mutation_fragment(), 'chained']
     kwargs = {'args': args, 'parent': None}
     lines.append.assert_called_with('mutation', tree.line(), **kwargs)
 

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -128,7 +128,8 @@ def test_grammar_expressions(grammar, ebnf, magic):
     assert ebnf.unary_operator == 'NOT'
     assert ebnf.mul_operator == 'MULTIPLIER, BSLASH, MODULUS'
 
-    assert ebnf.primary_expression == 'entity , op or_expression cp'
+    assert ebnf.primary_expression == 'entity , op or_expression cp, ' \
+                                      'op mutation cp'
     assert ebnf.pow_expression == ('primary_expression (POWER '
                                    'unary_expression)?')
     assert ebnf.unary_expression == ('unary_operator unary_expression , '
@@ -143,6 +144,7 @@ def test_grammar_expressions(grammar, ebnf, magic):
     assert ebnf.or_expression == '(or_expression OR)? and_expression'
 
     assert ebnf.expression == 'or_expression'
+    assert ebnf.expression_mutation == 'expression, mutation'
     assert ebnf.absolute_expression == 'expression'
 
 
@@ -185,8 +187,8 @@ def test_grammar_service_block(grammar, ebnf):
 
 def test_grammar_if_block(grammar, ebnf):
     grammar.if_block()
-    assert ebnf.if_statement == 'if expression'
-    elseif_statement = 'else if expression'
+    assert ebnf.if_statement == 'if expression_mutation'
+    elseif_statement = 'else if expression_mutation'
     assert ebnf.elseif_statement == elseif_statement
     assert ebnf.elseif_block == ebnf.simple_block()
     ebnf.set_rule.assert_called_with('!else_statement', 'else')
@@ -206,7 +208,7 @@ def test_grammar_foreach_block(grammar, ebnf):
 def test_grammar_while_block(grammar, ebnf):
     grammar.while_block()
     assert ebnf._WHILE == 'while'
-    assert ebnf.while_statement == 'while expression'
+    assert ebnf.while_statement == 'while expression_mutation'
     ebnf.simple_block.assert_called_with('while_statement')
     assert ebnf.while_block == ebnf.simple_block()
 


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/578 (includes #577 for better integration tests)

**- What I did**

- mutations currently conflict with entities that's why they need parenthesis
Example:

```
my_function k1: a k2: b
```

currently this can be parsed as

```
my_function k1: (a k2: b)
my_function (k1: a) (k2: b)
```

as `a k2    :b` is a valid mutation without a named argument.

**- How to verify it**

```coffee
if ["opened", "labeled"] contains item: req.body["action"] == false
  return
```

now compiles too:

```json
{
  "stories": {
    "foo.story": {
      "tree": {
        "1": {
          "method": "if",
          "ln": "1",
          "output": null,
          "name": null,
          "service": null,
          "command": null,
          "function": null,
          "args": [
            {
              "method": "mutation",
              "name": [
                {
                  "$OBJECT": "list",
                  "items": [
                    {
                      "$OBJECT": "string",
                      "string": "opened"
                    },
                    {
                      "$OBJECT": "string",
                      "string": "labeled"
                    }
                  ]
                }
              ],
              "args": [
                {
                  "$OBJECT": "mutation",
                  "mutation": "contains",
                  "arguments": [
                    {
                      "$OBJECT": "argument",
                      "name": "item",
                      "argument": {
                        "$OBJECT": "expression",
                        "expression": "equals",
                        "values": [
                          {
                            "$OBJECT": "path",
                            "paths": [
                              "req",
                              "body",
                              {
                                "$OBJECT": "string",
                                "string": "action"
                              }
                            ]
                          },
                          false
                        ]
                      }
                    }
                  ]
                }
              ]
            }
          ],
          "enter": "2",
          "exit": null,
          "parent": null,
          "next": "2"
        },
        "2": {
          "method": "return",
          "ln": "2",
          "output": null,
          "name": null,
          "service": null,
          "command": null,
          "function": null,
          "args": null,
          "enter": null,
          "exit": null,
          "parent": "1"
        }
      },
      "services": [],
      "entrypoint": "1",
      "modules": {},
      "functions": {},
      "version": "0.9.3"
    }
  },
  "services": [],
  "entrypoint": [
    "foo.story"
  ]
}
```

**- Description for the changelog**

Mutations can now be part of arbitrary expressions.
