### PR TITLE
refactor(exceptions): attach formats to thrown exceptions

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -24,44 +24,20 @@ class ErrorCodes:
     object_opening_bracket = ('E0017', 'Missing opening bracket for object')
     object_closing_bracket = ('E0018', 'Missing closing bracket for object')
     service_argument_colon = ('E0019', 'Missing colon in service argument')
-    reserved_keyword_function = ('E0020', '`function` is a reserved keyword')
-    reserved_keyword_if = ('E0021', '`if` is a reserved keyword')
-    reserved_keyword_else = ('E0022', '`else` is a reserved keyword')
-    reserved_keyword_foreach = ('E0023', '`foreach` is a reserved keyword')
-    reserved_keyword_return = ('E0024', '`return` is a reserved keyword')
-    reserved_keyword_returns = ('E0025', '`returns` is a reserved keyword')
-    reserved_keyword_try = ('E0026', '`try` is a reserved keyword')
-    reserved_keyword_catch = ('E0027', '`catch` is a reserved keyword')
-    reserved_keyword_finally = ('E0028', '`finally` is a reserved keyword')
-    reserved_keyword_when = ('E0029', '`when` is a reserved keyword')
-    reserved_keyword_as = ('E0030', '`as` is a reserved keyword')
-    reserved_keyword_import = ('E0031', '`import` is a reserved keyword')
-    reserved_keyword_while = ('E0032', '`while` is a reserved keyword')
-    reserved_keyword_throw = ('E0033', '`throw` is a reserved keyword')
-    future_reserved_keyword_async = (
-        'E0034',
-        '`async` is reserved for future use')
-    future_reserved_keyword_story = (
-        'E0035',
-        '`story` is reserved for future use')
-    future_reserved_keyword_assert = (
-        'E0036',
-        '`assert` is reserved for future use')
-    future_reserved_keyword_called = (
-        'E0037',
-        '`called` is reserved for future use')
-    future_reserved_keyword_mock = (
-        'E0038',
-        '`mock` is reserved for future use')
+    reserved_keyword = ('E0020', '`{keyword}` is a reserved keyword')
+    future_reserved_keyword = ('E0030',
+                               '`{keyword}` is reserved for future use')
     arguments_nomutation = (
         'E0039',
         'You have defined a chained mutation, but not a mutation')
-    compiler_error_no_operator = ('E0040', 'No operator provided')
-    invalid_character = ('E0041', '`{}` is not allowed here')
+    compiler_error_no_operator = (
+        'E0040', 'Invalid operator `{operator}` provided.')
+    invalid_character = ('E0041', '`{character}` is not allowed here')
     function_already_declared = (
         'E0042',
-        '`{}` has already been declared at line {}')
-    unexpected_token = ('E0043', '`{}` is not allowed here. Allowed: {}')
+        '`{function_name}` has already been declared at line {line}')
+    unexpected_token = ('E0043',
+                        '`{token}` is not allowed here. Allowed: {allowed}')
     break_outside = ('E0044', '`break` is allowed only inside loops')
     unnecessary_colon = (
         'E0045',
@@ -70,6 +46,8 @@ class ErrorCodes:
                             'An indented block is required to follow here')
     block_expected_before = ('E0046',
                              'An indented block is required to be before here')
+    file_not_found = ('E0047',
+                      'File `{path}` not found at `{abspath}`')
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/Story.py
+++ b/storyscript/Story.py
@@ -48,16 +48,17 @@ class Story:
         """
         Reads a story
         """
-        msg = None
+        has_error = False
         try:
             with io.open(path, 'r') as file:
                 return file.read()
         except FileNotFoundError:
-            abspath = os.path.abspath(path)
-            msg = 'File "{}" not found at {}'.format(path, abspath)
+            has_error = True
 
-        if msg is not None:
-            raise StoryError.unnamed_error(msg)
+        if has_error:
+            abspath = os.path.abspath(path)
+            raise StoryError.create_error('file_not_found', path=path,
+                                          abspath=abspath)
 
     @classmethod
     def from_file(cls, path):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -176,8 +176,7 @@ class Compiler:
         """
         Compiles a return_statement tree
         """
