### PR TITLE
fix(Compiler): set 'exit' correctly for blocks

### DIFF
--- a/tests/e2e/complex_assert.json
+++ b/tests/e2e/complex_assert.json
@@ -105,7 +105,7 @@
       "function": null,
       "args": null,
       "enter": "5",
-      "exit": null,
+      "exit": "6",
       "parent": null,
       "next": "5"
     },

--- a/tests/e2e/exit_line.json
+++ b/tests/e2e/exit_line.json
@@ -63,7 +63,7 @@
         }
       ],
       "enter": "5",
-      "exit": "9",
+      "exit": "6",
       "parent": null,
       "next": "5"
     },
@@ -95,7 +95,7 @@
       "function": null,
       "args": null,
       "enter": "7",
-      "exit": null,
+      "exit": "9",
       "parent": null,
       "next": "7"
     },
@@ -195,7 +195,7 @@
       "function": null,
       "args": null,
       "enter": "15",
-      "exit": null,
+      "exit": "17",
       "parent": null,
       "next": "15"
     },

--- a/tests/e2e/exit_line_complex.json
+++ b/tests/e2e/exit_line_complex.json
@@ -1,0 +1,254 @@
+{
+  "tree": {
+    "1": {
+      "method": "set",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "labels"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "dict",
+              "items": [
+                [
+                  {
+                    "$OBJECT": "string",
+                    "string": "name"
+                  },
+                  {
+                    "$OBJECT": "string",
+                    "string": "a"
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "set",
+      "ln": "2",
+      "output": null,
+      "name": [
+        "found"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        false
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "3"
+    },
+    "3": {
+      "method": "for",
+      "ln": "3",
+      "output": [
+        "label"
+      ],
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "labels"
+          ]
+        }
+      ],
+      "enter": "4",
+      "exit": "10",
+      "parent": null,
+      "next": "4"
+    },
+    "4": {
+      "method": "if",
+      "ln": "4",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "or",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "equals",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "label",
+                    {
+                      "$OBJECT": "string",
+                      "string": "name"
+                    }
+                  ]
+                },
+                {
+                  "$OBJECT": "string",
+                  "string": "a"
+                }
+              ]
+            },
+            {
+              "$OBJECT": "expression",
+              "expression": "equals",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "label",
+                    {
+                      "$OBJECT": "string",
+                      "string": "name"
+                    }
+                  ]
+                },
+                {
+                  "$OBJECT": "string",
+                  "string": "b"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "enter": "5",
+      "exit": "6",
+      "parent": "3",
+      "next": "5"
+    },
+    "5": {
+      "method": "set",
+      "ln": "5",
+      "output": null,
+      "name": [
+        "found"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        true
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "4",
+      "next": "6"
+    },
+    "6": {
+      "method": "else",
+      "ln": "6",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": null,
+      "enter": "7",
+      "exit": "8",
+      "parent": "3",
+      "next": "7"
+    },
+    "7": {
+      "method": "set",
+      "ln": "7",
+      "output": null,
+      "name": [
+        "found"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        false
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "6",
+      "next": "8"
+    },
+    "8": {
+      "method": "if",
+      "ln": "8",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "enter": "9",
+      "exit": "10",
+      "parent": "3",
+      "next": "9"
+    },
+    "9": {
+      "method": "set",
+      "ln": "9",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "8",
+      "next": "10"
+    },
+    "10": {
+      "method": "set",
+      "ln": "10",
+      "output": null,
+      "name": [
+        "outside"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        true
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/exit_line_complex.story
+++ b/tests/e2e/exit_line_complex.story
@@ -1,0 +1,10 @@
+labels = [{"name": "a"}]
+found = false
+foreach labels as label
+	if label["name"] == "a" or label["name"] == "b"
+		found = true
+	else
+		found = false
+	if a
+		x = 0
+outside = true

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -370,11 +370,13 @@ def test_compiler_if_block(patch, compiler, lines, tree):
     patch.object(Compiler, 'subtree')
     tree.elseif_block = None
     tree.else_block = None
+    tree.extract.return_value = []
     compiler.if_block(tree, '1')
     Objects.expression.assert_called_with(tree.if_statement.expression)
     nested_block = tree.nested_block
     args = [Objects.expression()]
     lines.set_scope.assert_called_with(tree.line(), '1')
+    lines.finish_scope.assert_called_with(tree.line())
     lines.append.assert_called_with('if', tree.line(), args=args,
                                     enter=nested_block.line(), parent='1')
     compiler.subtree.assert_called_with(nested_block, parent=tree.line())
@@ -402,9 +404,11 @@ def test_compiler_elseif_block(patch, compiler, lines, tree):
     patch.object(Objects, 'expression')
     patch.object(Compiler, 'subtree')
     compiler.elseif_block(tree, '1')
+    lines.set_exit.assert_called_with(tree.line())
     Objects.expression.assert_called_with(tree.elseif_statement.expression)
     args = [Objects.expression()]
     lines.set_scope.assert_called_with(tree.line(), '1')
+    lines.finish_scope.assert_called_with(tree.line())
     lines.append.assert_called_with('elif', tree.line(), args=args,
                                     enter=tree.nested_block.line(),
                                     parent='1')
@@ -414,7 +418,9 @@ def test_compiler_elseif_block(patch, compiler, lines, tree):
 def test_compiler_else_block(patch, compiler, lines, tree):
     patch.object(Compiler, 'subtree')
     compiler.else_block(tree, '1')
+    lines.set_exit.assert_called_with(tree.line())
     lines.set_scope.assert_called_with(tree.line(), '1')
+    lines.finish_scope.assert_called_with(tree.line())
     lines.append.assert_called_with('else', tree.line(), parent='1',
                                     enter=tree.nested_block.line())
     compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
@@ -429,6 +435,7 @@ def test_compiler_foreach_block(patch, compiler, lines, tree):
     compiler.output.assert_called_with(tree.foreach_statement.output)
     args = [Objects.entity()]
     lines.set_scope.assert_called_with(tree.line(), '1', Compiler.output())
+    lines.finish_scope.assert_called_with(tree.line())
     lines.append.assert_called_with('for', tree.line(), args=args,
                                     enter=tree.nested_block.line(),
                                     output=Compiler.output(), parent='1')
@@ -442,6 +449,7 @@ def test_compiler_while_block(patch, compiler, lines, tree):
     compiler.while_block(tree, '1')
     args = [Objects.expression()]
     lines.set_scope.assert_called_with(tree.line(), '1')
+    lines.finish_scope.assert_called_with(tree.line())
     lines.append.assert_called_with('while', tree.line(), args=args,
                                     enter=tree.nested_block.line(),
                                     parent='1')
@@ -602,6 +610,7 @@ def test_compiler_try_block(patch, compiler, lines, tree):
     compiler.try_block(tree, '1')
     kwargs = {'enter': tree.nested_block.line(), 'parent': '1'}
     lines.set_scope.assert_called_with(tree.line(), '1')
+    lines.finish_scope.assert_called_with(tree.line())
     lines.append.assert_called_with('try', tree.line(), **kwargs)
     Compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
@@ -627,8 +636,10 @@ def test_compiler_catch_block(patch, compiler, lines, tree):
     patch.object(Objects, 'names')
     patch.object(Compiler, 'subtree')
     compiler.catch_block(tree, '1')
+    lines.set_exit.assert_called_with(tree.line())
     Objects.names.assert_called_with(tree.catch_statement)
     lines.set_scope.assert_called_with(tree.line(), '1', Objects.names())
+    lines.finish_scope.assert_called_with(tree.line())
     kwargs = {'enter': tree.nested_block.line(), 'output': Objects.names(),
               'parent': '1'}
     lines.append.assert_called_with('catch', tree.line(), **kwargs)
@@ -641,7 +652,9 @@ def test_compiler_finally_block(patch, compiler, lines, tree):
     """
     patch.object(Compiler, 'subtree')
     compiler.finally_block(tree, '1')
+    lines.set_exit.assert_called_with(tree.line())
     lines.set_scope.assert_called_with(tree.line(), '1')
+    lines.finish_scope.assert_called_with(tree.line())
     kwargs = {'enter': tree.nested_block.line(), 'parent': '1'}
     lines.append.assert_called_with('finally', tree.line(), **kwargs)
     Compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())


### PR DESCRIPTION
A better fix to https://github.com/storyscript/storyscript/issues/635

**- What I did**

- Keep track of the currently entered scopes
- When appending a new line, set the `exit` value of all previously opened, but not closed scopes to this new line
- Keep the old logic which special cases this for e.g. `else` or `elseif`