### PR TITLE
fix(preprocessor): make a copy of the returned path reference and fixup the line numbers directly

### DIFF
--- a/storyscript/compiler/Faketree.py
+++ b/storyscript/compiler/Faketree.py
@@ -58,9 +58,10 @@ class FakeTree:
         fragment = Tree('assignment_fragment', [equals, value])
         return Tree('assignment', [path, fragment])
 
-    def add_assignment(self, value):
+    def add_assignment(self, value, original_line):
         """
         Creates an assignments and adds it to the current block
+        Returns a fake path reference to this assignment
         """
         assignment = self.assignment(value)
         if self.block.child(1):
@@ -68,4 +69,8 @@ class FakeTree:
             self.block.children = children
         else:
             self.block.children = [assignment, self.block.child(0)]
-        return assignment
+        # we need a new node, s.t. already inserted fake node doesn't get
+        # changed
+        name = Token('NAME', assignment.path.child(0), line=original_line)
+        fake_path = Tree('path', [name])
+        return fake_path

--- a/storyscript/compiler/Preprocessor.py
+++ b/storyscript/compiler/Preprocessor.py
@@ -22,12 +22,13 @@ class Preprocessor:
         Replaces an inline expression with a fake assignment
         """
         line = entity.line()
-        assignment = fake_tree.add_assignment(node.service)
+        # generate a new assignment line
+        # insert it above this statement in the current block
+        # return a path reference
+        fake_path = fake_tree.add_assignment(node.service, original_line=line)
 
-        # find parent node to replace
-        entity.path.replace(0, assignment.path.child(0))
-        # fix-up the line
-        entity.path.children[0].line = line
+        # Replace the inline expression with a fake_path reference
+        entity.path.replace(0, fake_path.child(0))
 
     @classmethod
     def visit(cls, node, block, entity, pred, fun):

--- a/tests/e2e/when_enter_line_fake_assignment.json
+++ b/tests/e2e/when_enter_line_fake_assignment.json
@@ -1,0 +1,120 @@
+{
+  "stories": {
+    "tests/e2e/when_enter_line_fake_assignment.story": {
+      "tree": {
+        "1": {
+          "method": "execute",
+          "ln": "1",
+          "output": [
+            "s"
+          ],
+          "name": null,
+          "service": "http",
+          "command": "server",
+          "function": null,
+          "args": [],
+          "enter": "2",
+          "exit": null,
+          "parent": null,
+          "next": "2"
+        },
+        "2": {
+          "method": "when",
+          "ln": "2",
+          "output": [
+            "req"
+          ],
+          "name": null,
+          "service": "s",
+          "command": "listen",
+          "function": null,
+          "args": [
+            {
+              "$OBJECT": "argument",
+              "name": "path",
+              "argument": {
+                "$OBJECT": "string",
+                "string": "/test"
+              }
+            }
+          ],
+          "enter": "3.1",
+          "exit": null,
+          "parent": "1",
+          "next": "3.1"
+        },
+        "3.1": {
+          "method": "execute",
+          "ln": "3.1",
+          "output": [],
+          "name": [
+            "p-3.1"
+          ],
+          "service": "fullcontact",
+          "command": "person",
+          "function": null,
+          "args": [],
+          "enter": null,
+          "exit": null,
+          "parent": "2",
+          "next": "3"
+        },
+        "3": {
+          "method": "set",
+          "ln": "3",
+          "output": null,
+          "name": [
+            "a"
+          ],
+          "service": null,
+          "command": null,
+          "function": null,
+          "args": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "p-3.1"
+              ]
+            }
+          ],
+          "enter": null,
+          "exit": null,
+          "parent": "2",
+          "next": "4"
+        },
+        "4": {
+          "method": "set",
+          "ln": "4",
+          "output": null,
+          "name": [
+            "a"
+          ],
+          "service": null,
+          "command": null,
+          "function": null,
+          "args": [
+            4
+          ],
+          "enter": null,
+          "exit": null,
+          "parent": "1"
+        }
+      },
+      "services": [
+        "http",
+        "fullcontact"
+      ],
+      "entrypoint": "1",
+      "modules": {},
+      "functions": {},
+      "version": "0.9.7-1-g7b209ee"
+    }
+  },
+  "services": [
+    "fullcontact",
+    "http"
+  ],
+  "entrypoint": [
+    "tests/e2e/when_enter_line_fake_assignment.story"
+  ]
+}

--- a/tests/e2e/when_enter_line_fake_assignment.story
+++ b/tests/e2e/when_enter_line_fake_assignment.story
@@ -1,0 +1,4 @@
+http server as s
+    when s listen path:'/test' as req
+        a = (fullcontact person)
+    a = 4

--- a/tests/unittests/compiler/Faketree.py
+++ b/tests/unittests/compiler/Faketree.py
@@ -90,14 +90,16 @@ def test_faketree_assignment(patch, tree, fake_tree):
 def test_faketree_add_assignment(patch, fake_tree, block):
     patch.object(FakeTree, 'assignment')
     block.child.return_value = None
-    result = fake_tree.add_assignment('value')
+    result = fake_tree.add_assignment('value', original_line=10)
     FakeTree.assignment.assert_called_with('value')
     assert block.children == [FakeTree.assignment(), block.child()]
-    assert result == FakeTree.assignment()
+    name = Token('NAME', FakeTree.assignment().path.child(0), line=10)
+    assert result.data == 'path'
+    assert result.children == [name]
 
 
 def test_faketree_add_assignment_more_children(patch, fake_tree, block):
     patch.object(FakeTree, 'assignment')
-    fake_tree.add_assignment('value')
+    fake_tree.add_assignment('value', original_line=42)
     expected = [block.child(), FakeTree.assignment(), block.child()]
     assert block.children == expected

--- a/tests/unittests/compiler/Preprocessor.py
+++ b/tests/unittests/compiler/Preprocessor.py
@@ -37,11 +37,9 @@ def test_preprocessor_replace_expression(magic, preprocessor, entity):
     entity.path.line = lambda: 123
     fake_tree = magic()
     preprocessor.replace_expression(node, fake_tree, entity)
-    fake_tree.add_assignment.assert_called_with(node.service)
-    assignment = fake_tree.add_assignment().path.child()
-    entity.path.replace.assert_called_with(0, assignment)
-    assert entity.path.children[0].line == 42
-    assert entity.path.line() == 123
+    fake_tree.add_assignment.assert_called_with(node.service, original_line=42)
+    assignment = fake_tree.add_assignment()
+    entity.path.replace.assert_called_with(0, assignment.child(0))
 
 
 def test_preprocessor_process(patch, magic, preprocessor):


### PR DESCRIPTION
Closes https://github.com/storyscript/storyscript/issues/615

**- What I did**

The problem was that in the Preprocessor we "fixup" the line of the fake path reference to the original line. However, with this fixup we overwrote the "path" path of the inserted fake node too.

**- How I did it**

This PR refactors the Preprocessor and FakeTree a bit, s.t. a proper copy is returned