### PR TITLE
feat(Compiler): introduce base_expression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ jobs:
                   # Workaround for https://github.com/codecov/codecov-python/issues/107
                   sed 's/internal_assert(0)/# ignored for CodeCov/' \
                   -i $(find storyscript -type f -name '*.py')
-                  sed 's/from.*internal_assert/# ignored for CodeCov/' \
-                  -i $(find storyscript -type f -name '*.py' \
-                    -not -name '*__init__.py')
+                  #sed 's/from.*internal_assert/# ignored for CodeCov/' \
+                  #-i $(find storyscript -type f -name '*.py' \
+                  #  -not -name '*__init__.py')
 
             - run:
                 name: run unit tests

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -73,9 +73,8 @@ class Compiler:
         service = tree.service
         if service:
             path = Objects.names(service.path)
-            if not self.lines.is_variable_defined(path):
-                self.service(service, None, parent)
-                return
+            internal_assert(not self.lines.is_variable_defined(path))
+            self.service(service, None, parent)
         elif tree.mutation:
             self.mutation_block(tree, parent)
             return
@@ -84,7 +83,7 @@ class Compiler:
             self.lines.append('expression', line, args=args, parent=parent)
             return
         else:
-            internal_assert(tree.child(0).data == 'call_expression')
+            internal_assert(tree.call_expression)
             exp = tree.call_expression
             self.call_expression(exp, parent)
             return

--- a/storyscript/compiler/Faketree.py
+++ b/storyscript/compiler/Faketree.py
@@ -56,7 +56,8 @@ class FakeTree:
         first_token.line = line
         path = self.path(line=line)
         equals = Token('EQUALS', '=', line=line)
-        fragment = Tree('assignment_fragment', [equals, value])
+        expr = Tree('base_expression', [value])
+        fragment = Tree('assignment_fragment', [equals, expr])
         return Tree('assignment', [path, fragment])
 
     def add_assignment(self, value, original_line):

--- a/storyscript/compiler/Lines.py
+++ b/storyscript/compiler/Lines.py
@@ -79,7 +79,7 @@ class Lines:
 
     def finish_scope(self, line):
         """
-        Finshes an output scope and prepares 'exit' adjustment for the scope
+        Finishes an output scope and prepares 'exit' adjustment for the scope
         when the next line gets added.
         """
         self.finished_scopes.append(line)

--- a/storyscript/compiler/Objects.py
+++ b/storyscript/compiler/Objects.py
@@ -137,7 +137,8 @@ class Objects:
             child = item.child(0)
             if child.data == 'string':
                 key = cls.string(child)
-            elif child.data == 'path':
+            else:
+                internal_assert(child.data == 'path')
                 key = cls.path(child)
             value = cls.base_expression(item.child(1))
             items.append([key, value])
@@ -185,9 +186,9 @@ class Objects:
                 return cls.types(subtree)
             elif subtree.data == 'void':
                 return None
-        else:
-            internal_assert(subtree.type == 'NAME')
-            return cls.path(tree)
+
+        internal_assert(subtree.type == 'NAME')
+        return cls.path(tree)
 
     @classmethod
     def argument(cls, tree):

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -64,14 +64,16 @@ class Grammar:
         self.ebnf.void = 'null'
         self.ebnf.number = 'int, float'
         self.ebnf.string = 'single_quoted, double_quoted'
-        list = self.ebnf.collection('osb', 'expression', 'expression', 'csb')
+        list = self.ebnf.collection('osb', 'base_expression',
+                                    'base_expression', 'csb')
         self.ebnf.set_rule('!list', list)
-        self.ebnf.key_value = '(string, path) colon expression'
+        self.ebnf.key_value = '(string, path) colon base_expression'
         objects = ('ocb', 'key_value', 'key_value', 'ccb')
         self.ebnf.objects = self.ebnf.collection(*objects)
         self.ebnf.regular_expression = 'regexp name?'
         self.ebnf.inline_expression = ('op service cp, '
-                                       'call_expression')
+                                       'call_expression, '
+                                       'op mutation cp')
         values = ('number, string, boolean, void, list, objects, '
                   'regular_expression')
         self.ebnf.values = values