-        if parent is None:
-            raise CompilerError('return_outside', tree=tree)
+        tree.expect(parent is not None, 'return_outside')
         line = tree.line()
         args = None
         if tree.expression:
@@ -260,8 +259,10 @@ class Compiler:
         if function_name in self.lines.functions:
             raise CompilerError(
                 'function_already_declared', token=function.child(1),
-                function_name=function_name,
-                previous_line=self.lines.functions[function_name])
+                format={
+                    'function_name': function_name,
+                    'line': self.lines.functions[function_name],
+                })
         self.lines.append('function', line, function=function_name,
                           output=output, args=args, enter=nested_block.line(),
                           parent=parent)
@@ -368,8 +369,7 @@ class Compiler:
         self.lines.finish_scope(line)
 
     def break_statement(self, tree, parent):
-        if parent is None:
-            raise CompilerError('break_outside', tree=tree)
+        tree.expect(parent is not None, 'break_outside')
         self.lines.append('break', tree.line(), parent=parent)
 
     def subtrees(self, *trees, parent=None):

--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -225,7 +225,8 @@ class Objects:
                  'NOT_EQUAL': 'not_equal',
                  'GREATER_EQUAL': 'greater_equal',
                  'LESSER_EQUAL': 'less_equal'}
-        tree.expect(operator in types, 'compiler_error_no_operator')
+        tree.expect(operator in types, 'compiler_error_no_operator',
+                    operator=operator)
         return types[operator]
 
     @classmethod

--- a/storyscript/exceptions/CompilerError.py
+++ b/storyscript/exceptions/CompilerError.py
@@ -1,18 +1,5 @@
 # -*- coding: utf-8 -*-
 from .ProcessingError import ProcessingError
-from ..ErrorCodes import ErrorCodes
-
-
-class ConstDict:
-    """
-    Like a dict, but as constant attributes
-    """
-
-    def __init__(self, data):
-        self.data = data
-
-    def __getattr__(self, attr):
-        return self.data[attr]
 
 
 class CompilerError(ProcessingError):
@@ -20,18 +7,5 @@ class CompilerError(ProcessingError):
     A compiler error that occurs despite the syntax being correct, for example
     a return outside of a function.
     """
-    def __init__(self, error, token=None, tree=None, message='', **kwargs):
-        super().__init__(error, token=token, tree=tree)
-        self._message = message
-        self.extra = ConstDict(kwargs)
-
-    def __str__(self):
-        if len(self._message) > 0:
-            return self._message
-        elif hasattr(self, 'error') and ErrorCodes.is_error(self.error):
-            return ErrorCodes.get_error(self.error)[1]
-        else:
-            return 'Unknown compiler error'
-
-    def message(self):
-        return str(self)
+    def __init__(self, error, token=None, tree=None, format=None):
+        super().__init__(error, token=token, tree=tree, format=format)

--- a/storyscript/exceptions/ProcessingError.py
+++ b/storyscript/exceptions/ProcessingError.py
@@ -1,13 +1,39 @@
 # -*- coding: utf-8 -*-
+from ..ErrorCodes import ErrorCodes
+
+
+class ConstDict:
+    """
+    Like a dict, but with constant attributes
+    """
+
+    def __init__(self, data):
+        self._data = data
+
+    def __getattr__(self, attr):
+        return self._data[attr]
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+    def keys(self):
+        return self._data.keys()
+
+
 class ProcessingError(Exception):
     """
     A generic error that occurs while processing a story
     """
 
-    def __init__(self, error, token=None, tree=None):
+    def __init__(self, error, token=None, tree=None, format=None):
         self.error = error
         self.token_position(token)
         self.tree_position(tree)
+        if format is None:
+            self.format = {}
+        else:
+            self.format = format
+        self.format = ConstDict(self.format)
 
     def token_position(self, token):
         """
@@ -26,3 +52,13 @@ class ProcessingError(Exception):
             self.line = tree.line()
             self.column = tree.column()
             self.end_column = tree.end_column()
