### PR TITLE
chore(circleci): install twine on the deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,4 +105,5 @@ jobs:
                   name: upload to pypi
                   command: |
                     . venv/bin/activate
+                    pip install twine==1.13.0
                     twine upload dist/*


### PR DESCRIPTION
From https://circleci.com/gh/storyscript/storyscript/679