### PR TITLE
chore(CircleCI): Bump Python to 3.6.8 on CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     build:
         working_directory: ~/repo
         docker:
-            - image: circleci/python:3.6.1
+            - image: circleci/python:3.6.8
         steps:
             - checkout
             #- restore_cache:
@@ -75,7 +75,7 @@ jobs:
                 destination: test-reports
     deploy:
         docker:
-            - image: circleci/python:3.6.1
+            - image: circleci/python:3.6.8
         steps:
             - checkout
             - run:


### PR DESCRIPTION
It looks like the `setuptools` version on CircleCi is simply too old.
(see e.g. https://circleci.com/gh/storyscript/storyscript/683)