+
+    def message(self):
+        if ErrorCodes.is_error(self.error):
+            return ErrorCodes.get_error(self.error)[1].format(
+                **self.format)
+        else:
+            return 'Unknown compiler error'
+
+    def __str__(self):
+        return self.message()

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -21,11 +21,11 @@ class Transformer(LarkTransformer):
     def is_keyword(cls, token):
         keyword = token.value
         if keyword in cls.reserved_keywords:
-            error_name = 'reserved_keyword_{}'.format(keyword)
-            raise StorySyntaxError(error_name, token=token)
+            raise StorySyntaxError('reserved_keyword',
+                                   token=token, format={'keyword': keyword})
         if keyword in cls.future_reserved_keywords:
-            error_name = 'future_reserved_keyword_{}'.format(keyword)
-            raise StorySyntaxError(error_name, token=token)
+            raise StorySyntaxError('future_reserved_keyword',
+                                   token=token, format={'keyword': keyword})
 
     @staticmethod
     def implicit_output(tree):

--- a/storyscript/parser/Tree.py
+++ b/storyscript/parser/Tree.py
@@ -136,12 +136,12 @@ class Tree(LarkTree):
             e = e.child(0)
         return True
 
-    def expect(self, cond, error):
+    def expect(self, cond, error, **kwargs):
         """
         Throws a compiler error with message if the condition is falsy.
         """
         if not cond:
-            raise CompilerError(error, tree=self)
+            raise CompilerError(error, tree=self, format=kwargs)
 
     def follow_node_chain(self, expected_nodes):
         """

--- a/tests/integration/Cli.py
+++ b/tests/integration/Cli.py
@@ -38,7 +38,7 @@ def test_cli_exit_file_not_found():
 
     assert e.exit_code == 1
     # the error message contains the absolute path too
-    assert 'File "this-path-will-never-ever-exist-123456" not found' \
+    assert 'File `this-path-will-never-ever-exist-123456` not found' \
         in e.output
 
 
@@ -52,7 +52,7 @@ def test_cli_parse_exit_file_not_found():
 
     assert e.exit_code == 1
     # the error message contains the absolute path too
-    assert 'File "this-path-will-never-ever-exist-123456" not found' \
+    assert 'File `this-path-will-never-ever-exist-123456` not found' \
         in e.output
 
 
@@ -66,5 +66,5 @@ def test_cli_lex_exit_file_not_found():
 
     assert e.exit_code == 1
     # the error message contains the absolute path too
-    assert 'File "this-path-will-never-ever-exist-123456" not found' \
+    assert 'File `this-path-will-never-ever-exist-123456` not found' \
         in e.output

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -73,7 +73,7 @@ def test_exceptions_file_not_found(capsys):
     with raises(StoryError) as e:
         Story.from_file('this-file-does-not-exist')
     message = e.value.message()
-    assert 'File "this-file-does-not-exist" not found at' in message
+    assert 'File `this-file-does-not-exist` not found at' in message
 
 
 def test_exceptions_dollar(capsys):

--- a/tests/unittests/Cli.py
+++ b/tests/unittests/Cli.py
@@ -163,12 +163,12 @@ def test_cli_parse_debug(runner, echo, app):
     Ensures the parse command supports raises errors with debug=True
     """
     runner.invoke(Cli.parse, ['--debug'])
-    ce = CompilerError(None, message='unexpected error')
+    ce = CompilerError(None)
     app.parse.side_effect = StoryError(ce, None)
     e = runner.invoke(Cli.parse, ['--debug', '/a/non/existent/file'])
     assert e.exit_code == 1
     assert isinstance(e.exception, CompilerError)
-    assert e.exception.message() == 'unexpected error'
+    assert e.exception.message() == 'Unknown compiler error'
 
 
 def test_cli_parse_ice(runner, echo, app):
@@ -198,11 +198,11 @@ def test_cli_parse_not_found(runner, echo, app):
     """
     Ensures the parse command catches errors
     """
-    ce = CompilerError(None, message='error')
+    ce = CompilerError(None)
     app.parse.side_effect = StoryError(ce, None)
     e = runner.invoke(Cli.parse, ['/a/non/existent/file'])
     assert e.exit_code == 1