@@ -83,7 +85,7 @@ class Grammar:
         self.ebnf.path_fragment = path_fragment
         self.ebnf.path = ('name (path_fragment)* | '
                           'inline_expression (path_fragment)*')
-        assignment_fragment = 'equals (expression, service, mutation)'
+        assignment_fragment = 'equals base_expression'
         self.ebnf.assignment_fragment = assignment_fragment
         self.ebnf.assignment = 'path assignment_fragment'
 
@@ -136,6 +138,9 @@ class Grammar:
 
         self.ebnf.expression = 'or_expression'
         self.ebnf.absolute_expression = 'expression'
+        # service and mutation calls don't need parentheses when they are at
+        # the base,e.g. `if my_service commmand`
+        self.ebnf.base_expression = '(expression, service, mutation)'
 
     def throw_statement(self):
         self.ebnf.THROW = 'throw'
@@ -144,7 +149,7 @@ class Grammar:
     def rules(self):
         self.ebnf.RETURN = 'return'
         self.ebnf.BREAK = 'break'
-        self.ebnf.return_statement = 'return expression?'
+        self.ebnf.return_statement = 'return base_expression?'
         self.ebnf.break_statement = 'break'
         self.ebnf.entity = 'values, path'
         rules = ('absolute_expression, assignment, imports, return_statement, '
@@ -173,8 +178,8 @@ class Grammar:
     def if_block(self):
         self.ebnf._IF = 'if'
         self.ebnf._ELSE = 'else'
-        self.ebnf.if_statement = 'if expression'
-        elseif_statement = 'else if expression'
+        self.ebnf.if_statement = 'if base_expression'
+        elseif_statement = 'else if base_expression'
         self.ebnf.elseif_statement = elseif_statement
         self.ebnf.elseif_block = self.ebnf.simple_block('elseif_statement')
         self.ebnf.set_rule('!else_statement', 'else')
@@ -184,7 +189,7 @@ class Grammar:
 
     def while_block(self):
         self.ebnf._WHILE = 'while'
-        self.ebnf.while_statement = 'while expression'
+        self.ebnf.while_statement = 'while base_expression'
         self.ebnf.while_block = self.ebnf.simple_block('while_statement')
 
     def foreach_block(self):

--- a/tests/e2e/collection_with_mutation.json
+++ b/tests/e2e/collection_with_mutation.json
@@ -1,0 +1,61 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "mutation",
+      "ln": "1.1",
+      "output": null,
+      "name": [
+        "p-1.1"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        2,
+        {
+          "$OBJECT": "mutation",
+          "mutation": "increment",
+          "arguments": []
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "set",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "a"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            1,
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "p-1.1"
+              ]
+            },
+            3
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/collection_with_mutation.story
+++ b/tests/e2e/collection_with_mutation.story
@@ -1,0 +1,1 @@
+a = [1, 2 increment, 3]

--- a/tests/e2e/collection_with_service.json
+++ b/tests/e2e/collection_with_service.json
@@ -1,0 +1,62 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "execute",
+      "ln": "1.1",
+      "output": [],
+      "name": [
+        "p-1.1"
+      ],
+      "service": "my_service",
+      "command": "command",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "p1",
+          "argument": 2
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "set",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "a"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            1,
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "p-1.1"
+              ]
+            },
+            3
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [
+    "my_service"
+  ],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/collection_with_service.story
+++ b/tests/e2e/collection_with_service.story
@@ -1,0 +1,1 @@
+a = [1, my_service command p1:2, 3]

