### PR TITLE
Allow mutation and services to be used together

### DIFF
--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -100,7 +100,7 @@ class Compiler:
         service = fragment.service
         if service:
             path = Objects.names(service.path)
-            if [path] not in self.lines.variables:
+            if not self.lines.is_variable_defined(path):
                 self.service(service, None, parent)
                 self.lines.set_name(name)
                 return

--- a/storyscript/compiler/Lines.py
+++ b/storyscript/compiler/Lines.py
@@ -47,6 +47,8 @@ class Lines:
         if previous_line:
             self.lines[previous_line]['name'] = name
 
+        self.variables.append(name)
+
     def set_next(self, line_number):
         """
         Finds the previous line, and set the current as its next line
@@ -146,3 +148,12 @@ class Lines:
         Get the services and remove duplicates.
         """
         return list(set(self.services))
+
+    def is_variable_defined(self, variable_name):
+        """
+        Checks whether a variable has been defined so far
+        """
+        for vs in self.variables:
+            if variable_name in vs:
+                return True
+        return False

--- a/storyscript/compiler/Preprocessor.py
+++ b/storyscript/compiler/Preprocessor.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .Faketree import FakeTree
+from ..parser.Tree import Tree
 
 
 class Preprocessor:
@@ -34,13 +35,14 @@ class Preprocessor:
             return
 
         if node.data == 'block':
-            # the block in which the fake assignments should be inserted
-            block = node
             # only generate a fake_block once for every line
-            block = cls.fake_tree(block)
+            # node: block in which the fake assignments should be inserted
+            block = cls.fake_tree(node)
         elif node.data == 'entity':
             # set the parent where the inline_expression path should be
             # inserted
+            entity = node
+        elif node.data == 'service' and node.child(0).data == 'path':
             entity = node
 
         for c in node.children:
@@ -55,6 +57,12 @@ class Preprocessor:
 
             # Evaluate from leaf to the top
             fun(node, fake_tree, entity)
+
+            # split services into service calls and mutations
+            if entity.data == 'service':
+                entity.data = 'mutation'
+                entity.entity = Tree('entity', [entity.path])
+                entity.service_fragment.data = 'mutation_fragment'
 
     @staticmethod
     def is_inline_expression(n):

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -2163,3 +2163,74 @@ def test_compiler_unary_complex_6(parser):
           }
         ]
     }]
+
+
+def test_compiler_service_mutation(parser):
+    """
+    Ensures that a service with a mutation is compiled correctly
+    """
+    source = 'lines = (http get url: diff_url) split by: "\n"'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1.1'] == {
+        'method': 'execute',
+        'ln': '1.1',
+        'output': [],
+        'name': [
+          'p-1.1'
+        ],
+        'service': 'http',
+        'command': 'get',
+        'function': None,
+        'args': [
+          {
+            '$OBJECT': 'argument',
+            'name': 'url',
+            'argument': {
+              '$OBJECT': 'path',
+              'paths': [
+                'diff_url'
+              ]
+            }
+          }
+        ],
+        'enter': None,
+        'exit': None,
+        'parent': None,
+        'next': '1'
+    }
+    assert result['tree']['1'] == {
+        'method': 'mutation',
+        'ln': '1',
+        'output': None,
+        'name': [
+          'lines'
+        ],
+        'service': None,
+        'command': None,
+        'function': None,
+        'args': [
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'p-1.1'
+            ]
+          },
+          {
+            '$OBJECT': 'mutation',
+            'mutation': 'split',
+            'arguments': [
+              {
+                '$OBJECT': 'argument',
+                'name': 'by',
+                'argument': {
+                  '$OBJECT': 'string',
+                  'string': '\n'
+                }
+              }
+            ]
+          }
+        ],
+        'enter': None,
+        'exit': None,
+        'parent': None
+    }

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -2234,3 +2234,77 @@ def test_compiler_service_mutation(parser):
         'exit': None,
         'parent': None
     }
