### PR TITLE
fix(grammar): allow string escaping for quotes

### DIFF
--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -48,8 +48,8 @@ class Grammar:
         self.ebnf.set_token('INT.2', '("+"|"-")? RAW_INT')
         self.ebnf.set_token('FLOAT.2', '("+"|"-")? INT "." RAW_INT? | '
                             '"." RAW_INT')
-        self.ebnf.SINGLE_QUOTED = "/'([^']*)'/"
-        self.ebnf.DOUBLE_QUOTED = '/"([^"]*)"/'
+        self.ebnf.SINGLE_QUOTED = r"/'([^'\\]*(?:\\.[^'\\]*)*)'/"
+        self.ebnf.DOUBLE_QUOTED = r'/"([^"\\]*(?:\\.[^"\\]*)*)"/'
         self.ebnf.set_token('REGEXP.2', r'/\/([^\/]*)\//')
         self.ebnf.set_token('NAME.1', r'/[a-zA-Z-\/_0-9]+/')
         self.ebnf._OSB = '['

--- a/tests/integration/compiler/Assignments.py
+++ b/tests/integration/compiler/Assignments.py
@@ -248,3 +248,27 @@ def test_assignments_mutation_variable(parser):
     assert result['services'] == []
     assert result['tree']['2']['method'] == 'mutation'
     assert result['tree']['2']['args'][1]['$OBJECT'] == 'mutation'
+
+
+def test_assignments_string_escape_single(parser):
+    """
+    Ensures that assignments to strings with escaping are compiled correctly
+    """
+    tree = parser.parse('a = \'b.\\n.\\\\.\\\'.c\'')
+    result = Compiler.compile(tree)
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['name'] == ['a']
+    expected = [{'$OBJECT': 'string', 'string': 'b.\n.\\.\'.c'}]
+    assert result['tree']['1']['args'] == expected
+
+
+def test_assignments_string_escape_double(parser):
+    """
+    Ensures that assignments to strings with escaping are compiled correctly
+    """
+    tree = parser.parse(r'a = "b.\n.\\.\".c"')
+    result = Compiler.compile(tree)
+    assert result['tree']['1']['method'] == 'set'
+    assert result['tree']['1']['name'] == ['a']
+    expected = [{'$OBJECT': 'string', 'string': 'b.\n.\\.".c'}]
+    assert result['tree']['1']['args'] == expected

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -244,3 +244,19 @@ def test_parser_number_float(parser, number):
     entity = get_entity(ar_exp)
     f = entity.values.number
     assert f.child(0) == Token('FLOAT', number)
+
+
+def test_parser_string_double_quoted(parser):
+    result = parser.parse(r'a = "b\n.\\.\".c"')
+    result = result.block.rules.assignment.assignment_fragment
+    ar_exp = arith_exp(result)
+    lhs = get_entity(ar_exp.child(0)).values.string.child(0)
+    assert lhs == r'"b\n.\\.\".c"'
+
+
+def test_parser_string_single_quoted(parser):
+    result = parser.parse(r"""a = 'b.\n.\\.\'.c'""")
+    result = result.block.rules.assignment.assignment_fragment
+    ar_exp = arith_exp(result)
+    lhs = get_entity(ar_exp.child(0)).values.string.child(0)
+    assert lhs == r"""'b.\n.\\.\'.c'"""

--- a/tests/unittests/parser/Grammar.py
+++ b/tests/unittests/parser/Grammar.py
@@ -54,8 +54,8 @@ def test_grammar_values(grammar, ebnf):
     assert ebnf.TRUE == 'true'
     assert ebnf.FALSE == 'false'
     assert ebnf.NULL == 'null'
-    assert ebnf.SINGLE_QUOTED == "/'([^']*)'/"
-    assert ebnf.DOUBLE_QUOTED == '/"([^"]*)"/'
+    assert ebnf.SINGLE_QUOTED == r"/'([^'\\]*(?:\\.[^'\\]*)*)'/"
+    assert ebnf.DOUBLE_QUOTED == r'/"([^"\\]*(?:\\.[^"\\]*)*)"/'
     assert ebnf._OSB == '['
     assert ebnf._CSB == ']'
     assert ebnf._OCB == '{'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/558 and https://github.com/storyscript/storyscript/issues/557

**- What I did**

- Used a RegExp that allows escaping of the same quotes
- Added integration tests

**- Description for the changelog**

- Fix: string escaping for the respective quotes works now