--- a/tests/e2e/expression_mutation_nested.json
+++ b/tests/e2e/expression_mutation_nested.json
@@ -1,0 +1,82 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "mutation",
+      "ln": "1.1",
+      "output": null,
+      "name": [
+        "p-1.1"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "string",
+              "string": "opened"
+            },
+            {
+              "$OBJECT": "string",
+              "string": "labeled"
+            }
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "contains",
+          "arguments": [
+            {
+              "$OBJECT": "argument",
+              "name": "item",
+              "argument": {
+                "$OBJECT": "string",
+                "string": "a"
+              }
+            }
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "b"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "and",
+          "values": [
+            1,
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "p-1.1"
+              ]
+            }
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/expression_mutation_nested.story
+++ b/tests/e2e/expression_mutation_nested.story
@@ -1,0 +1,1 @@
+b = 1 and (["opened", "labeled"] contains item: "a")

--- a/tests/e2e/expression_mutation_while.json
+++ b/tests/e2e/expression_mutation_while.json
@@ -1,0 +1,79 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "mutation",
+      "ln": "1.1",
+      "output": null,
+      "name": [
+        "p-1.1"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "contains",
+          "arguments": [
+            {
+              "$OBJECT": "argument",
+              "name": "item",
+              "argument": 1
+            }
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "while",
+      "ln": "1",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-1.1"
+          ]
+        }
+      ],
+      "enter": "2",
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": null,
+      "enter": null,
+      "exit": null,
+      "parent": "1"
+    }
+  },
+  "services": [],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/expression_mutation_while.story
+++ b/tests/e2e/expression_mutation_while.story
@@ -1,0 +1,2 @@
+while [1, 2, 3] contains item:1
+	return