+
+
+def test_compiler_service_mutation_2(parser):
+    """
+    Ensures that a service with a mutation is compiled correctly
+    """
+    source = """diff = http get url: diff_url
+lines = diff split by: "\n"
+"""
+    result = Compiler.compile(parser.parse(source))
+    assert result['services'] == ['http']
+    assert result['tree']['1'] == {
+        'method': 'execute',
+        'ln': '1',
+        'output': [],
+        'name': [
+          'diff'
+        ],
+        'service': 'http',
+        'command': 'get',
+        'function': None,
+        'args': [
+          {
+            '$OBJECT': 'argument',
+            'name': 'url',
+            'argument': {
+              '$OBJECT': 'path',
+              'paths': [
+                'diff_url'
+              ]
+            }
+          }
+        ],
+        'enter': None,
+        'exit': None,
+        'parent': None,
+        'next': '2'
+    }
+    assert result['tree']['2'] == {
+        'method': 'mutation',
+        'ln': '2',
+        'output': None,
+        'name': [
+          'lines'
+        ],
+        'service': None,
+        'command': None,
+        'function': None,
+        'args': [
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'diff'
+            ]
+          },
+          {
+            '$OBJECT': 'mutation',
+            'mutation': 'split',
+            'arguments': [
+              {
+                '$OBJECT': 'argument',
+                'name': 'by',
+                'argument': {
+                  '$OBJECT': 'string',
+                  'string': '\n'
+                }
+              }
+            ]
+          }
+        ],
+        'enter': None,
+        'exit': None,
+        'parent': None
+    }

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -168,6 +168,7 @@ def test_compiler_assignment(patch, compiler, lines, tree):
 def test_compiler_assignment_service(patch, compiler, lines, tree):
     patch.object(Objects, 'names')
     patch.object(Compiler, 'service')
+    lines.is_variable_defined.return_value = False
     compiler.assignment(tree, '1')
     service = tree.assignment_fragment.service
     Compiler.service.assert_called_with(service, None, '1')

--- a/tests/unittests/compiler/Lines.py
+++ b/tests/unittests/compiler/Lines.py
@@ -239,3 +239,14 @@ def test_lines_execute(patch, lines):
 def test_compiler_get_services(lines):
     lines.services = ['one', 'one']
     assert lines.get_services() == ['one']
+
+
+def test_lines_is_variable_defined(patch, lines):
+    """
+    Ensures that the check for previously seen variables works
+    """
+    lines.variables = [['one', 'two'], ['three']]
+    assert lines.is_variable_defined('one')
+    assert lines.is_variable_defined('two')
+    assert lines.is_variable_defined('three')
+    assert not lines.is_variable_defined('four')

--- a/tests/unittests/compiler/Preprocessor.py
+++ b/tests/unittests/compiler/Preprocessor.py
@@ -4,6 +4,7 @@ from unittest import mock
 from pytest import fixture
 
 from storyscript.compiler import FakeTree, Preprocessor
+from storyscript.parser import Tree
 
 
 @fixture
@@ -13,6 +14,13 @@ def preprocessor(patch):
     return Preprocessor()
 
 
+@fixture
+def entity(magic):
+    obj = magic()
+    obj.data = 'entity'
+    return obj
+
+
 def test_preprocessor_fake_tree(patch):
     patch.init(FakeTree)
     result = Preprocessor.fake_tree('block')
@@ -20,12 +28,11 @@ def test_preprocessor_fake_tree(patch):
     assert isinstance(result, FakeTree)
 
 
-def test_preprocessor_replace_expression(magic, preprocessor):
+def test_preprocessor_replace_expression(magic, preprocessor, entity):
     """
     Check that the new assignment is inserted above the tree
     """
     node = magic()
-    entity = magic()
     entity.line = lambda: 42
     entity.path.line = lambda: 123
     fake_tree = magic()
@@ -83,7 +90,7 @@ def test_preprocessor_visit_no_children(patch, magic, preprocessor):
     assert not preprocessor.replace_expression.called
 
 
