### PR TITLE
feat(tests): add a convenient and fast e2e update tool

### DIFF
--- a/storyscript/__main__.py
+++ b/storyscript/__main__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from .Cli import Cli
+
+Cli.main()

--- a/tests/e2e/update
+++ b/tests/e2e/update
@@ -1,0 +1,103 @@
+#!/bin/bash
+################################################################################
+# Small e2e update tool
+# This script can be used to automatically create or update the output/error
+# file of an e2e story test.
+# Required tools: 'parallel', 'jq'
+################################################################################
+
+set -uo pipefail
+
+function usage() {
+cat <<EOF
+./update <story-file|all>
+
+<file>:  updates or creates the e2e output of a story
+all:     updates all stories in parallel
+
+Usage examples
+--------------
+
+> ./update all
+(updates all story outputs in parallel)
+
+> ./update function_call_nested.story
+(creates or updates 'function_call_nested.json')
+
+> ./update function_call_no_inline_expression.story
+(creates or updates 'function_call_no_inline_expression.error')
+EOF
+}
+
+function error() {
+	echo "${1:-}" >&2
+}
+
+function relpath() {
+    realpath --relative-to "$PWD" "$1"
+}
+
+if [ "${1:-x}" == "x" ] ; then
+	error "ERROR: No input file specified."
+	error
+	usage
+	exit 1
+fi
+
+if ! command -v jq > /dev/null 2>&1 ; then
+    error "ERROR: 'jq' is not installed, but required."
+    exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# shortcut for running in parallel
+if [ "$1" == "all" ] || [ "$1" == "a" ] ; then
+	if ! command -v parallel > /dev/null 2>&1 ; then
+		error "ERROR: 'parallel' is not installed, but required for 'all'."
+		exit 1
+	fi
+	stories="$(find "$SCRIPT_DIR" -name "*.story")"
+	echo "INFO: Updating $(echo "$stories" | wc -l) stories"
+	echo "$stories" | parallel -j20 "${BASH_SOURCE[0]}"
+	exit 0
+fi
+
+file="$1"
+
+if [ ! -e "${file}" ] ; then
+    # check for paths from the e2e tool
+    if [ -e "${SCRIPT_DIR}/${file}" ] ; then
+        file="${SCRIPT_DIR}/${file}"
+    else
+	    error "ERROR: Input file '${file}' does not exist."
+	    error
+	    usage
+	    exit 1
+    fi
+fi
+
+file="$(realpath "$file")"
+file="${file%.story}"
+story="${file}.story"
+output_json="${file}.json"
+output_error="${file}.error"
+
+output="$(cd "$SCRIPT_DIR/../.." && python -m storyscript compile -j "${story}" 2>&1)"
+exit_code=$?
+
+# depending on whether the compiler failed, we want to write the
+# json output (success) or the error message (failed).
+if [ $exit_code -eq 0 ] ; then
+    echo "> $(relpath "$output_json")"
+    echo "$output" | \
+    sed 's/"version": ".*"/"version": null/' | \
+    jq ".stories[\"${story}\"]"> "${output_json}"
+else
+    echo "> $output_error"
+    # SS failed, write error file
+    echo "$output" > "$(relpath "$output_error")"
+    echo "---"
+    cat "$output_error"
+    echo "---"
+fi


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/425

**- What I did**

- Added the ad-hoc `e2e` update tool which I'm currently using to the tree
- Allowed running storyscript on the CLI with `python -m storyscript`

**- How I did it**

- A few lines of bash for nice test automation (if this is used by anyone else, we can always convert it to Python)

**- How to verify it**

```
./update <story-file|all>

<file>:  updates or creates the e2e output of a story
all:     updates all stories in parallel

Usage examples
--------------

> ./update all
(updates all story outputs in parallel)

> ./update function_call_nested.story
(creates or updates 'function_call_nested.json')

> ./update function_call_no_inline_expression.story
(creates or updates 'function_call_no_inline_expression.error')
```

**- Description for the changelog**

- developer improvements: `e2e` tests can now be automatically updated or created with a new `update` tool
