### PR TITLE
fix(compiler): improve the edge case of `when` without a command name

### DIFF
--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -228,7 +228,7 @@ class Grammar:
 
     def block(self):
         self.ebnf._WHEN = 'when'
-        when = 'when (path output|service)'
+        when = 'when (path output, service, name)'
         self.ebnf.when_block = self.ebnf.simple_block(when)
         self.ebnf.indented_arguments = 'indent (arguments nl)+ dedent'
         block = ('rules nl, if_block, foreach_block, function_block, '

--- a/tests/e2e/condensed_when_as.json
+++ b/tests/e2e/condensed_when_as.json
@@ -1,0 +1,77 @@
+{
+  "tree": {
+    "1": {
+      "method": "execute",
+      "ln": "1",
+      "output": [
+        "my_server"
+      ],
+      "name": null,
+      "service": "http",
+      "command": "server",
+      "function": null,
+      "args": [],
+      "enter": "2",
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "when",
+      "ln": "2",
+      "output": [
+        "client"
+      ],
+      "name": null,
+      "service": "my_server",
+      "command": "listen",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "path",
+          "argument": {
+            "$OBJECT": "string",
+            "string": "/health"
+          }
+        },
+        {
+          "$OBJECT": "argument",
+          "name": "method",
+          "argument": {
+            "$OBJECT": "string",
+            "string": "get"
+          }
+        }
+      ],
+      "enter": "3",
+      "exit": null,
+      "parent": "1",
+      "next": "3"
+    },
+    "3": {
+      "method": "set",
+      "ln": "3",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "2"
+    }
+  },
+  "services": [
+    "http"
+  ],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/condensed_when_as.story
+++ b/tests/e2e/condensed_when_as.story
@@ -1,0 +1,3 @@
+http server as my_server
+  when listen path:'/health' method:'get' as client
+  	x = 0

--- a/tests/e2e/condensed_when_fail3.error
+++ b/tests/e2e/condensed_when_fail3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 6
+
+1|    when echo
+           ^^^^
+
+E0051: No service parent has been found.

--- a/tests/e2e/condensed_when_fail3.story
+++ b/tests/e2e/condensed_when_fail3.story
@@ -1,0 +1,2 @@
+when echo
+	x = 0

--- a/tests/e2e/condensed_when_nested2.json
+++ b/tests/e2e/condensed_when_nested2.json
@@ -1,0 +1,180 @@
+{
+  "tree": {
+    "1": {
+      "method": "execute",
+      "ln": "1",
+      "output": [
+        "default"
+      ],
+      "name": null,
+      "service": "logging",
+      "command": "default",
+      "function": null,
+      "args": [],
+      "enter": "2",
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "when",
+      "ln": "2",
+      "output": [
+        "logger"
+      ],
+      "name": null,
+      "service": "default",
+      "command": "log",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "level",
+          "argument": {
+            "$OBJECT": "string",
+            "string": "normal"
+          }
+        }
+      ],
+      "enter": "3",
+      "exit": null,
+      "parent": "1",
+      "next": "3"
+    },
+    "3": {
+      "method": "set",
+      "ln": "3",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "2",
+      "next": "4"
+    },
+    "4": {
+      "method": "when",
+      "ln": "4",
+      "output": [
+        "log"
+      ],
+      "name": null,
+      "service": "default",
+      "command": "log",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "level",
+          "argument": {
+            "$OBJECT": "string",
+            "string": "normal"
+          }
+        }
+      ],
+      "enter": "5",
+      "exit": null,
+      "parent": "1",
+      "next": "5"
+    },
+    "5": {
+      "method": "set",
+      "ln": "5",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        1
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "4",
+      "next": "6"
+    },
+    "6": {
+      "method": "when",
+      "ln": "6",
+      "output": [
+        "logger"
+      ],
+      "name": null,
+      "service": "default",
+      "command": "log",
+      "function": null,
+      "args": [],
+      "enter": "7",
+      "exit": null,
+      "parent": "1",
+      "next": "7"
+    },
+    "7": {
+      "method": "set",
+      "ln": "7",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        2
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "6",
+      "next": "8"
+    },
+    "8": {
+      "method": "when",
+      "ln": "8",
+      "output": [
+        "log"
+      ],
+      "name": null,
+      "service": "default",
+      "command": "log",
+      "function": null,
+      "args": [],
+      "enter": "9",
+      "exit": null,
+      "parent": "1",
+      "next": "9"
+    },
+    "9": {
+      "method": "set",
+      "ln": "9",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        3
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "8"
+    }
+  },
+  "services": [
+    "logging"
+  ],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/condensed_when_nested2.story
+++ b/tests/e2e/condensed_when_nested2.story
@@ -1,0 +1,9 @@
+logging default
+  	when log level: 'normal' as logger
+  		x = 0
+  	when log level: 'normal'
+  		x = 1
+  	when log as logger
+  		x = 2
+  	when log
+  		x = 3