--- a/tests/e2e/if_with_mutation.json
+++ b/tests/e2e/if_with_mutation.json
@@ -1,0 +1,210 @@
+{
+  "tree": {
+    "1": {
+      "method": "set",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "var"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "mutation",
+      "ln": "2.1",
+      "output": null,
+      "name": [
+        "p-2.1"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "var"
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "increment",
+          "arguments": []
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "2.2"
+    },
+    "2.2": {
+      "method": "mutation",
+      "ln": "2.2",
+      "output": null,
+      "name": [
+        "p-2.2"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "var"
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "decrement",
+          "arguments": []
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "if",
+      "ln": "2",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-2.1"
+          ]
+        }
+      ],
+      "enter": "3",
+      "exit": "4",
+      "parent": null,
+      "next": "3"
+    },
+    "3": {
+      "method": "set",
+      "ln": "3",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "2",
+      "next": "4"
+    },
+    "4": {
+      "method": "elif",
+      "ln": "4",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-2.2"
+          ]
+        }
+      ],
+      "enter": "5",
+      "exit": "6",
+      "parent": null,
+      "next": "5"
+    },
+    "5": {
+      "method": "set",
+      "ln": "5",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        1
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "4",
+      "next": "6"
+    },
+    "6": {
+      "method": "else",
+      "ln": "6",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": null,
+      "enter": "7",
+      "exit": "9",
+      "parent": null,
+      "next": "7"
+    },
+    "7": {
+      "method": "set",
+      "ln": "7",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        2
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "6",
+      "next": "9"
+    },
+    "9": {
+      "method": "set",
+      "ln": "9",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        3
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/if_with_mutation.story
+++ b/tests/e2e/if_with_mutation.story
@@ -1,0 +1,9 @@
+var = 0
+if var increment
+	x = 0
+else if var decrement
+	x = 1
+else
+	x = 2
+
+x = 3

--- a/tests/e2e/if_with_service.json
+++ b/tests/e2e/if_with_service.json
@@ -1,0 +1,193 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "execute",
+      "ln": "1.1",
+      "output": [],
+      "name": [
+        "p-1.1"
+      ],
+      "service": "my_service",
+      "command": "command",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "p1",
+          "argument": 1
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "p2",
+          "argument": 2
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1.2"
+    },
+    "1.2": {
+      "method": "execute",
+      "ln": "1.2",
+      "output": [],
+      "name": [
+        "p-1.2"
+      ],
+      "service": "my_service2",
+      "command": "command",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "p3",
+          "argument": 3
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "p4",
+          "argument": 4
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "if",
+      "ln": "1",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-1.1"
+          ]
+        }
+      ],
+      "enter": "2",
+      "exit": "3",
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "set",
+      "ln": "2",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1",
+      "next": "3"
+    },
+    "3": {
+      "method": "elif",
+      "ln": "3",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-1.2"
+          ]
+        }
+      ],
+      "enter": "4",
+      "exit": "5",
+      "parent": null,
+      "next": "4"
+    },
+    "4": {
+      "method": "set",
+      "ln": "4",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        1
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "3",
+      "next": "5"
+    },
+    "5": {
+      "method": "else",
+      "ln": "5",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": null,
+      "enter": "6",
+      "exit": "8",
+      "parent": null,
+      "next": "6"
+    },
+    "6": {
+      "method": "set",
+      "ln": "6",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        2
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "5",
+      "next": "8"
+    },
+    "8": {
+      "method": "set",
+      "ln": "8",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        3
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [
+    "my_service",
+    "my_service2"
+  ],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/if_with_service.story
+++ b/tests/e2e/if_with_service.story
@@ -1,0 +1,8 @@
+if my_service command p1:1 p2: 2
+	x = 0
+else if my_service2 command p3:3 p4:4
+	x = 1
+else
+	x = 2
+
+x = 3

--- a/tests/e2e/obj_with_mutation.json
+++ b/tests/e2e/obj_with_mutation.json
@@ -1,0 +1,65 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "mutation",
+      "ln": "1.1",
+      "output": null,
+      "name": [
+        "p-1.1"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        1,
+        {
+          "$OBJECT": "mutation",
+          "mutation": "increment",
+          "arguments": []
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "set",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "a"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": [
+            [
+              {
+                "$OBJECT": "string",
+                "string": "my_key"
+              },
+              {
+                "$OBJECT": "path",
+                "paths": [
+                  "p-1.1"
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/obj_with_mutation.story
+++ b/tests/e2e/obj_with_mutation.story
@@ -1,0 +1,1 @@
+a = {'my_key': 1 increment}

--- a/tests/e2e/obj_with_service.json
+++ b/tests/e2e/obj_with_service.json
@@ -1,0 +1,73 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "execute",
+      "ln": "1.1",
+      "output": [],
+      "name": [
+        "p-1.1"
+      ],
+      "service": "my_service",
+      "command": "command",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "p1",
+          "argument": 1
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "set",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "a"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": [
+            [
+              {
+                "$OBJECT": "string",
+                "string": "my_key"
+              },
+              {
+                "$OBJECT": "path",
+                "paths": [
+                  "p-1.1"
+                ]
+              }
+            ],
+            [
+              {
+                "$OBJECT": "string",
+                "string": "k2"
+              },
+              2
+            ]
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [
+    "my_service"
+  ],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/obj_with_service.story
+++ b/tests/e2e/obj_with_service.story
@@ -1,0 +1,1 @@
+a = {'my_key': my_service command p1: 1, 'k2': 2}

--- a/tests/e2e/return_with_mutation.json
+++ b/tests/e2e/return_with_mutation.json
@@ -1,0 +1,91 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [],
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": "random",
+      "args": [],
+      "enter": "2",
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "set",
+      "ln": "2",
+      "output": null,
+      "name": [
+        "my_int"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        5
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1",
+      "next": "3.1"
+    },
+    "3.1": {
+      "method": "mutation",
+      "ln": "3.1",
+      "output": null,
+      "name": [
+        "p-3.1"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "my_int"
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "decrement",
+          "arguments": []
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1",
+      "next": "3"
+    },
+    "3": {
+      "method": "return",
+      "ln": "3",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-3.1"
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1"
+    }
+  },
+  "services": [],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {
+    "random": "1"
+  },
+  "version": null
+}

--- a/tests/e2e/return_with_mutation.story
+++ b/tests/e2e/return_with_mutation.story
@@ -1,0 +1,3 @@
+function random
+	my_int = 5
+	return my_int decrement

--- a/tests/e2e/return_with_service.json
+++ b/tests/e2e/return_with_service.json
@@ -1,0 +1,63 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [],
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": "random",
+      "args": [],
+      "enter": "2.1",
+      "exit": null,
+      "parent": null,
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "execute",
+      "ln": "2.1",
+      "output": [],
+      "name": [
+        "p-2.1"
+      ],
+      "service": "my_random_service",
+      "command": "get_integer",
+      "function": null,
+      "args": [],
+      "enter": null,
+      "exit": null,
+      "parent": "1",
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-2.1"
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1"
+    }
+  },
+  "services": [
+    "my_random_service"
+  ],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {
+    "random": "1"
+  },
+  "version": null
+}

--- a/tests/e2e/return_with_service.story
+++ b/tests/e2e/return_with_service.story
@@ -1,0 +1,2 @@
+function random
+	return my_random_service get_integer

--- a/tests/e2e/while_with_mutation.json
+++ b/tests/e2e/while_with_mutation.json
@@ -1,0 +1,91 @@
+{
+  "tree": {
+    "1": {
+      "method": "set",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        5
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "mutation",
+      "ln": "2.1",
+      "output": null,
+      "name": [
+        "p-2.1"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "x"
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "is_odd",
+          "arguments": []
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "while",
+      "ln": "2",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-2.1"
+          ]
+        }
+      ],
+      "enter": "3",
+      "exit": null,
+      "parent": null,
+      "next": "3"
+    },
+    "3": {
+      "method": "execute",
+      "ln": "3",
+      "output": [],
+      "name": null,
+      "service": "continue",
+      "command": null,
+      "function": null,
+      "args": [],
+      "enter": null,
+      "exit": null,
+      "parent": "2"
+    }
+  },
+  "services": [
+    "continue"
+  ],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/while_with_mutation.story
+++ b/tests/e2e/while_with_mutation.story
@@ -1,0 +1,3 @@
+x = 5
+while x is_odd
+	continue

--- a/tests/e2e/while_with_service.json
+++ b/tests/e2e/while_with_service.json
@@ -1,0 +1,71 @@
+{
+  "tree": {
+    "1.1": {
+      "method": "execute",
+      "ln": "1.1",
+      "output": [],
+      "name": [
+        "p-1.1"
+      ],
+      "service": "my_service",
+      "command": "my_command",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "p1",
+          "argument": 42
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "1"
+    },
+    "1": {
+      "method": "while",
+      "ln": "1",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-1.1"
+          ]
+        }
+      ],
+      "enter": "2",
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "set",
+      "ln": "2",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1"
+    }
+  },
+  "services": [
+    "my_service"
+  ],
+  "entrypoint": "1.1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/while_with_service.story
+++ b/tests/e2e/while_with_service.story
@@ -1,0 +1,2 @@
+while my_service my_command p1: 42
+	x = 0

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -43,7 +43,7 @@ def test_parser_list_path(parser):
     expression = result.child(1).rules.absolute_expression
     entity = get_entity(arith_exp(expression))
     list = arith_exp(Tree('absolute_expression',
-                          [entity.values.list.child(3)]))
+                          [entity.values.list.child(3).expression]))
     x = get_entity(list)
     assert x.path.child(0) == Token('NAME', 'x')
 