-    click.echo.assert_called_with('error')
+    click.echo.assert_called_with(StoryError._internal_error(ce))
 
 
 def test_cli_compile(patch, runner, echo, app):
@@ -294,27 +294,28 @@ def test_cli_compile_debug_ice(runner, echo, app):
     assert str(e.exception) == 'ICE'
 
 
-def test_cli_compile_not_found(runner, echo, app):
+def test_cli_compile_not_found(patch, runner, echo, app):
     """
     Ensures the compile command catches errors
     """
-    ce = CompilerError(None, message='error')
+    patch.object(StoryError, '_internal_error')
+    ce = CompilerError(None)
     app.compile.side_effect = StoryError(ce, None)
     e = runner.invoke(Cli.compile, ['/a/non/existent/file'])
     assert e.exit_code == 1
-    click.echo.assert_called_with('error')
+    click.echo.assert_called_with(StoryError._internal_error())
 
 
 def test_cli_compile_not_found_debug(runner, echo, app):
     """
     Ensures the compile command raises errors with debug=True
     """
-    ce = CompilerError(None, message='error')
+    ce = CompilerError(None)
     app.compile.side_effect = StoryError(ce, None)
     e = runner.invoke(Cli.compile, ['--debug', '/a/non/existent/file'])
     assert e.exit_code == 1
     assert isinstance(e.exception, CompilerError)
-    assert e.exception.message() == 'error'
+    assert e.exception.message() == 'Unknown compiler error'
 
 
 def test_cli_lex(patch, magic, runner, app, echo):
@@ -374,25 +375,26 @@ def test_cli_lex_not_found(patch, runner, echo, app):
     """
     Ensures the lex command catches errors
     """
-    ce = CompilerError(None, message='error')
+    patch.object(StoryError, '_internal_error')
+    ce = CompilerError(None)
     patch.object(App, 'lex')
     App.lex.side_effect = StoryError(ce, None)
     e = runner.invoke(Cli.lex, ['/a/non/existent/file'])
     assert e.exit_code == 1
-    click.echo.assert_called_with('error')
+    click.echo.assert_called_with(StoryError._internal_error())
 
 
 def test_cli_lex_not_found_debug(patch, runner, echo, app):
     """
     Ensures the lex command raises errors with debug=True
     """
-    ce = CompilerError(None, message='error')
+    ce = CompilerError(None)
     patch.object(App, 'lex')
     App.lex.side_effect = StoryError(ce, None)
     e = runner.invoke(Cli.lex, ['--debug', '/a/non/existent/file'])
     assert e.exit_code == 1
     assert isinstance(e.exception, CompilerError)
-    assert e.exception.message() == 'error'
+    assert e.exception.message() == 'Unknown compiler error'
 
 
 def test_cli_grammar(patch, runner, app, echo):

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -31,48 +31,9 @@ from storyscript.ErrorCodes import ErrorCodes
     ('object_closing_bracket', ('E0018',
                                 'Missing closing bracket for object')),
     ('service_argument_colon', ('E0019', 'Missing colon in service argument')),
