### PR TITLE
feat(compiler): lower string templates as concatenation

### DIFF
--- a/tests/e2e/templated_strings.json
+++ b/tests/e2e/templated_strings.json
@@ -1,0 +1,158 @@
+{
+  "tree": {
+    "1": {
+      "method": "set",
+      "ln": "1",
+      "output": null,
+      "name": [
+        "t1"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "string",
+              "string": "hello"
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "story"
+              ]
+            },
+            {
+              "$OBJECT": "string",
+              "string": "world"
+            }
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "2"
+    },
+    "2": {
+      "method": "set",
+      "ln": "2",
+      "output": null,
+      "name": [
+        "t2"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "b"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "c"
+              ]
+            },
+            {
+              "$OBJECT": "string",
+              "string": "."
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "d"
+              ]
+            }
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "3"
+    },
+    "3": {
+      "method": "set",
+      "ln": "3",
+      "output": null,
+      "name": [
+        "t3"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null,
+      "next": "4"
+    },
+    "4": {
+      "method": "set",
+      "ln": "4",
+      "output": null,
+      "name": [
+        "t4"
+      ],
+      "service": null,
+      "command": null,
+      "function": null,
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "string",
+              "string": "hello\\{with\\}\\{"
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a",
+                "b",
+                "c"
+              ]
+            },
+            {
+              "$OBJECT": "string",
+              "string": " paths"
+            }
+          ]
+        }
+      ],
+      "enter": null,
+      "exit": null,
+      "parent": null
+    }
+  },
+  "services": [],
+  "entrypoint": "1",
+  "modules": {},
+  "functions": {},
+  "version": null
+}

--- a/tests/e2e/templated_strings.story
+++ b/tests/e2e/templated_strings.story
@@ -1,0 +1,4 @@
+t1 = "hello{story}world"
+t2 = "{a}{b}{c}.{d}"
+t3 = "{a}"
+t4 = "hello\{with\}\{{a.b.c} paths"

--- a/tests/integration/compiler/Assignments.py
+++ b/tests/integration/compiler/Assignments.py
@@ -78,22 +78,6 @@ def test_assignments_string(parser):
     assert result['tree']['1']['args'] == expected
 
 
-def test_assignments_string_template(parser):
-    tree = parser.parse('a = "hello {nl}"')
-    result = Compiler.compile(tree)
-    assert result['tree']['1']['args'][0]['string'] == 'hello {}'
-    values = [{'$OBJECT': 'path', 'paths': ['nl']}]
-    assert result['tree']['1']['args'][0]['values'] == values
-
-
-def test_assignments_string_template_dots(parser):
-    tree = parser.parse('a = "hello {nl.ams}"')
-    result = Compiler.compile(tree)
-    assert result['tree']['1']['args'][0]['string'] == 'hello {}'
-    values = [{'$OBJECT': 'path', 'paths': ['nl', 'ams']}]
-    assert result['tree']['1']['args'][0]['values'] == values
-
-
 def test_assignments_list(parser):
     """
     Ensures that assignments to lists are compiled correctly


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/608

**- What I did**

- Lowered string templates into string concatenation

Example:

```coffee
t1 = "hello{story}world"
```

```json
{
  "1": {
    "method": "set",
    "ln": "1",
    "output": null,
    "name": [
      "t1"
    ],
    "service": null,
    "command": null,
    "function": null,
    "args": [
      {
        "$OBJECT": "expression",
        "expression": "sum",
        "values": [
          {
            "$OBJECT": "string",
            "string": "hello"
          },
          {
            "$OBJECT": "path",
            "paths": [
              "story"
            ]
          },
          {
            "$OBJECT": "string",
            "string": "world"
          }
        ]
      }
    ],
    "enter": null,
    "exit": null,
    "parent": null
  }
}
```

See the diff for more examples.
