### PR TITLE
feat(compiler): implement the unary operator '!'

### DIFF
--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -246,7 +246,7 @@ class Objects:
 
     @classmethod
     def build_unary_expression(cls, tree, op, left):
-        expression_type = Objects.expression_type(op, tree)
+        expression_type = Objects.expression_type(op.type, tree)
         return {
             '$OBJECT': 'expression',
             'expression': expression_type,
@@ -298,9 +298,10 @@ class Objects:
             return cls.pow_expression(tree.child(0))
 
         assert tree.child(0).data == 'unary_operator'
+        op = tree.unary_operator.child(0)
         return cls.build_unary_expression(
-                    tree, tree.child(1),
-                    cls.unary_expression(tree.child(0)))
+                    tree, op,
+                    cls.unary_expression(tree.child(1)))
 
     @classmethod
     def mul_expression(cls, tree):

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -94,7 +94,7 @@ class Grammar:
     def expressions(self):
 
         self.ebnf.POWER = '^'
-        self.ebnf.NOT = 'not'
+        self.ebnf.NOT = '!'
 
         self.ebnf.OR = 'or'
         self.ebnf.AND = 'and'

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -1810,3 +1810,356 @@ def test_compiler_return_complex_expression_2(parser):
           }
         ]
     }]
+
+
+def test_compiler_unary_not(parser):
+    """
+    Ensures that unary expressions are compiled correctly
+    """
+    source = 'a = !b'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'not',
+        'values': [
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'b'
+            ]
+          }
+        ]
+    }]
+
+
+def test_compiler_unary_not_if(parser):
+    """
+    Ensures that unary expression in if statements are compiled correctly
+    """
+    source = 'if !b\n\treturn'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'if'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'assertion',
+        'assertion': 'not',
+        'values': [
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'b'
+            ]
+          }
+        ]
+    }]
+
+
+def test_compiler_unary_double(parser):
+    """
+    Ensures that double unary expressions are compiled correctly
+    """
+    source = 'a = !!b'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'not',
+        'values': [
+          {
+            '$OBJECT': 'expression',
+            'expression': 'not',
+            'values': [
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  'b'
+                ]
+              }
+            ]
+          }
+        ]
+    }]
+
+
+def test_compiler_unary_complex(parser):
+    """
+    Ensures that complex unary expressions are compiled correctly
+    """
+    source = 'a = b and !c'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'and',
+        'values': [
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'b'
+            ]
+          },
+          {
+            '$OBJECT': 'expression',
+            'expression': 'not',
+            'values': [
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  'c'
+                ]
+              }
+            ]
+          }
+        ]
+    }]
+
+
+def test_compiler_unary_complex_2(parser):
+    """
+    Ensures that complex unary expressions are compiled correctly
+    """
+    source = 'a = ! 2 == !3 or ! 4'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'or',
+        'values': [
+          {
+            '$OBJECT': 'expression',
+            'expression': 'equals',
+            'values': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'not',
+                'values': [
+                  2
+                ]
+              },
+              {
+                '$OBJECT': 'expression',
+                'expression': 'not',
+                'values': [
+                  3
+                ]
+              }
+            ]
+          },
+          {
+            '$OBJECT': 'expression',
+            'expression': 'not',
+            'values': [
+              4
+            ]
+          }
+        ]
+    }]
+
+
+def test_compiler_unary_complex_3(parser):
+    """
+    Ensures that complex unary expressions are compiled correctly
+    """
+    source = 'a = [! b, !2] <= ! t + t'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'less_equal',
+        'values': [
+          {
+            '$OBJECT': 'list',
+            'items': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'not',
+                'values': [
+                  {
+                    '$OBJECT': 'path',
+                    'paths': [
+                      'b'
+                    ]
+                  }
+                ]
+              },
+              {
+                '$OBJECT': 'expression',
+                'expression': 'not',
+                'values': [
+                  2
+                ]
+              }
+            ]
+          },
+          {
+            '$OBJECT': 'expression',
+            'expression': 'sum',
+            'values': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'not',
+                'values': [
+                  {
+                    '$OBJECT': 'path',
+                    'paths': [
+                      't'
+                    ]
+                  }
+                ]
+              },
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  't'
+                ]
+              }
+            ]
+          }
+        ]
+    }]
+
+
+def test_compiler_unary_complex_4(parser):
+    """
+    Ensures that complex unary expressions are compiled correctly
+    """
+    source = 'a = my_function k1: !b or 2'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'execute'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'argument',
+        'name': 'k1',
+        'argument': {
+          '$OBJECT': 'expression',
+          'expression': 'or',
+          'values': [
+            {
+              '$OBJECT': 'expression',
+              'expression': 'not',
+              'values': [
+                {
+                  '$OBJECT': 'path',
+                  'paths': [
+                    'b'
+                  ]
+                }
+              ]
+            },
+            2
+          ]
+        }
+    }]
+
+
+def test_compiler_unary_complex_5(parser):
+    """
+    Ensures that complex unary expressions are compiled correctly
+    """
+    source = ('a = ! (my_service command k1: !b) or '
+              '!(my_service2 command k2: ! !c)')
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'or',
+        'values': [
+          {
+            '$OBJECT': 'expression',
+            'expression': 'not',
+            'values': [
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  'p-1.1'
+                ]
+              }
+            ]
+          },
+          {
+            '$OBJECT': 'expression',
+            'expression': 'not',
+            'values': [
+              {
+                '$OBJECT': 'path',
+                'paths': [
+                  'p-1.2'
+                ]
+              }
+            ]
+          }
+        ]
+    }]
+    assert result['tree']['1.1']['args'] == [{
+        '$OBJECT': 'argument',
+        'name': 'k1',
+        'argument': {
+          '$OBJECT': 'expression',
+          'expression': 'not',
+          'values': [
+            {
+              '$OBJECT': 'path',
+              'paths': [
+                'b'
+              ]
+            }
+          ]
+        }
+    }]
+    assert result['tree']['1.2']['args'] == [{
+        '$OBJECT': 'argument',
+        'name': 'k2',
+        'argument': {
+          '$OBJECT': 'expression',
+          'expression': 'not',
+          'values': [
+            {
+              '$OBJECT': 'expression',
+              'expression': 'not',
+              'values': [
+                {
+                  '$OBJECT': 'path',
+                  'paths': [
+                    'c'
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+    }]
+
+
+def test_compiler_unary_complex_6(parser):
+    """
+    Ensures that complex unary expressions are compiled correctly
+    """
+    source = 'a = !-2 or ! -3 - -4'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'or',
+        'values': [
+          {
+            '$OBJECT': 'expression',
+            'expression': 'not',
+            'values': [
+              -2
+            ]
+          },
+          {
+            '$OBJECT': 'expression',
+            'expression': 'subtraction',
+            'values': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'not',
+                'values': [
+                  -3
+                ]
+              },
+              -4
+            ]
+          }
+        ]
+    }]

--- a/tests/unittests/compiler/Objects.py
+++ b/tests/unittests/compiler/Objects.py
@@ -367,10 +367,10 @@ def test_objects_build_unary_expression(patch, tree, magic):
     Ensures Objects.build_unary_expression builds an expression properly
     """
     patch.many(Objects, ['expression_type'])
-    op = '.my.op.'
+    op = magic()
     left = magic()
     result = Objects.build_unary_expression(tree, op, left)
-    Objects.expression_type.assert_called_with(op, tree)
+    Objects.expression_type.assert_called_with(op.type, tree)
     assert result == {
         '$OBJECT': 'expression',
         'expression': Objects.expression_type(),
@@ -466,8 +466,9 @@ def test_objects_unary_expression_two(patch, tree):
     unary_expression = Objects.unary_expression
     patch.object(Objects, 'unary_expression')
     r = unary_expression(tree)
+    op = tree.unary_operator.child(0)
     Objects.build_unary_expression.assert_called_with(
-        tree, tree.child(1), Objects.unary_expression(tree.child(0)))
+        tree, op, Objects.unary_expression(tree.child(1)))
     assert r == Objects.build_unary_expression()
 
 

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -108,7 +108,7 @@ def test_grammar_expressions(grammar, ebnf, magic):
     ]
 
     assert ebnf.POWER == '^'
-    assert ebnf.NOT == 'not'
+    assert ebnf.NOT == '!'
 
     assert ebnf.OR == 'or'
     assert ebnf.AND == 'and'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/519

**- How I did it**

- This was already implemented in the Grammar part (and most of the Compiler in https://github.com/storyscript/storyscript/pull/542) which is why this PR is so small
- However, I added quite a bunch of integration tests to hopefully avoid future breakages

**- How to verify it**

```coffee
a = not b
```

```json
{
  "stories": {
    "foo.story": {
      "tree": {
        "1": {
          "method": "expression",
          "ln": "1",
          "output": null,
          "name": [
            "a"
          ],
          "service": null,
          "command": null,
          "function": null,
          "args": [
            {
              "$OBJECT": "expression",
              "expression": "not",
              "values": [
                {
                  "$OBJECT": "path",
                  "paths": [
                    "b"
                  ]
                }
              ]
            }
          ],
          "enter": null,
          "exit": null,
          "parent": null
        }
      },
      "services": [],
      "entrypoint": "1",
      "modules": {},
      "functions": {},
      "version": "0.9.4"
    }
  },
  "services": [],
  "entrypoint": [
    "foo.story"
  ]
}
```

**- Description for the changelog**

- The unary operator `!` is now supported