-    ('reserved_keyword_function', ('E0020',
-                                   '`function` is a reserved keyword')),
-    ('reserved_keyword_if', ('E0021', '`if` is a reserved keyword')),
-    ('reserved_keyword_else', ('E0022', '`else` is a reserved keyword')),
-    ('reserved_keyword_foreach', ('E0023', '`foreach` is a reserved keyword')),
-    ('reserved_keyword_return', ('E0024', '`return` is a reserved keyword')),
-    ('reserved_keyword_returns', ('E0025', '`returns` is a reserved keyword')),
-    ('reserved_keyword_try', ('E0026', '`try` is a reserved keyword')),
-    ('reserved_keyword_catch', ('E0027', '`catch` is a reserved keyword')),
-    ('reserved_keyword_finally', ('E0028', '`finally` is a reserved keyword')),
-    ('reserved_keyword_when', ('E0029', '`when` is a reserved keyword')),
-    ('reserved_keyword_as', ('E0030', '`as` is a reserved keyword')),
-    ('reserved_keyword_import', ('E0031', '`import` is a reserved keyword')),
-    ('reserved_keyword_while', ('E0032', '`while` is a reserved keyword')),
-    ('reserved_keyword_throw', ('E0033', '`throw` is a reserved keyword')),
-    ('future_reserved_keyword_async', (
-        'E0034',
-        '`async` is reserved for future use')),
-    ('future_reserved_keyword_story', (
-        'E0035',
-        '`story` is reserved for future use')),
-    ('future_reserved_keyword_assert', (
-        'E0036',
-        '`assert` is reserved for future use')),
-    ('future_reserved_keyword_called', (
-        'E0037',
-        '`called` is reserved for future use')),
-    ('future_reserved_keyword_mock', (
-        'E0038',
-        '`mock` is reserved for future use')),
-    ('arguments_nomutation', (
-        'E0039',
-        'You have defined a chained mutation, but not a mutation')),
-    ('compiler_error_no_operator', ('E0040', 'No operator provided')),
-    ('invalid_character', (('E0041', '`{}` is not allowed here'))),
-    ('function_already_declared',
-        ('E0042', '`{}` has already been declared at line {}')),
-    ('unexpected_token', ('E0043', '`{}` is not allowed here. Allowed: {}')),
-    ('break_outside', ('E0044', '`break` is allowed only inside loops')),
-    ('unnecessary_colon', (
-        'E0045',
-        'There is an unnecessary colon at the end of the line'))
+    ('reserved_keyword', ('E0020', '`{keyword}` is a reserved keyword')),
+    ('future_reserved_keyword',
+        ('E0030', '`{keyword}` is reserved for future use')),
 ])
 def test_errorcodes_errors(name, definition):
     assert getattr(ErrorCodes, name) == definition

--- a/tests/unittests/Story.py
+++ b/tests/unittests/Story.py
@@ -102,7 +102,7 @@ def test_story_read_not_found(patch, capsys):
     patch.object(os, 'path')
     with raises(StoryError) as e:
         Story.read('whatever')
-    assert 'E0001: File "whatever" not found at ' in e.value.short_message()
+    assert 'E0047: File `whatever` not found at ' in e.value.short_message()
 
 
 def test_story_from_file(patch):

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -359,10 +359,9 @@ def test_compiler_return_statement_error(patch, compiler, tree):
     Ensures Compiler.return_statement raises CompilerError when the return
     is outside a function.
     """
-    patch.init(CompilerError)
-    with raises(CompilerError):
-        compiler.return_statement(tree, None)
-    CompilerError.__init__.assert_called_with('return_outside', tree=tree)
+    patch.object(Objects, 'expression')
+    compiler.return_statement(tree, None)
+    tree.expect.assert_called_with(False, 'return_outside')
 
 
 def test_compiler_if_block(patch, compiler, lines, tree):
@@ -481,9 +480,9 @@ def test_compiler_function_block_redeclared(patch, compiler, lines, tree):
     with raises(CompilerError) as e:
         compiler.function_block(tree, '1')
 
-    e.value.extra.function_name = '.function.'
-    e.value.extra.previous_line = '0'
-    e.value.extra.error = 'function_already_declared'
+    e.value.format.function_name = '.function.'
+    e.value.format.line = '0'
+    e.value.error = 'function_already_declared'
 
 
 def test_compiler_throw_statement(patch, compiler, lines, tree):
@@ -666,10 +665,8 @@ def test_compiler_break_statement(compiler, lines, tree):
 
 
 def test_compiler_break_statement_outside(patch, compiler, lines, tree):
-    patch.init(CompilerError)
-    with raises(CompilerError):
-        compiler.break_statement(tree, None)
-    CompilerError.__init__.assert_called_with('break_outside', tree=tree)
+    compiler.break_statement(tree, None)
+    tree.expect.assert_called_with(False, 'break_outside')
 
 
 @mark.parametrize('method_name', [

--- a/tests/unittests/exceptions/CompilerError.py
+++ b/tests/unittests/exceptions/CompilerError.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-from pytest import raises
-
 from storyscript.ErrorCodes import ErrorCodes
-from storyscript.exceptions import ProcessingError
-from storyscript.exceptions.CompilerError import CompilerError, ConstDict
+from storyscript.exceptions import CompilerError, ProcessingError
 
 
 def test_compilererror():
@@ -12,9 +9,6 @@ def test_compilererror():
 
 def test_error_message(patch):
     patch.many(ErrorCodes, ['is_error', 'get_error'])
-    e = CompilerError(None, message='test error')
-    assert str(e) == 'test error'
-
     ErrorCodes.is_error.return_value = True
     ErrorCodes.get_error.return_value = [None, 'foo']
     e2 = CompilerError('my_custom_error')
@@ -25,15 +19,6 @@ def test_error_message(patch):
     assert str(e3) == 'Unknown compiler error'
 
 
-def test_const_dict():
-    d = ConstDict({'foo': 'bar', 'f2': 'b2'})
-    assert d.foo == 'bar'
-    assert d.f2 == 'b2'
-    with raises(Exception):
-        d.bar
-
-
 def test_compiler_error_extra_parameters():
-    e2 = CompilerError('my_custom_error', my_param='p1', my_param2='p2')
-    assert e2.extra.my_param == 'p1'
-    assert e2.extra.my_param2 == 'p2'
+    e2 = CompilerError('my_custom_error', format={'a': 2})
+    assert e2.format.a == 2

--- a/tests/unittests/exceptions/ProcessingError.py
+++ b/tests/unittests/exceptions/ProcessingError.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from pytest import fixture
+from pytest import fixture, raises
 
-from storyscript.exceptions import ProcessingError
+from storyscript.exceptions.ProcessingError import ConstDict, ProcessingError
 
 
 @fixture
@@ -67,3 +67,14 @@ def test_processingerror_tree_position_none(error):
     Ensures tree_position can deal with null values
     """
     error.tree_position(None)