--- a/tests/e2e/condensed_when_nested_path.json
+++ b/tests/e2e/condensed_when_nested_path.json
@@ -1,0 +1,203 @@
+{
+  "tree": {
+    "1": {
+      "method": "execute",
+      "ln": "1",
+      "output": [],
+      "name": [
+        "log"
+      ],
+      "service": "logging",
+      "command": "error",
+      "function": null,
+      "args": [],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "execute",
+      "ln": "2",
+      "output": [
+        "default"
+      ],
+      "name": null,
+      "service": "logging",
+      "command": "default",
+      "function": null,
+      "args": [],
+      "enter": "3",
+      "exit": null,
+      "parent": null,
+      "next": "3"
+    },
+    "3": {
+      "method": "when",
+      "ln": "3",
+      "output": [
+        "logger"
+      ],
+      "name": null,
+      "service": "default",
+      "command": "log",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "level",
+          "argument": {
+            "$OBJECT": "string",
+            "string": "normal"
+          }
+        }
+      ],
+      "enter": "4",
+      "exit": null,
+      "parent": "2",
+      "next": "4"
+    },
+    "4": {
+      "method": "set",
+      "ln": "4",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        0
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "3",
+      "next": "5"
+    },
+    "5": {
+      "method": "when",
+      "ln": "5",
+      "output": [
+        "log"
+      ],
+      "name": null,
+      "service": "default",
+      "command": "log",
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "argument",
+          "name": "level",
+          "argument": {
+            "$OBJECT": "string",
+            "string": "normal"
+          }
+        }
+      ],
+      "enter": "6",
+      "exit": null,
+      "parent": "2",
+      "next": "6"
+    },
+    "6": {
+      "method": "set",
+      "ln": "6",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        1
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "5",
+      "next": "7"
+    },
+    "7": {
+      "method": "when",
+      "ln": "7",
+      "output": [
+        "logger"
+      ],
+      "name": null,
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "log"
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "2",
+      "next": "8"
+    },
+    "8": {
+      "method": "set",
+      "ln": "8",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        2
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "7",
+      "next": "9"
+    },
+    "9": {
+      "method": "when",
+      "ln": "9",
+      "output": [
+        "log"
+      ],
+      "name": null,
+      "service": "default",
+      "command": "log",
+      "function": null,
+      "args": [],
+      "enter": "10",
+      "exit": null,
+      "parent": "2",
+      "next": "10"
+    },
+    "10": {
+      "method": "set",
+      "ln": "10",
+      "output": null,
+      "name": [
+        "x"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        3
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": "9"
+    }
+  },
+  "services": [
+    "logging"
+  ],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/condensed_when_nested_path.story
+++ b/tests/e2e/condensed_when_nested_path.story
@@ -1,0 +1,10 @@
+log = logging error
+logging default
+  	when log level: 'normal' as logger
+  		x = 0
+  	when log level: 'normal'
+  		x = 1
+  	when log as logger
+  		x = 2
+  	when log
+  		x = 3

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -67,7 +67,7 @@ finally_block: finally_statement _NL nested_block
 try_statement: TRY
 try_block: try_statement _NL nested_block catch_block? finally_block?
 throw_statement: THROW entity?
-when_block: _WHEN (path output|service) _NL nested_block
+when_block: _WHEN (path output| service| NAME) _NL nested_block
 indented_arguments: _INDENT (arguments _NL)+ _DEDENT
 block: rules _NL| if_block| foreach_block| function_block| arguments| indented_chain| chained_mutation| mutation_block| service_block| when_block| try_block| indented_arguments| while_block
 nested_block: _INDENT block+ _DEDENT


### PR DESCRIPTION
There are quite a few interesting edge cases resulting from https://github.com/storyscript/storyscript/pull/663 and https://github.com/storyscript/storyscript/pull/664.

This tries to add tests for them and improve the behavior, s.t. it's more intuitive for the users.
In particular, all the following examples will now be compiled as services

```coffee
logging default
  	when log level: 'normal' as logger
  		x = 0
  	when log level: 'normal' # service with implicit output: 'log'
  		x = 1
  	when log as logger # <- this is a tricky case it could be a path (here: service)
  		x = 2
  	when log # service with implicit output: 'log' (this ERRORed before)
  		x = 3
```

In particular, case (3) is a bit ambiguous, so the compiler now checks whether the path exists and only if emits a `path`:

```coffee
log = logging error
logging default
  	when log level: 'normal' as logger
  		x = 0
  	when log level: 'normal' # service with implicit output: 'log'
  		x = 1
  	when log as logger # <- this is a tricky case as it could be a path (here: path)
  		x = 2
  	when log # service with implicit output: 'log'
  		x = 3
```