@@ -59,7 +59,7 @@ def test_parser_assignment(parser, code, token):
     assignment = result.block.rules.assignment
     assert assignment.path.child(0) == Token('NAME', 'var')
     assert assignment.assignment_fragment.child(0) == Token('EQUALS', '=')
-    expression = assignment.assignment_fragment
+    expression = assignment.assignment_fragment.base_expression
     entity = get_entity(arith_exp(expression))
     assert entity.values.child(0).child(0) == token
 
@@ -96,7 +96,7 @@ def test_parser_foreach_block(parser):
 def test_parser_while_block(parser):
     result = parser.parse('while cond\n\tvar=3\n')
     block = result.block.while_block
-    exp = arith_exp(block.while_statement)
+    exp = arith_exp(block.while_statement.base_expression)
     entity = get_entity(exp)
     assert entity.path.child(0) == Token('NAME', 'cond')
     assert block.nested_block.data == 'nested_block'
@@ -127,7 +127,7 @@ def test_parser_service_output(parser):
 def test_parser_if_block(parser):
     result = parser.parse('if expr\n\tvar=3\n')
     if_block = result.block.if_block
-    ar_exp = arith_exp(if_block.if_statement)
+    ar_exp = arith_exp(if_block.if_statement.base_expression)
     entity = get_entity(ar_exp)
     path = entity.path
     assignment = if_block.nested_block.block.rules.assignment