+
+
+def test_const_dict():
+    """
+    Ensures that the const dictionary provides access
+    """
+    d = ConstDict({'foo': 'bar', 'f2': 'b2'})
+    assert d.foo == 'bar'
+    assert d.f2 == 'b2'
+    with raises(Exception):
+        d.bar

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -32,8 +32,9 @@ def test_transformer_is_keyword(syntax_error, keyword):
     token = Token('any', keyword)
     with raises(StorySyntaxError):
         Transformer.is_keyword(token)
-    name = 'reserved_keyword_{}'.format(keyword)
-    syntax_error.assert_called_with(name, token=token)
+    name = 'reserved_keyword'
+    format = {'keyword': keyword}
+    syntax_error.assert_called_with(name, token=token, format=format)
 
 
 @mark.parametrize('keyword', [
@@ -43,8 +44,9 @@ def test_transformer_is_keyword_future(syntax_error, keyword):
     token = Token('any', keyword)
     with raises(StorySyntaxError):
         Transformer.is_keyword(token)
-    name = 'future_reserved_keyword_{}'.format(keyword)
-    syntax_error.assert_called_with(name, token=token)
+    name = 'future_reserved_keyword'
+    format = {'keyword': keyword}
+    syntax_error.assert_called_with(name, token=token, format=format)
 
 
 def test_transformer_implicit_output(tree):

--- a/tests/unittests/parser/Tree.py
+++ b/tests/unittests/parser/Tree.py
@@ -202,6 +202,18 @@ def test_tree_expect(tree):
     assert e.value.message() == 'Unknown compiler error'
 
 
+def test_tree_expect_kwargs(tree):
+    """
+    Ensures expect throws an error and forwards arguments
+    """
+    with raises(CompilerError) as e:
+        tree.expect(0, 'error', a=0, b=1, c=2)
+
+    assert e.value.format.a == 0
+    assert e.value.format.b == 1
+    assert e.value.format.c == 2
+
+
 def test_follow_node_chain_no_children(tree):
     """
     Ensures we don't follow a node chain if there are no children


### PR DESCRIPTION
Required for e.g. https://github.com/storyscript/storyscript/pull/643

**- What I did**

- ProcessingErrors now contain a `format` object (for parameters in their format string)
- Replaced the duplication in ` reserved_keyword_*` with a generic error (as format parameters are now supported)