### PR TITLE
feat(Compiler): require service calls to have command names

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -56,6 +56,8 @@ class ErrorCodes:
         'E0050', 'Service output can not be called as a function')
     when_no_output_parent = (
         'E0051', 'No service parent has been found.')
+    service_without_command = (
+        'E0052', 'Service calls require a command.')
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -156,8 +156,8 @@ class Compiler:
             return
         line = tree.line()
         command = tree.service_fragment.command
-        if command:
-            command = command.child(0)
+        tree.expect(command is not None, 'service_without_command')
+        command = command.child(0)
         arguments = Objects.arguments(tree.service_fragment)
         service = tree.path.extract_path()
         output = self.output(tree.service_fragment.output)

--- a/tests/e2e/call_function_expression_nested.json
+++ b/tests/e2e/call_function_expression_nested.json
@@ -1,0 +1,148 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [],
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": "my_function",
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "k1",
+          "argument": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "k2",
+          "argument": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1",
+      "next": "4.1"
+    },
+    "4.1": {
+      "method": "call",
+      "ln": "4.1",
+      "output": null,
+      "name": [
+        "p-4.1"
+      ],
+      "service": "my_function",
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "k1",
+          "argument": {
+            "$OBJECT": "expression",
+            "expression": "sum",
+            "values": [
+              2,
+              {
+                "$OBJECT": "expression",
+                "expression": "modulus",
+                "values": [
+                  2,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "k2",
+          "argument": {
+            "$OBJECT": "expression",
+            "expression": "subtraction",
+            "values": [
+              {
+                "$OBJECT": "expression",
+                "expression": "division",
+                "values": [
+                  {
+                    "$OBJECT": "path",
+                    "paths": [
+                      "a"
+                    ]
+                  },
+                  {
+                    "$OBJECT": "path",
+                    "paths": [
+                      "b"
+                    ]
+                  }
+                ]
+              },
+              {
+                "$OBJECT": "path",
+                "paths": [
+                  "c"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-4.1"
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {
+    "my_function": "1"
+  },
+  "version": null
+}

--- a/tests/e2e/call_function_expression_nested.story
+++ b/tests/e2e/call_function_expression_nested.story
@@ -1,0 +1,4 @@
+function my_function k1: int k2:int
+	return 0
+
+my_function (k1: 2 + 2 % 4 k2: a / b - c)

--- a/tests/e2e/call_function_expression_unary_complex_4.json
+++ b/tests/e2e/call_function_expression_unary_complex_4.json
@@ -1,0 +1,112 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [],
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": "my_function",
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "k1",
+          "argument": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "output": null,
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "1",
+      "next": "4.1"
+    },
+    "4.1": {
+      "method": "call",
+      "ln": "4.1",
+      "output": null,
+      "name": [
+        "p-4.1"
+      ],
+      "service": "my_function",
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "k1",
+          "argument": {
+            "$OBJECT": "expression",
+            "expression": "or",
+            "values": [
+              {
+                "$OBJECT": "expression",
+                "expression": "not",
+                "values": [
+                  {
+                    "$OBJECT": "path",
+                    "paths": [
+                      "b"
+                    ]
+                  }
+                ]
+              },
+              2
+            ]
+          }
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "4"
+    },
+    "4": {
+      "method": "set",
+      "ln": "4",
+      "output": null,
+      "name": [
+        "a"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "p-4.1"
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {
+    "my_function": "1"
+  },
+  "version": null
+}

--- a/tests/e2e/call_function_expression_unary_complex_4.story
+++ b/tests/e2e/call_function_expression_unary_complex_4.story
@@ -1,0 +1,4 @@
+function my_function k1:int
+	return 0
+
+a = my_function(k1: !b or 2)

--- a/tests/e2e/expression_is_if_statement.json
+++ b/tests/e2e/expression_is_if_statement.json
@@ -61,8 +61,8 @@
       "ln": "2",
       "output": [],
       "name": null,
-      "service": "echo",
-      "command": null,
+      "service": "logger",
+      "command": "echo",
       "function": null,
       "args": [
         {
@@ -80,7 +80,7 @@
     }
   },
   "services": [
-    "echo",
+    "logger",
     "weather"
   ],
   "entrypoint": "1.1",

--- a/tests/e2e/expression_is_if_statement.story
+++ b/tests/e2e/expression_is_if_statement.story
@@ -1,2 +1,2 @@
 if (weather tommorow where:'Amsterdam') == 'horrible'
-	echo message:'oh no!'
+	logger echo message:'oh no!'

--- a/tests/e2e/service_call_require_command.error
+++ b/tests/e2e/service_call_require_command.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 1
+
+1|    echo message:"hello"
+      ^^^^
+
+E0052: Service calls require a command.

--- a/tests/e2e/service_call_require_command.story
+++ b/tests/e2e/service_call_require_command.story
@@ -1,0 +1,1 @@
+echo message:"hello"

--- a/tests/e2e/while_with_mutation.json
+++ b/tests/e2e/while_with_mutation.json
@@ -68,22 +68,20 @@
       "next": "3"
     },
     "3": {
-      "method": "execute",
+      "method": "break",
       "ln": "3",
-      "output": [],
+      "output": null,
       "name": null,
-      "service": "continue",
+      "service": null,
       "command": null,
       "function": null,
-      "args": [],
+      "args": null,
       "enter": null,
       "exit": null,
       "parent": "2"
     }
   },
-  "services": [
-    "continue"
-  ],
+  "services": [],
   "entrypoint": "1",
   "modules": {},
   "functions": {},

--- a/tests/e2e/while_with_mutation.story
+++ b/tests/e2e/while_with_mutation.story
@@ -1,3 +1,3 @@
 x = 5
 while x is_odd
-	continue
+	break

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -318,16 +318,6 @@ def test_compiler_try_nested_throw_error(parser):
     assert result['tree']['5']['args'] == args
 
 
-def test_compiler_service_with_zero_args(parser):
-    source = 'foo'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
-    assert result['tree']['1']['method'] == 'execute'
-    assert result['tree']['1']['service'] == 'foo'
-    assert result['tree']['1']['args'] == []
-    assert result['services'] == ['foo']
-
-
 def test_compiler_break(parser):
     source = 'while true\n\tbreak'
     tree = parser.parse(source)
@@ -1494,71 +1484,6 @@ def test_compiler_service_expression(parser):
     ]
 
 
-def test_compiler_function_expression(parser):
-    """
-    Ensures that function calls with expressions are compiled correctly
-    """
-    source = 'my_function k1: 2 + 2 % 4 k2: a / b - c'
-    result = Compiler.compile(parser.parse(source))
-    assert result['tree']['1']['method'] == 'execute'
-    assert result['tree']['1']['service'] == 'my_function'
-    assert result['tree']['1']['args'] == [
-        {
-          '$OBJECT': 'argument',
-          'name': 'k1',
-          'argument': {
-            '$OBJECT': 'expression',
-            'expression': 'sum',
-            'values': [
-              2,
-              {
-                '$OBJECT': 'expression',
-                'expression': 'modulus',
-                'values': [
-                  2,
-                  4
-                ]
-              }
-            ]
-          }
-        },
-        {
-          '$OBJECT': 'argument',
-          'name': 'k2',
-          'argument': {
-            '$OBJECT': 'expression',
-            'expression': 'subtraction',
-            'values': [
-              {
-                '$OBJECT': 'expression',
-                'expression': 'division',
-                'values': [
-                  {
-                    '$OBJECT': 'path',
-                    'paths': [
-                      'a'
-                    ]
-                  },
-                  {
-                    '$OBJECT': 'path',
-                    'paths': [
-                      'b'
-                    ]
-                  }
-                ]
-              },
-              {
-                '$OBJECT': 'path',
-                'paths': [
-                  'c'
-                ]
-              }
-            ]
-          }
-        }
-    ]
-
-
 def test_compiler_mutation_expression_list(parser):
     """
     Ensures that mutations on lists work
@@ -1896,38 +1821,6 @@ def test_compiler_unary_complex_3(parser):
             ]
           }
         ]
-    }]
-
-
-def test_compiler_unary_complex_4(parser):
-    """
-    Ensures that complex unary expressions are compiled correctly
-    """
-    source = 'a = my_function k1: !b or 2'
-    result = Compiler.compile(parser.parse(source))
-    assert result['tree']['1']['method'] == 'execute'
-    assert result['tree']['1']['args'] == [{
-        '$OBJECT': 'argument',
-        'name': 'k1',
-        'argument': {
-          '$OBJECT': 'expression',
-          'expression': 'or',
-          'values': [
-            {
-              '$OBJECT': 'expression',
-              'expression': 'not',
-              'values': [
-                {
-                  '$OBJECT': 'path',
-                  'paths': [
-                    'b'
-                  ]
-                }
-              ]
-            },
-            2
-          ]
-        }
     }]
 
 


### PR DESCRIPTION
From https://github.com/storyscript/storyscript/issues/275#issuecomment-464672501

>>> path arguments exists because services can be called without a command, as long as they have at least one argument:

>> IMHO we should remove path arguments, because an action is required to be able to execute anything.

> Yes, there is no need for path arguments

**- What I did**

- Added a check & error message for service calls without a command