@@ -138,7 +138,7 @@ def test_parser_if_block(parser):
 def test_parser_if_block_nested(parser):
     result = parser.parse('if expr\n\tif things\n\t\tvar=3\n')
     if_block = result.block.if_block.nested_block.block.if_block
-    ar_exp = arith_exp(if_block.if_statement)
+    ar_exp = arith_exp(if_block.if_statement.base_expression)
     entity = get_entity(ar_exp)
     path = entity.path
     assignment = if_block.nested_block.block.rules.assignment
@@ -249,6 +249,7 @@ def test_parser_number_float(parser, number):
 def test_parser_string_double_quoted(parser):
     result = parser.parse(r'a = "b\n.\\.\".c"')
     result = result.block.rules.assignment.assignment_fragment
+    result = result.base_expression
     ar_exp = arith_exp(result)
     lhs = get_entity(ar_exp.child(0)).values.string.child(0)
     assert lhs == r'"b\n.\\.\".c"'
@@ -257,6 +258,7 @@ def test_parser_string_double_quoted(parser):
 def test_parser_string_single_quoted(parser):
     result = parser.parse(r"""a = 'b.\n.\\.\'.c'""")
     result = result.block.rules.assignment.assignment_fragment
+    result = result.base_expression
     ar_exp = arith_exp(result)
     lhs = get_entity(ar_exp.child(0)).values.string.child(0)
     assert lhs == r"""'b.\n.\\.\'.c'"""

--- a/tests/integration/parser/Values.py
+++ b/tests/integration/parser/Values.py
@@ -95,8 +95,8 @@ def test_values_list(parser):
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     list = entity.values.list
-    c1 = get_entity(list.child(1))
-    c2 = get_entity(list.child(3))
+    c1 = get_entity(list.child(1).expression)
+    c2 = get_entity(list.child(3).expression)
     assert c1.values.number.child(0) == Token('INT', 3)
     assert c2.values.number.child(0) == Token('INT', 4)
 
@@ -116,7 +116,7 @@ def test_values_object(parser):
     values = entity.values
     key_value = values.objects.key_value
     assert key_value.string.child(0) == Token('SINGLE_QUOTED', "'color'")
-    entity = get_entity(key_value.child(1))
+    entity = get_entity(key_value.child(1).expression)
     assert entity.values.string.child(0) == Token('SINGLE_QUOTED', "'red'")
 
 

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -3,15 +3,15 @@ boolean: TRUE| FALSE
 void: NULL
 number: INT| FLOAT
 string: SINGLE_QUOTED| DOUBLE_QUOTED
-!list: _OSB (_NL _INDENT)? (expression (_COMMA _NL? expression)*)? (_NL _DEDENT)? _CSB
-key_value: (string| path) _COLON expression
+!list: _OSB (_NL _INDENT)? (base_expression (_COMMA _NL? base_expression)*)? (_NL _DEDENT)? _CSB
+key_value: (string| path) _COLON base_expression
 objects: _OCB (_NL _INDENT)? (key_value (_COMMA _NL? key_value)*)? (_NL _DEDENT)? _CCB
 regular_expression: REGEXP NAME?
-inline_expression: _OP service _CP| call_expression
+inline_expression: _OP service _CP| call_expression| _OP mutation _CP
 values: number| string| boolean| void| list| objects| regular_expression
 path_fragment: _DOT NAME| _OSB INT _CSB| _OSB string _CSB| _OSB path _CSB
 path: NAME (path_fragment)* | inline_expression (path_fragment)*
-assignment_fragment: EQUALS (expression| service| mutation)
+assignment_fragment: EQUALS base_expression
 assignment: path assignment_fragment
 imports: _IMPORT string _AS NAME
 cmp_operator: GREATER| GREATER_EQUAL| LESSER| LESSER_EQUAL| NOT_EQUAL| EQUAL
