### PR TITLE
feat(compiler): Add 'is' as an alternative to '=='

### DIFF
--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -222,7 +222,7 @@ class Objects:
                  'MODULUS': 'modulus',
                  'AND': 'and', 'OR': 'or', 'NOT': 'not', 'EQUAL': 'equals',
                  'GREATER': 'greater', 'LESSER': 'less',
-                 'NOT_EQUAL': 'not_equal',
+                 'NOT_EQUAL': 'not_equal', 'IS': 'equals',
                  'GREATER_EQUAL': 'greater_equal',
                  'LESSER_EQUAL': 'less_equal'}
         tree.expect(operator in types, 'compiler_error_no_operator')

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -105,6 +105,7 @@ class Grammar:
         self.ebnf.LESSER_EQUAL = '<='
         self.ebnf.NOT_EQUAL = '!='
         self.ebnf.EQUAL = '=='
+        self.ebnf.IS = 'is'
 
         self.ebnf.set_token('BSLASH.5', '/')
         self.ebnf.MULTIPLIER = '*'
@@ -114,7 +115,7 @@ class Grammar:
         self.ebnf.set_token('DASH.5', '-')
 
         self.ebnf.cmp_operator = ('GREATER, GREATER_EQUAL, LESSER, '
-                                  'LESSER_EQUAL, NOT_EQUAL, EQUAL')
+                                  'LESSER_EQUAL, NOT_EQUAL, EQUAL, IS')
         self.ebnf.arith_operator = 'PLUS, DASH'
         self.ebnf.unary_operator = 'NOT'
         self.ebnf.mul_operator = 'MULTIPLIER, BSLASH, MODULUS'

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -1810,3 +1810,192 @@ def test_compiler_return_complex_expression_2(parser):
           }
         ]
     }]
+
+
+def test_compiler_expression_is(parser):
+    """
+    Ensures that 'is' expressions compile correctly
+    """
+    source = 'a = 1 is 2'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'equals',
+        'values': [
+          1,
+          2
+        ]
+    }]
+
+
+def test_compiler_expression_is_nested(parser):
+    """
+    Ensures that nested 'is' expressions compile correctly
+    """
+    source = 'a = 1 + 2 is 3/4 is 5*6 is 7%8 or 9'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'or',
+        'values': [
+          {
+            '$OBJECT': 'expression',
+            'expression': 'equals',
+            'values': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'equals',
+                'values': [
+                  {
+                    '$OBJECT': 'expression',
+                    'expression': 'equals',
+                    'values': [
+                      {
+                        '$OBJECT': 'expression',
+                        'expression': 'sum',
+                        'values': [
+                          1,
+                          2
+                        ]
+                      },
+                      {
+                        '$OBJECT': 'expression',
+                        'expression': 'division',
+                        'values': [
+                          3,
+                          4
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    '$OBJECT': 'expression',
+                    'expression': 'multiplication',
+                    'values': [
+                      5,
+                      6
+                    ]
+                  }
+                ]
+              },
+              {
+                '$OBJECT': 'expression',
+                'expression': 'modulus',
+                'values': [
+                  7,
+                  8
+                ]
+              }
+            ]
+          },
+          9
+        ]
+    }]
+
+
+def test_compiler_expression_is_nested_2(parser):
+    """
+    Ensures that nested 'is' expressions compile correctly
+    """
+    source = 'a = 1 is 2 < 3 or 4 > 0.5+5 is -6 and 7 is 8'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'expression'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'expression',
+        'expression': 'or',
+        'values': [
+          {
+            '$OBJECT': 'expression',
+            'expression': 'less',
+            'values': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'equals',
+                'values': [
+                  1,
+                  2
+                ]
+              },
+              3
+            ]
+          },
+          {
+            '$OBJECT': 'expression',
+            'expression': 'and',
+            'values': [
+              {
+                '$OBJECT': 'expression',
+                'expression': 'equals',
+                'values': [
+                  {
+                    '$OBJECT': 'expression',
+                    'expression': 'greater',
+                    'values': [
+                      4,
+                      {
+                        '$OBJECT': 'expression',
+                        'expression': 'sum',
+                        'values': [
+                          0.5,
+                          5
+                        ]
+                      }
+                    ]
+                  },
+                  -6
+                ]
+              },
+              {
+                '$OBJECT': 'expression',
+                'expression': 'equals',
+                'values': [
+                  7,
+                  8
+                ]
+              }
+            ]
+          }
+        ]
+    }]
+
+
+def test_compiler_expression_is_if_statement(parser):
+    """
+    Ensures that 'is' expressions can be used in if statements
+    """
+    source = """if (weather tommorow where:'Amsterdam') is 'horrible'
+    echo message:'oh no!'
+"""
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'if'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'assertion',
+        'assertion': 'equals',
+        'values': [
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'p-1.1'
+            ]
+          },
+          {
+            '$OBJECT': 'string',
+            'string': 'horrible'
+          }
+        ]
+    }]
+    assert result['tree']['1.1']['method'] == 'execute'
+    assert result['tree']['1.1']['service'] == 'weather'
+    assert result['tree']['1.1']['args'] == [{
+        '$OBJECT': 'argument',
+        'name': 'where',
+        'argument': {
+          '$OBJECT': 'string',
+          'string': 'Amsterdam'
+        }
+    }]
+    assert result['tree']['2']['method'] == 'execute'
+    assert result['tree']['2']['service'] == 'echo'
+    assert result['tree']['2']['args'][0]['argument']['string'] == 'oh no!'

