### PR TITLE
 fix(FakeTree): don't swallow real_line on three or more assignments

### DIFF
--- a/storyscript/compiler/Faketree.py
+++ b/storyscript/compiler/Faketree.py
@@ -65,13 +65,9 @@ class FakeTree:
         Returns a fake path reference to this assignment
         """
         assignment = self.assignment(value)
-        if self.block.child(1):
-            children = [self.block.child(0), assignment, self.block.child(1)]
-            self.block.children = children
-        else:
-            self.block.children = [assignment, self.block.child(0)]
-        # we need a new node, s.t. already inserted fake node doesn't get
-        # changed
+        self.block.children = [*self.block.children[:-1], assignment,
+                               self.block.last_child()]
+        # we need a new node, s.t. already inserted fake node don't get changed
         name = Token('NAME', assignment.path.child(0), line=original_line)
         fake_path = Tree('path', [name])
         return fake_path

--- a/storyscript/parser/Tree.py
+++ b/storyscript/parser/Tree.py
@@ -31,7 +31,24 @@ class Tree(LarkTree):
                 current = self.walk(current, shard)
         return current
 
+    def first_child(self):
+        """
+        Return the first child
+        """
+        if len(self.children) > 0:
+            return self.children[0]
+
+    def last_child(self):
+        """
+        Return the first child
+        """
+        if len(self.children) > 0:
+            return self.children[-1]
+
     def child(self, index):
+        """
+        Returns the child at the position of `index`.
+        """
         if len(self.children) > index:
             return self.children[index]
 

--- a/tests/e2e/function_call_three_inline_exprs.json
+++ b/tests/e2e/function_call_three_inline_exprs.json
@@ -1,0 +1,108 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "execute",
+      "ln": "1.1",
+      "output": [],
+      "name": [
+        "p-1.1"
+      ],
+      "service": "serv1",
+      "command": "f1",
+      "function": null,
+      "args": [],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1.2"
+    },
+    "1.2": {
+      "method": "execute",
+      "ln": "1.2",
+      "output": [],
+      "name": [
+        "p-1.2"
+      ],
+      "service": "serv2",
+      "command": "f2",
+      "function": null,
+      "args": [],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1.3"
+    },
+    "1.3": {
+      "method": "execute",
+      "ln": "1.3",
+      "output": [],
+      "name": [
+        "p-1.3"
+      ],
+      "service": "serv3",
+      "command": "f3",
+      "function": null,
+      "args": [],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "execute",
+      "ln": "1",
+      "output": [],
+      "name": [
+        "b"
+      ],
+      "service": "my_service",
+      "command": "command",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "p1",
+          "argument": {
+            "$OBJECT": "path",
+            "paths": [
+              "p-1.1"
+            ]
+          }
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "p2",
+          "argument": {
+            "$OBJECT": "path",
+            "paths": [
+              "p-1.2"
+            ]
+          }
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "p3",
+          "argument": {
+            "$OBJECT": "path",
+            "paths": [
+              "p-1.3"
+            ]
+          }
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [
+    "my_service",
+    "serv1",
+    "serv2",
+    "serv3"
+  ],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/function_call_three_inline_exprs.story
+++ b/tests/e2e/function_call_three_inline_exprs.story
@@ -1,0 +1,1 @@
+b = my_service command p1: (serv1 f1) p2: (serv2 f2) p3: (serv3 f3)

--- a/tests/unittests/compiler/Faketree.py
+++ b/tests/unittests/compiler/Faketree.py
@@ -93,7 +93,7 @@ def test_faketree_add_assignment(patch, fake_tree, block):
     block.child.return_value = None
     result = fake_tree.add_assignment('value', original_line=10)
     FakeTree.assignment.assert_called_with('value')
-    assert block.children == [FakeTree.assignment(), block.child()]
+    assert block.children == [FakeTree.assignment(), block.last_child()]
     name = Token('NAME', FakeTree.assignment().path.child(0), line=10)
     assert result.data == 'path'
     assert result.children == [name]
@@ -101,6 +101,15 @@ def test_faketree_add_assignment(patch, fake_tree, block):
 
 def test_faketree_add_assignment_more_children(patch, fake_tree, block):
     patch.object(FakeTree, 'assignment')
+    block.children = ['c1', fake_tree.block.last_child()]
     fake_tree.add_assignment('value', original_line=42)
-    expected = [block.child(), FakeTree.assignment(), block.child()]
+    expected = ['c1', FakeTree.assignment(), block.last_child()]
+    assert block.children == expected
+
+
+def test_faketree_add_assignment_four_children(patch, fake_tree, block):
+    patch.object(FakeTree, 'assignment')
+    block.children = ['c1', 'c2', 'c3', fake_tree.block.last_child()]
+    fake_tree.add_assignment('value', original_line=42)
+    expected = ['c1', 'c2', 'c3', FakeTree.assignment(), block.last_child()]
     assert block.children == expected

--- a/tests/unittests/parser/Tree.py
+++ b/tests/unittests/parser/Tree.py
@@ -47,6 +47,36 @@ def test_tree_node(patch):
     assert result == Tree.walk()
 
 
+def test_tree_first_child():
+    tree = Tree('rule', ['child'])
+    assert tree.first_child() == 'child'
+
+
+def test_tree_first_child_multiple():
+    tree = Tree('rule', ['child', 'child2'])
+    assert tree.first_child() == 'child'
+
+
+def test_tree_first_child_empty():
+    tree = Tree('rule', [])
+    assert tree.first_child() is None
+
+
+def test_tree_last_child():
+    tree = Tree('rule', ['child'])
+    assert tree.last_child() == 'child'
+
+
+def test_tree_last_child_multiple():
+    tree = Tree('rule', ['child', 'child2'])
+    assert tree.last_child() == 'child2'
+
+
+def test_tree_last_child_empty():
+    tree = Tree('rule', [])
+    assert tree.last_child() is None
+
+
 def test_tree_child():
     tree = Tree('rule', ['child'])
     assert tree.child(0) == 'child'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/648

**- What I did**

- added `first_child` and `last_child` for better access safety
- fixed the FakeTree insertion for three or more fake insertions
