### PR TITLE
replace 'raise' in favour of 'throw'

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -37,7 +37,7 @@ class ErrorCodes:
     reserved_keyword_as = ('E0030', '`as` is a reserved keyword')
     reserved_keyword_import = ('E0031', '`import` is a reserved keyword')
     reserved_keyword_while = ('E0032', '`while` is a reserved keyword')
-    reserved_keyword_raise = ('E0033', '`raise` is a reserved keyword')
+    reserved_keyword_throw = ('E0033', '`throw` is a reserved keyword')
     future_reserved_keyword_async = (
         'E0034',
         '`async` is reserved for future use')

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -322,15 +322,15 @@ class Compiler:
         if tree.finally_block:
             self.finally_block(tree.finally_block, parent=parent)
 
-    def raise_statement(self, tree, parent):
+    def throw_statement(self, tree, parent):
         """
-        Compiles a raise statement
+        Compiles a throw statement
         """
         line = tree.line()
         args = []
         if len(tree.children) > 1:
             args = [Objects.entity(tree.child(1))]
-        self.lines.append('raise', line, args=args, parent=parent)
+        self.lines.append('throw', line, args=args, parent=parent)
 
     def catch_block(self, tree, parent):
         """
@@ -378,7 +378,7 @@ class Compiler:
                          'if_block', 'elseif_block', 'else_block',
                          'foreach_block', 'function_block', 'when_block',
                          'try_block', 'return_statement', 'arguments',
-                         'imports', 'while_block', 'raise_statement',
+                         'imports', 'while_block', 'throw_statement',
                          'break_statement', 'mutation_block', 'indented_chain']
         if tree.data in allowed_nodes:
             getattr(self, tree.data)(tree, parent)

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -136,9 +136,9 @@ class Grammar:
         self.ebnf.expression = 'or_expression'
         self.ebnf.absolute_expression = 'expression'
 
-    def raise_statement(self):
-        self.ebnf.RAISE = 'raise'
-        self.ebnf.raise_statement = ('raise entity?')
+    def throw_statement(self):
+        self.ebnf.THROW = 'throw'
+        self.ebnf.throw_statement = ('throw entity?')
 
     def rules(self):
         self.ebnf.RETURN = 'return'
@@ -147,7 +147,7 @@ class Grammar:
         self.ebnf.break_statement = 'break'
         self.ebnf.entity = 'values, path'
         rules = ('absolute_expression, assignment, imports, return_statement, '
-                 'raise_statement, break_statement, block')
+                 'throw_statement, break_statement, block')
         self.ebnf.rules = rules
 
     def mutation_block(self):
@@ -238,7 +238,7 @@ class Grammar:
         self.while_block()
         self.function_block()
         self.try_block()
-        self.raise_statement()
+        self.throw_statement()
         self.block()
         self.ebnf.start = 'nl? block*'
         self.ebnf.ignore('_WS')

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -14,7 +14,7 @@ class Transformer(LarkTransformer):
     """
     reserved_keywords = ['function', 'if', 'else', 'foreach', 'return',
                          'returns', 'try', 'catch', 'finally', 'when', 'as',
-                         'import', 'while', 'raise']
+                         'import', 'while', 'throw']
     future_reserved_keywords = ['async', 'story', 'assert', 'called', 'mock']
 
     @classmethod

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -282,38 +282,38 @@ def test_compiler_try_finally(parser):
     assert result['tree']['4']['parent'] == '3'
 
 
-def test_compiler_try_raise(parser):
-    source = 'try\n\tx=0\ncatch as error\n\traise'
+def test_compiler_try_throw(parser):
+    source = 'try\n\tx=0\ncatch as error\n\tthrow'
     tree = parser.parse(source)
     result = Compiler.compile(tree)
     assert result['tree']['1']['exit'] == '3'
     assert result['tree']['3']['method'] == 'catch'
-    assert result['tree']['4']['method'] == 'raise'
+    assert result['tree']['4']['method'] == 'throw'
     assert result['tree']['4']['parent'] == '3'
 
 