--- a/tests/unittests/compiler/Objects.py
+++ b/tests/unittests/compiler/Objects.py
@@ -311,7 +311,7 @@ def test_objects_function_arguments(patch, tree):
     ('BSLASH', 'division'), ('MODULUS', 'modulus'),
     ('POWER', 'exponential'), ('DASH', 'subtraction'), ('AND', 'and'),
     ('OR', 'or'), ('NOT', 'not'),
-    ('EQUAL', 'equals'), ('GREATER', 'greater'),
+    ('EQUAL', 'equals'), ('GREATER', 'greater'), ('IS', 'equals'),
     ('LESSER', 'less'), ('NOT_EQUAL', 'not_equal'),
     ('GREATER_EQUAL', 'greater_equal'), ('LESSER_EQUAL', 'less_equal'),
 ])

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -119,11 +119,12 @@ def test_grammar_expressions(grammar, ebnf, magic):
     assert ebnf.LESSER_EQUAL == '<='
     assert ebnf.NOT_EQUAL == '!='
     assert ebnf.EQUAL == '=='
+    assert ebnf.IS == 'is'
 
     assert ebnf.MULTIPLIER == '*'
 
     assert ebnf.cmp_operator == ('GREATER, GREATER_EQUAL, LESSER, '
-                                 'LESSER_EQUAL, NOT_EQUAL, EQUAL')
+                                 'LESSER_EQUAL, NOT_EQUAL, EQUAL, IS')
     assert ebnf.arith_operator == 'PLUS, DASH'
     assert ebnf.unary_operator == 'NOT'
     assert ebnf.mul_operator == 'MULTIPLIER, BSLASH, MODULUS'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/589

**- What I did**

Added `is` to the syntax and compiler.  Its compiles done to `equals`

**- How to verify it**

```coffee
if (weather tommorow where:'Amsterdam') is 'horrible'
    echo message:'oh no!'
```

```json
{
  "stories": {
    "foo.story": {
      "tree": {
        "1.1": {
          "method": "execute",
          "ln": "1.1",
          "output": [],
          "name": [
            "p-1.1"
          ],
          "service": "weather",
          "command": "tommorow",
          "function": null,
          "args": [
            {
              "$OBJECT": "argument",
              "name": "where",
              "argument": {
                "$OBJECT": "string",
                "string": "Amsterdam"
              }
            }
          ],
          "enter": null,
          "exit": null,
          "parent": null,
          "next": "1"
        },
        "1": {
          "method": "if",
          "ln": "1",
          "output": null,
          "name": null,
          "service": null,
          "command": null,
          "function": null,
          "args": [
            {
              "$OBJECT": "assertion",
              "assertion": "equals",
              "values": [
                {
                  "$OBJECT": "path",
                  "paths": [
                    "p-1.1"
                  ]
                },
                {
                  "$OBJECT": "string",
                  "string": "horrible"
                }
              ]
            }
          ],
          "enter": "2",
          "exit": null,
          "parent": null,
          "next": "2"
        },
        "2": {
          "method": "execute",
          "ln": "2",
          "output": [],
          "name": null,
          "service": "echo",
          "command": null,
          "function": null,
          "args": [
            {
              "$OBJECT": "argument",
              "name": "message",
              "argument": {
                "$OBJECT": "string",
                "string": "oh no!"
              }
            }
          ],
          "enter": null,
          "exit": null,
          "parent": "1"
        }
      },
      "services": [
        "echo",
        "weather"
      ],
      "entrypoint": "1.1",
      "modules": {},
      "functions": {},
      "version": "0.9.4"
    }
  },
  "services": [
    "echo",
    "weather"
  ],
  "entrypoint": [
    "foo.story"
  ]
}
```

**- Description for the changelog**

- `is` expression are now allowed for comparing equality