-def test_preprocessor_visit_one_children(patch, magic, preprocessor):
+def test_preprocessor_visit_one_children(patch, magic, preprocessor, entity):
     """
     Check that a single inline_expression is found
     """
@@ -95,13 +102,13 @@ def test_preprocessor_visit_one_children(patch, magic, preprocessor):
 
     def is_inline(n):
         return n == c1
-    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.visit(tree, '.block.', entity, is_inline, replace)
     preprocessor.fake_tree.assert_called_with('.block.')
-    replace.assert_called_with(c1, preprocessor.fake_tree(), '.entity.')
+    replace.assert_called_with(c1, preprocessor.fake_tree(), entity)
     assert replace.call_count == 1
 
 
-def test_preprocessor_visit_two_children(patch, magic, preprocessor):
+def test_preprocessor_visit_two_children(patch, magic, preprocessor, entity):
     """
     Check that all inline_expressions are found
     """
@@ -114,14 +121,15 @@ def test_preprocessor_visit_two_children(patch, magic, preprocessor):
     def is_inline(n):
         return n == cs[0] or n == cs[1]
 
-    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.visit(tree, '.block.', entity, is_inline, replace)
     replace.mock_calls = [
-        mock.call(cs[0], preprocessor.fake_tree(), '.entity.'),
-        mock.call(cs[1], preprocessor.fake_tree(), '.entity.'),
+        mock.call(cs[0], preprocessor.fake_tree(), entity),
+        mock.call(cs[1], preprocessor.fake_tree(), entity),
     ]
 
 
-def test_preprocessor_visit_nested_multiple(patch, magic, preprocessor):
+def test_preprocessor_visit_nested_multiple(patch, magic, preprocessor,
+                                            entity):
     """
     Check that all inline_expressions are found (even if they are nested)
     """
@@ -137,14 +145,14 @@ def test_preprocessor_visit_nested_multiple(patch, magic, preprocessor):
     def is_inline(n):
         return n == cs[0] or n == cs[1]
 
-    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.visit(tree, '.block.', entity, is_inline, replace)
     replace.mock_calls = [
-        mock.call(cs[1], preprocessor.fake_tree(), '.entity.'),
-        mock.call(cs[0], preprocessor.fake_tree(), '.entity.'),
+        mock.call(cs[1], preprocessor.fake_tree(), entity),
+        mock.call(cs[0], preprocessor.fake_tree(), entity),
     ]
 
 
-def test_preprocessor_visit_nested_inner(patch, magic, preprocessor):
+def test_preprocessor_visit_nested_inner(patch, magic, preprocessor, entity):
     """
     Check that a nested inline_expression is called if it's deeper in the tree
     """
@@ -160,13 +168,14 @@ def test_preprocessor_visit_nested_inner(patch, magic, preprocessor):
     def is_inline(n):
         return n == cs[1]
 
-    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.visit(tree, '.block.', entity, is_inline, replace)
     replace.mock_calls = [
-        mock.call(cs[1], preprocessor.fake_tree(), '.entity.'),
+        mock.call(cs[1], preprocessor.fake_tree(), entity),
     ]
 
 
-def test_preprocessor_visit_nested_multiple_block(patch, magic, preprocessor):
+def test_preprocessor_visit_nested_multiple_block(patch, magic, preprocessor,
+                                                  entity):
     """
     Check that the fake tree is always generated from the nearest block
     """
@@ -183,19 +192,20 @@ def test_preprocessor_visit_nested_multiple_block(patch, magic, preprocessor):
     def is_inline(n):
         return n == cs[0] or n == cs[1]
 
-    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.visit(tree, '.block.', entity, is_inline, replace)
     preprocessor.fake_tree.mock_calls = [
         mock.call(tree),
         mock.call(tree),
     ]
     replace.mock_calls = [
-        mock.call(cs[1], preprocessor.fake_tree(), '.entity.'),
-        mock.call(cs[0], preprocessor.fake_tree(), '.entity.'),
+        mock.call(cs[1], preprocessor.fake_tree(), entity),
+        mock.call(cs[0], preprocessor.fake_tree(), entity),
     ]
 
 
 def test_preprocessor_visit_nested_multiple_block_nearest(patch,
-                                                          magic, preprocessor):
+                                                          magic, preprocessor,
+                                                          entity):
     """
     Check that the fake tree is always generated from the nearest block
     """
