### PR TITLE
fix(compiler): support string interpolation evaluation

### DIFF
--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -4,7 +4,7 @@ import re
 from lark.lexer import Token
 
 from ..exceptions import internal_assert
-from ..parser import Tree
+from ..parser import Parser, Tree
 
 
 class Objects:
@@ -82,9 +82,17 @@ class Objects:
 
     @classmethod
     def fillers_values(cls, matches):
+        from .Compiler import Compiler
         values = []
         for match in matches:
-            values.append(cls.path(cls.name_to_path(match)))
+            tree = Parser().parse(match)
+            args = Compiler().compile(tree)['tree']['1']['args']
+            if len(args) == 0:
+                args = cls.path(cls.name_to_path(match))
+            else:
+                args = args[0]
+
+            values.append(args)
         return values
 
     @staticmethod

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -2163,3 +2163,35 @@ def test_compiler_unary_complex_6(parser):
           }
         ]
     }]
+
+
+def test_compiler_string_evaluation(parser):
+    """
+    Ensures that expressions in strings are evaluated
+    """
+    source = 'diff = "https://github.com/{repo_full_name}'
+    source += '/pull/{pull_request[\'number\']}.diff"'
+    result = Compiler.compile(parser.parse(source))
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['args'] == [{
+        '$OBJECT': 'string',
+        'string': 'https://github.com/{}/pull/{}.diff',
+        'values': [
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'repo_full_name'
+            ]
+          },
+          {
+            '$OBJECT': 'path',
+            'paths': [
+              'pull_request',
+              {
+                '$OBJECT': 'string',
+                'string': 'number'
+              }
+            ]
+          }
+        ]
+    }]


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/603

This is just a Proof of Concept.

**- How I did it**

- evaluate the string instead of the hard-coded assumption that it's a path by calling the Parser and Compiler on it again

However, this has its downsides:
- overhead (slower)
- might be hard to merge error messages
- might be hard to merge fake line from the temporary AST

**- Todo**

- [ ] how are errors dealt with
- [ ] how are newly inserted fake-line dealt with
- [ ] how are more complex expressions dealt with
- [ ] do not use nested imports

**- Description for the changelog**

- arbitrary expressions in string interpolation are supported