-def test_compiler_try_raise_error(parser):
-    source = 'try\n\tx=0\ncatch as error\n\traise error'
+def test_compiler_try_throw_error(parser):
+    source = 'try\n\tx=0\ncatch as error\n\tthrow error'
     tree = parser.parse(source)
     result = Compiler.compile(tree)
     args = [{'$OBJECT': 'path', 'paths': ['error']}]
     assert result['tree']['1']['exit'] == '3'
     assert result['tree']['3']['method'] == 'catch'
     assert result['tree']['3']['enter'] == '4'
-    assert result['tree']['4']['method'] == 'raise'
+    assert result['tree']['4']['method'] == 'throw'
     assert result['tree']['4']['parent'] == '3'
     assert result['tree']['4']['args'] == args
 
 
-def test_compiler_try_nested_raise_error(parser):
-    source = 'try\n\tx=0\ncatch as error\n\tif TRUE\n\t\traise error'
+def test_compiler_try_nested_throw_error(parser):
+    source = 'try\n\tx=0\ncatch as error\n\tif TRUE\n\t\tthrow error'
     tree = parser.parse(source)
     result = Compiler.compile(tree)
     args = [{'$OBJECT': 'path', 'paths': ['error']}]
     assert result['tree']['1']['exit'] == '3'
     assert result['tree']['3']['method'] == 'catch'
     assert result['tree']['3']['enter'] == '4'
-    assert result['tree']['5']['method'] == 'raise'
+    assert result['tree']['5']['method'] == 'throw'
     assert result['tree']['5']['parent'] == '4'
     assert result['tree']['5']['args'] == args
 

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -204,28 +204,28 @@ def test_parser_try_finally(parser):
     assert path.child(0) == Token('NAME', 'x')
 
 
-def test_parser_try_raise(parser):
-    result = parser.parse('try\n\tx=0\ncatch as error\n\traise')
+def test_parser_try_throw(parser):
+    result = parser.parse('try\n\tx=0\ncatch as error\n\tthrow')
     nested_block = result.block.try_block.catch_block.nested_block
-    assert nested_block.block.rules.raise_statement.child(0) == 'raise'
+    assert nested_block.block.rules.throw_statement.child(0) == 'throw'
 
 
-def test_parser_try_raise_error(parser):
-    result = parser.parse('try\n\tx=0\ncatch as error\n\traise error')
+def test_parser_try_throw_error(parser):
+    result = parser.parse('try\n\tx=0\ncatch as error\n\tthrow error')
     nested_block = result.block.try_block.catch_block.nested_block
-    raise_statement = nested_block.block.rules.raise_statement
-    assert raise_statement.child(0) == 'raise'
-    assert raise_statement.entity.path.child(0) == Token('NAME', 'error')
+    throw_statement = nested_block.block.rules.throw_statement
+    assert throw_statement.child(0) == 'throw'
+    assert throw_statement.entity.path.child(0) == Token('NAME', 'error')
 
 
-def test_parser_try_raise_error_message(parser):
-    result = parser.parse('try\n\tx=0\ncatch as error\n\traise "error"')
+def test_parser_try_throw_error_message(parser):
+    result = parser.parse('try\n\tx=0\ncatch as error\n\tthrow "error"')
     nested_block = result.block.try_block.catch_block.nested_block
-    raise_statement = nested_block.block.rules.raise_statement
-    print(raise_statement.pretty())
-    assert raise_statement.child(0) == 'raise'
+    throw_statement = nested_block.block.rules.throw_statement
+    print(throw_statement.pretty())
+    assert throw_statement.child(0) == 'throw'
     token = Token('DOUBLE_QUOTED', '"error"')
-    assert raise_statement.entity.values.string.child(0) == token
+    assert throw_statement.entity.values.string.child(0) == token
 
 
 @mark.parametrize('number', ['+10', '-10'])

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -45,7 +45,7 @@ from storyscript.ErrorCodes import ErrorCodes
     ('reserved_keyword_as', ('E0030', '`as` is a reserved keyword')),
     ('reserved_keyword_import', ('E0031', '`import` is a reserved keyword')),
     ('reserved_keyword_while', ('E0032', '`while` is a reserved keyword')),