@@ -214,14 +224,14 @@ def test_preprocessor_visit_nested_multiple_block_nearest(patch,
     def is_inline(n):
         return n == cs[0] or n == cs[1]
 
-    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.visit(tree, '.block.', entity, is_inline, replace)
     replace.mock_calls = [
-        mock.call(cs[1], preprocessor.fake_tree(cs[0]), '.entity.'),
-        mock.call(cs[0], preprocessor.fake_tree(cs[1]), '.entity.'),
+        mock.call(cs[1], preprocessor.fake_tree(cs[0]), entity),
+        mock.call(cs[0], preprocessor.fake_tree(cs[1]), entity),
     ]
 
 
-def test_preprocessor_visit_nested_parent(patch, magic, preprocessor):
+def test_preprocessor_visit_nested_parent(patch, magic, preprocessor, entity):
     """
     Check that the parent is always from the taken from the parent entity
     """
@@ -234,12 +244,12 @@ def test_preprocessor_visit_nested_parent(patch, magic, preprocessor):
 
     tree.children = [cs[0]]
     cs[0].children = [cs[1]]
-    cs[0].children = 'entity'
+    cs[0].data = 'entity'
 
     def is_inline(n):
         return n == cs[0] or n == cs[1]
 
-    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
+    preprocessor.visit(tree, '.block.', entity, is_inline, replace)
     preprocessor.fake_tree.mock_calls = [
         mock.call(tree),
         mock.call(tree),
@@ -250,13 +260,12 @@ def test_preprocessor_visit_nested_parent(patch, magic, preprocessor):
     ]
 
 
-def test_preprocessor_visit_nested_same_fake_tree(patch, magic, preprocessor):
+def test_preprocessor_service_mut(patch, magic, preprocessor, entity):
     """
-    Check that multiple nested statements are inserted in the same fake_tree
+    Check that services are correctly converted into mutations
     """
-    patch.object(Preprocessor, 'fake_tree')
     tree = magic()
-    tree.data = 'service_block'
+    tree.data = 'service'
     replace = magic()
     cs = [magic(), magic()]
     for c in cs:
@@ -264,17 +273,19 @@ def test_preprocessor_visit_nested_same_fake_tree(patch, magic, preprocessor):
 
     tree.children = [cs[0]]
     cs[0].children = [cs[1]]
-    cs[0].children = 'entity'
+    cs[0].data = 'path'
+    tree.child(0).data = 'path'
 
     def is_inline(n):
-        return n == cs[0] or n == cs[1]
+        return n == cs[0]
 
-    preprocessor.visit(tree, '.block.', '.entity.', is_inline, replace)
-    # fake_tree is only called once
+    preprocessor.visit(tree, '.block.', entity, is_inline, replace)
     preprocessor.fake_tree.mock_calls = [
         mock.call(tree),
     ]
     replace.mock_calls = [
-        mock.call(cs[1], preprocessor.fake_tree(tree), cs[0]),
-        mock.call(cs[0], preprocessor.fake_tree(tree), tree),
+        mock.call(cs[0], preprocessor.fake_tree(), tree),
     ]
+    assert tree.data == 'mutation'
+    assert tree.entity == Tree('entity', [tree.path])
+    assert tree.service_fragment.data == 'mutation_fragment'


### PR DESCRIPTION
Fixes #604 and #605 

**- What I did**

- when service_fragment are split up into fake lines -> we need to convert them into a mutation fragment
- when a service_fragment is called, we need to check whether the variable has been defined before (this check didn't work because `self.variables` wasn't always set)

I am not very happy with the Preprocessor and we should probably have a more detailed look at it in the near future.

**- Description for the changelog**

- Fix: services and mutations can be used together