@@ -28,7 +28,8 @@ and_expression: (and_expression AND)? cmp_expression
 or_expression: (or_expression OR)? and_expression
 expression: or_expression
 absolute_expression: expression
-return_statement: RETURN expression?
+base_expression: (expression| service| mutation)
+return_statement: RETURN base_expression?
 break_statement: BREAK
 entity: values| path
 rules: absolute_expression| assignment| imports| return_statement| throw_statement| break_statement| block
@@ -44,15 +45,15 @@ service_fragment: (command arguments*|arguments+) output?
 service: path service_fragment chained_mutation*
 service_block: service _NL (nested_block)?
 call_expression: path _OP arguments* _CP
-if_statement: _IF expression
-elseif_statement: _ELSE _IF expression
+if_statement: _IF base_expression
+elseif_statement: _ELSE _IF base_expression
 elseif_block: elseif_statement _NL nested_block
 !else_statement: _ELSE
 else_block: else_statement _NL nested_block
 if_block: if_statement _NL nested_block elseif_block* else_block?
 foreach_statement: _FOREACH entity output
 foreach_block: foreach_statement _NL nested_block
-while_statement: _WHILE expression
+while_statement: _WHILE base_expression
 while_block: while_statement _NL nested_block
 typed_argument: NAME _COLON types
 function_output: _RETURNS types

--- a/tests/unittests/compiler/Faketree.py
+++ b/tests/unittests/compiler/Faketree.py
@@ -83,6 +83,7 @@ def test_faketree_assignment(patch, tree, fake_tree):
     tree.find_first_token.assert_called()
     assert tree.find_first_token().line == line
     assert result.children[0] == FakeTree.path()
+    tree = Tree('base_expression', [tree])
     subtree = [Token('EQUALS', '=', line=line), tree]
     expected = Tree('assignment_fragment', subtree)
     assert result.children[1] == expected


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/578

**- What I did**

This introduces a new AST node: `base_expression` which assignments, while, if (else if) etc. can use. The general idea is to fill a few of the holes where services and mutations haven't been allowed so far with `base_expression` as at the beginning of a statement we still can identify whether it's a service, mutation or expression without the need for parenthesis.

Example:

```coffee
if my_service command
  x = 0
```

Note: that previously this required parenthesis with `inline_expressions` (`if (my_service command)`).

The biggest problem here is that due to Storyscript's format we have to emit fake lines for nested service and mutation invocations. However, this leads to this problem:

```coffee
while my_service command
   x = 0
```

As here the `my_service` invocation only happens once at the beginning, because the AST looks like:

```json
{
  "1.1": {
    "method": "execute",
    "ln": "1.1",
    "output": [],
    "name": [
      "p-1.1"
    ],
    "service": "my_service",
    "command": "command",
    "function": null,
    "args": [],
    "enter": null,
    "exit": null,
    "parent": null,
    "next": "1"
  },
  "1": {
    "method": "while",
    "ln": "1",
    "output": null,
    "name": null,
    "service": null,
    "command": null,
    "function": null,
    "args": [
      {
        "$OBJECT": "path",
        "paths": [
          "p-1.1"
        ]
      }
    ],
    "enter": "2",
    "exit": null,
    "parent": null,
    "next": "2"
  },
  "2": {
    "method": "set",
    "ln": "2",
    "output": null,
    "name": [
      "x"
    ],
    "service": null,
    "command": null,
    "function": null,
    "args": [
      0
    ],
    "enter": null,
    "exit": null,
    "parent": "1"
  }
}
```

For more details on this, see https://github.com/storyscript/storyscript/issues/593.

As the Storyscript engine doesn't support nested inline service expressions yet, I kept the fake tree approach to avoid breaking the engine.

TODO
-----

- [x] `to_be_base_expression` (should be eliminated and transformed into a `base_expression` too, but at the moment when the `Objects` AST traverse gets called, it "lost" the information about lines and existing variables).