-    ('reserved_keyword_raise', ('E0033', '`raise` is a reserved keyword')),
+    ('reserved_keyword_throw', ('E0033', '`throw` is a reserved keyword')),
     ('future_reserved_keyword_async', (
         'E0034',
         '`async` is reserved for future use')),

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -480,19 +480,19 @@ def test_compiler_function_block_redeclared(patch, compiler, lines, tree):
     e.value.extra.error = 'function_already_declared'
 
 
-def test_compiler_raise_statement(patch, compiler, lines, tree):
-    tree.children = [Token('RAISE', 'raise')]
-    compiler.raise_statement(tree, '1')
-    lines.append.assert_called_with('raise', tree.line(), args=[],
+def test_compiler_throw_statement(patch, compiler, lines, tree):
+    tree.children = [Token('RAISE', 'throw')]
+    compiler.throw_statement(tree, '1')
+    lines.append.assert_called_with('throw', tree.line(), args=[],
                                     parent='1')
 
 
-def test_compiler_raise_name_statement(patch, compiler, lines, tree):
+def test_compiler_throw_name_statement(patch, compiler, lines, tree):
     patch.object(Objects, 'entity')
-    tree.children = [Token('RAISE', 'raise'), Token('NAME', 'error')]
-    compiler.raise_statement(tree, '1')
+    tree.children = [Token('RAISE', 'throw'), Token('NAME', 'error')]
+    compiler.throw_statement(tree, '1')
     args = [Objects.entity()]
-    lines.append.assert_called_with('raise', tree.line(), args=args,
+    lines.append.assert_called_with('throw', tree.line(), args=args,
                                     parent='1')
 
 

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -146,10 +146,10 @@ def test_grammar_expressions(grammar, ebnf, magic):
     assert ebnf.absolute_expression == 'expression'
 
 
-def test_grammar_raise_statement(grammar, ebnf):
-    grammar.raise_statement()
-    assert ebnf.RAISE == 'raise'
-    assert ebnf.raise_statement == 'raise entity?'
+def test_grammar_throw_statement(grammar, ebnf):
+    grammar.throw_statement()
+    assert ebnf.THROW == 'throw'
+    assert ebnf.throw_statement == 'throw entity?'
 
 
 def test_grammar_rules(grammar, ebnf):
@@ -159,7 +159,7 @@ def test_grammar_rules(grammar, ebnf):
     assert ebnf.entity == 'values, path'
     assert ebnf.return_statement == 'return expression?'
     rules = ('absolute_expression, assignment, imports, return_statement, '
-             'raise_statement, break_statement, block')
+             'throw_statement, break_statement, block')
     assert ebnf.rules == rules
 
 
@@ -254,7 +254,7 @@ def test_grammar_build(patch, call_count, grammar, ebnf):
     methods = ['macros', 'types', 'values', 'assignments', 'imports',
                'expressions', 'rules', 'mutation_block', 'service_block',
                'if_block', 'foreach_block', 'function_block', 'try_block',
-               'block', 'while_block', 'raise_statement']
+               'block', 'while_block', 'throw_statement']
     patch.many(Grammar, methods)
     result = grammar.build()
     assert ebnf._WS == '(" ")+'

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -17,7 +17,7 @@ def syntax_error(patch):
 def test_transformer():
     keywords = ['function', 'if', 'else', 'foreach', 'return', 'returns',
                 'try', 'catch', 'finally', 'when', 'as', 'import', 'while',
-                'raise']
+                'throw']
     future_keywords = ['async', 'story', 'assert', 'called', 'mock']
     assert Transformer.reserved_keywords == keywords
     assert Transformer.future_reserved_keywords == future_keywords
@@ -26,7 +26,7 @@ def test_transformer():
 
 @mark.parametrize('keyword', [
     'function', 'if', 'else', 'foreach', 'return', 'returns', 'try', 'catch',
-    'finally', 'when', 'as', 'import', 'while', 'raise'
+    'finally', 'when', 'as', 'import', 'while', 'throw'
 ])
 def test_transformer_is_keyword(syntax_error, keyword):
     token = Token('any', keyword)


### PR DESCRIPTION
Closes #595

**- What I did**
* Renamed all definitions related to the 'raise' keyword to 'throw'. Edited tests consequently.

**- Description for the changelog**
* 'raise' is deprecated in favour of 'throw'
