### PR TITLE
Try read_version first + cache it + use stderr for git API calls

### DIFF
--- a/storyscript/Version.py
+++ b/storyscript/Version.py
@@ -39,15 +39,15 @@ def read_version():
 
 
 def get_version():
-    # try detecting the git version first
+    # try to read a VERSION file (e.g. for a released storyscript)
     try:
-        return git_describe()
+        return read_version()
     except Exception:
         pass
 
-    # fallback to a VERSION file (e.g. for a released storyscript)
+    # detect a git version (for development builds)
     try:
-        return read_version()
+        return git_describe()
     except Exception:
         pass
 
@@ -56,15 +56,15 @@ def get_version():
 
 
 def get_release_version():
-    # try detecting the git version first
+    # try to read a VERSION file (e.g. for a released storyscript)
     try:
-        return git_version()
+        return read_version()
     except Exception:
         pass
 
-    # fallback to a VERSION file (e.g. for a released storyscript)
+    # detect a git version (for development builds)
     try:
-        return read_version()
+        return git_version()
     except Exception:
         pass
 

--- a/storyscript/Version.py
+++ b/storyscript/Version.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import io
 import subprocess
+from functools import lru_cache
 from os import path
 
 root_dir = path.abspath(path.dirname(path.dirname(__file__)))
@@ -29,6 +30,9 @@ def git_describe():
     ).stdout.strip()
 
 
+# The version is a constant which isn't going to change over the program
+# lifetime
+@lru_cache(maxsize=1)
 def read_version():
     return io.open(path.join(root_dir, 'storyscript', 'VERSION'), 'r',
                    encoding='utf8').read().strip()

--- a/storyscript/Version.py
+++ b/storyscript/Version.py
@@ -11,6 +11,7 @@ def git_version():
     return subprocess.run(
         ['git', 'describe', '--abbrev=0', '--tags'],
         stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
         text=True,
         check=True,
         cwd=root_dir,
@@ -21,6 +22,7 @@ def git_describe():
     return subprocess.run(
         ['git', 'describe', '--dirty'],
         stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
         text=True,
         check=True,
         cwd=root_dir,

--- a/tests/unittests/Version.py
+++ b/tests/unittests/Version.py
@@ -12,6 +12,7 @@ def test_git_version(patch):
     subprocess.run.assert_called_with(
         ['git', 'describe', '--abbrev=0', '--tags'],
         stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
         text=True,
         check=True,
         cwd=mock.ANY,
@@ -25,6 +26,7 @@ def test_git_describe(patch):
     subprocess.run.assert_called_with(
         ['git', 'describe', '--dirty'],
         stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
         text=True,
         check=True,
         cwd=mock.ANY,

--- a/tests/unittests/Version.py
+++ b/tests/unittests/Version.py
@@ -36,6 +36,7 @@ def test_git_describe(patch):
 
 def test_read_version(patch):
     patch.object(io, 'open')
+    Version.read_version.cache_clear()
     r = Version.read_version()
     io.open.assert_called_with(
         mock.ANY,

--- a/tests/unittests/Version.py
+++ b/tests/unittests/Version.py
@@ -48,24 +48,24 @@ def test_read_version(patch):
 
 
 def test_get_version(patch):
-    patch.object(Version, 'git_describe')
-    assert Version.get_version() == Version.git_describe()
-
     patch.object(Version, 'read_version')
-    Version.git_describe.side_effect = Exception('.no.file.found.')
     assert Version.get_version() == Version.read_version()
 
+    patch.object(Version, 'git_describe')
     Version.read_version.side_effect = Exception('.no.file.found.')
+    assert Version.get_version() == Version.git_describe()
+
+    Version.git_describe.side_effect = Exception('.no.file.found.')
     assert Version.get_version() == '0.0.0'
 
 
 def test_get_release_version(patch):
-    patch.object(Version, 'git_version')
-    assert Version.get_release_version() == Version.git_version()
-
     patch.object(Version, 'read_version')
-    Version.git_version.side_effect = Exception('.no.file.found.')
     assert Version.get_release_version() == Version.read_version()
 
+    patch.object(Version, 'git_version')
     Version.read_version.side_effect = Exception('.no.file.found.')
+    assert Version.get_release_version() == Version.git_version()
+
+    Version.git_version.side_effect = Exception('.no.file.found.')
     assert Version.get_release_version() == '0.0.0'


### PR DESCRIPTION
Fix https://github.com/storyscript/storyscript/issues/616

**- What I did**

- fix(version): pipe stderr to /dev/null
- feat(version): cache read_version to avoid superfluous reads
- feat(version): try the common case (read_version) first