### PR TITLE
Missing arguments in mutations

### DIFF
--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -39,7 +39,7 @@ class Objects:
         mutation = tree.child(0).value
         arguments = []
         if tree.arguments:
-            arguments = cls.arguments(tree.arguments)
+            arguments = cls.arguments(tree)
         if tree.command:
             mutation = tree.command.child(0).value
         return {'$OBJECT': 'mutation', 'mutation': mutation,

--- a/tests/unittests/compiler/Objects.py
+++ b/tests/unittests/compiler/Objects.py
@@ -81,7 +81,7 @@ def test_objects_mutation_arguments(patch, magic):
     patch.object(Objects, 'arguments')
     tree = magic()
     result = Objects.mutation(tree)
-    Objects.arguments.assert_called_with(tree.arguments)
+    Objects.arguments.assert_called_with(tree)
     assert result['arguments'] == Objects.arguments()
 
 


### PR DESCRIPTION
closes #594 

**- What I did**
Fix mutations having only their first argument compiled, by calling Objects.arguments with the correct tree
