### PR TITLE
Add --concise and --first CLI options

### DIFF
--- a/storyscript/App.py
+++ b/storyscript/App.py
@@ -3,6 +3,7 @@ import json
 
 from .Bundle import Bundle
 from .compiler.Preprocessor import Preprocessor
+from .exceptions import StoryError
 from .parser import Grammar
 
 
@@ -24,7 +25,8 @@ class App:
         return stories
 
     @staticmethod
-    def compile(path, ignored_path=None, ebnf=None, concise=False):
+    def compile(path, ignored_path=None, ebnf=None, concise=False,
+                first=False):
         """
         Parses and compiles stories found in path, returning JSON
         """
@@ -32,6 +34,10 @@ class App:
         result = bundle.bundle(ebnf=ebnf)
         if concise:
             result = _clean_dict(result)
+        if first:
+            if len(result['stories']) != 1:
+                raise StoryError.create_error('first_option_more_stories')
+            result = next(iter(result['stories'].values()))
         return json.dumps(result, indent=2)
 
     @staticmethod

--- a/storyscript/App.py
+++ b/storyscript/App.py
@@ -24,12 +24,15 @@ class App:
         return stories
 
     @staticmethod
-    def compile(path, ignored_path=None, ebnf=None):
+    def compile(path, ignored_path=None, ebnf=None, concise=False):
         """
         Parses and compiles stories found in path, returning JSON
         """
         bundle = Bundle.from_path(path, ignored_path=ignored_path)
-        return json.dumps(bundle.bundle(ebnf=ebnf), indent=2)
+        result = bundle.bundle(ebnf=ebnf)
+        if concise:
+            result = _clean_dict(result)
+        return json.dumps(result, indent=2)
 
     @staticmethod
     def lex(path, ebnf=None):
@@ -44,3 +47,12 @@ class App:
         Returns the current grammar
         """
         return Grammar().build()
+
+
+def _clean_dict(d):
+    """
+    Removes all falsy elements from a nested dict
+    """
+    if not isinstance(d, dict):
+        return d
+    return {k: _clean_dict(v) for k, v in d.items() if v}

--- a/storyscript/Cli.py
+++ b/storyscript/Cli.py
@@ -75,16 +75,17 @@ class Cli:
     @click.option('--json', '-j', is_flag=True)
     @click.option('--silent', '-s', is_flag=True, help=silent_help)
     @click.option('--debug', is_flag=True)
+    @click.option('--concise', '-c', is_flag=True)
     @click.option('--ebnf', help=ebnf_help)
     @click.option('--ignore', default=None,
                   help='Specify path of ignored files')
-    def compile(path, output, json, silent, debug, ebnf, ignore):
+    def compile(path, output, json, silent, debug, ebnf, ignore, concise):
         """
         Compiles stories and prints the resulting json
         """
         try:
             results = App.compile(path, ignored_path=ignore,
-                                  ebnf=ebnf)
+                                  ebnf=ebnf, concise=concise)
             if not silent:
                 if json:
                     if output:

--- a/storyscript/Cli.py
+++ b/storyscript/Cli.py
@@ -76,16 +76,18 @@ class Cli:
     @click.option('--silent', '-s', is_flag=True, help=silent_help)
     @click.option('--debug', is_flag=True)
     @click.option('--concise', '-c', is_flag=True)
+    @click.option('--first', '-f', is_flag=True)
     @click.option('--ebnf', help=ebnf_help)
     @click.option('--ignore', default=None,
                   help='Specify path of ignored files')
-    def compile(path, output, json, silent, debug, ebnf, ignore, concise):
+    def compile(path, output, json, silent, debug, ebnf, ignore, concise,
+                first):
         """
         Compiles stories and prints the resulting json
         """
         try:
             results = App.compile(path, ignored_path=ignore,
-                                  ebnf=ebnf, concise=concise)
+                                  ebnf=ebnf, concise=concise, first=first)
             if not silent:
                 if json:
                     if output:

--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -62,6 +62,9 @@ class ErrorCodes:
         'E0053', 'Unexpected end of line. Expected: {allowed}.')
     arguments_expected = (
         'E0054', 'Arguments need to be declared with `key:value`')
+    first_option_more_stories = (
+        'E0055',
+        'The option `--first`/-`f` can only be used if one story is complied.')
 
     @staticmethod
     def is_error(error_name):

--- a/tests/e2e/call_function_expression_nested.json
+++ b/tests/e2e/call_function_expression_nested.json
@@ -3,10 +3,6 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "my_function",
       "args": [
         {
@@ -27,36 +23,24 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "return",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4.1"
     },
     "4.1": {
       "method": "call",
       "ln": "4.1",
-      "output": null,
       "name": [
         "p-4.1"
       ],
       "service": "my_function",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -112,19 +96,11 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "expression",
       "ln": "4",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -132,15 +108,10 @@
             "p-4.1"
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "my_function": "1"
   },

--- a/tests/e2e/call_function_expression_unary_complex_4.json
+++ b/tests/e2e/call_function_expression_unary_complex_4.json
@@ -3,10 +3,6 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "my_function",
       "args": [
         {
@@ -19,36 +15,24 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "return",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4.1"
     },
     "4.1": {
       "method": "call",
       "ln": "4.1",
-      "output": null,
       "name": [
         "p-4.1"
       ],
       "service": "my_function",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -74,21 +58,14 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -96,15 +73,10 @@
             "p-4.1"
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "my_function": "1"
   },

--- a/tests/e2e/collection_with_mutation.json
+++ b/tests/e2e/collection_with_mutation.json
@@ -3,13 +3,9 @@
     "1.1": {
       "method": "mutation",
       "ln": "1.1",
-      "output": null,
       "name": [
         "p-1.1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         2,
         {
@@ -18,21 +14,14 @@
           "arguments": []
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "list",
@@ -47,15 +36,9 @@
             3
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/collection_with_service.json
+++ b/tests/e2e/collection_with_service.json
@@ -3,13 +3,11 @@
     "1.1": {
       "method": "execute",
       "ln": "1.1",
-      "output": [],
       "name": [
         "p-1.1"
       ],
       "service": "my_service",
       "command": "command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -17,21 +15,14 @@
           "argument": 2
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "list",
@@ -46,17 +37,12 @@
             3
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
     "my_service"
   ],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/complex_assert.json
+++ b/tests/e2e/complex_assert.json
@@ -3,29 +3,17 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "foo"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         true
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "if",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -69,17 +57,13 @@
       ],
       "enter": "3",
       "exit": "4",
-      "parent": null,
       "next": "3"
     },
     "3": {
       "method": "execute",
       "ln": "3",
-      "output": [],
-      "name": null,
       "service": "log",
       "command": "info",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -90,33 +74,21 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "2",
       "next": "4"
     },
     "4": {
       "method": "else",
       "ln": "4",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
       "enter": "5",
       "exit": "6",
-      "parent": null,
       "next": "5"
     },
     "5": {
       "method": "execute",
       "ln": "5",
-      "output": [],
-      "name": null,
       "service": "log",
       "command": "info",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -127,19 +99,14 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "4",
       "next": "6"
     },
     "6": {
       "method": "execute",
       "ln": "6",
-      "output": [],
-      "name": null,
       "service": "log",
       "command": "info",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -149,17 +116,12 @@
             "string": "completed"
           }
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
     "log"
   ],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/condensed_when.json
+++ b/tests/e2e/condensed_when.json
@@ -6,14 +6,9 @@
       "output": [
         "server"
       ],
-      "name": null,
       "service": "http",
       "command": "server",
-      "function": null,
-      "args": [],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
@@ -22,10 +17,8 @@
       "output": [
         "client"
       ],
-      "name": null,
       "service": "server",
       "command": "listen",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -45,25 +38,18 @@
         }
       ],
       "enter": "3",
-      "exit": null,
       "parent": "1",
       "next": "3"
     },
     "3": {
       "method": "set",
       "ln": "3",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "2"
     }
   },
@@ -71,7 +57,5 @@
     "http"
   ],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/condensed_when_nested.json
+++ b/tests/e2e/condensed_when_nested.json
@@ -6,14 +6,9 @@
       "output": [
         "server"
       ],
-      "name": null,
       "service": "http",
       "command": "server",
-      "function": null,
-      "args": [],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
@@ -22,10 +17,6 @@
       "output": [
         "item"
       ],
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -35,7 +26,6 @@
         }
       ],
       "enter": "3",
-      "exit": null,
       "parent": "1",
       "next": "3"
     },
@@ -45,10 +35,8 @@
       "output": [
         "client"
       ],
-      "name": null,
       "service": "server",
       "command": "listen",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -68,25 +56,18 @@
         }
       ],
       "enter": "4",
-      "exit": null,
       "parent": "2",
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "3"
     }
   },
@@ -94,7 +75,5 @@
     "http"
   ],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/exit_line.json
+++ b/tests/e2e/exit_line.json
@@ -6,10 +6,6 @@
       "output": [
         "item"
       ],
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -20,19 +16,14 @@
       ],
       "enter": "2",
       "exit": "4",
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -41,19 +32,12 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4"
     },
     "4": {
       "method": "if",
       "ln": "4",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -64,122 +48,77 @@
       ],
       "enter": "5",
       "exit": "6",
-      "parent": null,
       "next": "5"
     },
     "5": {
       "method": "set",
       "ln": "5",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "4",
       "next": "6"
     },
     "6": {
       "method": "else",
       "ln": "6",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
       "enter": "7",
       "exit": "9",
-      "parent": null,
       "next": "7"
     },
     "7": {
       "method": "set",
       "ln": "7",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "6",
       "next": "9"
     },
     "9": {
       "method": "while",
       "ln": "9",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         true
       ],
       "enter": "10",
       "exit": "12",
-      "parent": null,
       "next": "10"
     },
     "10": {
       "method": "set",
       "ln": "10",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "9",
       "next": "12"
     },
     "12": {
       "method": "try",
       "ln": "12",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
       "enter": "13",
       "exit": "14",
-      "parent": null,
       "next": "13"
     },
     "13": {
       "method": "set",
       "ln": "13",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "12",
       "next": "14"
     },
@@ -189,55 +128,33 @@
       "output": [
         "e"
       ],
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
       "enter": "15",
       "exit": "17",
-      "parent": null,
       "next": "15"
     },
     "15": {
       "method": "set",
       "ln": "15",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "14",
       "next": "17"
     },
     "17": {
       "method": "set",
       "ln": "17",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/exit_line_complex.json
+++ b/tests/e2e/exit_line_complex.json
@@ -3,13 +3,9 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "labels"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "list",
@@ -32,27 +28,17 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "found"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         false
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "3"
     },
     "3": {
@@ -61,10 +47,6 @@
       "output": [
         "label"
       ],
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -75,17 +57,11 @@
       ],
       "enter": "4",
       "exit": "10",
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "if",
       "ln": "4",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -142,30 +118,18 @@
     "5": {
       "method": "set",
       "ln": "5",
-      "output": null,
       "name": [
         "found"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         true
       ],
-      "enter": null,
-      "exit": null,
       "parent": "4",
       "next": "6"
     },
     "6": {
       "method": "else",
       "ln": "6",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
       "enter": "7",
       "exit": "8",
       "parent": "3",
@@ -174,29 +138,18 @@
     "7": {
       "method": "set",
       "ln": "7",
-      "output": null,
       "name": [
         "found"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         false
       ],
-      "enter": null,
-      "exit": null,
       "parent": "6",
       "next": "8"
     },
     "8": {
       "method": "if",
       "ln": "8",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -213,42 +166,26 @@
     "9": {
       "method": "set",
       "ln": "9",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "8",
       "next": "10"
     },
     "10": {
       "method": "set",
       "ln": "10",
-      "output": null,
       "name": [
         "outside"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         true
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/expression_is.json
+++ b/tests/e2e/expression_is.json
@@ -3,11 +3,6 @@
     "1": {
       "method": "if",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -27,31 +22,20 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/expression_is_if_statement.json
+++ b/tests/e2e/expression_is_if_statement.json
@@ -3,13 +3,11 @@
     "1.1": {
       "method": "execute",
       "ln": "1.1",
-      "output": [],
       "name": [
         "p-1.1"
       ],
       "service": "weather",
       "command": "tommorow",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -20,19 +18,11 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "if",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -52,18 +42,13 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "execute",
       "ln": "2",
-      "output": [],
-      "name": null,
       "service": "logger",
       "command": "echo",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -74,8 +59,6 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
@@ -84,7 +67,5 @@
     "weather"
   ],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/expression_mutation_nested.json
+++ b/tests/e2e/expression_mutation_nested.json
@@ -3,13 +3,9 @@
     "1.1": {
       "method": "mutation",
       "ln": "1.1",
-      "output": null,
       "name": [
         "p-1.1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "list",
@@ -39,21 +35,14 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "expression",
       "ln": "1",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -68,15 +57,9 @@
             }
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/expression_mutation_while.json
+++ b/tests/e2e/expression_mutation_while.json
@@ -3,13 +3,9 @@
     "1.1": {
       "method": "mutation",
       "ln": "1.1",
-      "output": null,
       "name": [
         "p-1.1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "list",
@@ -31,19 +27,11 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "while",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -53,27 +41,14 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "return",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
-  "services": [],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/function_call.json
+++ b/tests/e2e/function_call.json
@@ -3,10 +3,6 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "name",
       "args": [
         {
@@ -19,38 +15,27 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4.1"
     },
     "4.1": {
       "method": "call",
       "ln": "4.1",
-      "output": null,
       "name": [
         "p-4.1"
       ],
       "service": "name",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -58,19 +43,11 @@
           "argument": 2
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "expression",
       "ln": "4",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -78,15 +55,10 @@
             "p-4.1"
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "name": "1"
   },

--- a/tests/e2e/function_call_assignment.json
+++ b/tests/e2e/function_call_assignment.json
@@ -3,10 +3,6 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "name",
       "args": [
         {
@@ -19,38 +15,27 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4.1"
     },
     "4.1": {
       "method": "call",
       "ln": "4.1",
-      "output": null,
       "name": [
         "p-4.1"
       ],
       "service": "name",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -58,21 +43,14 @@
           "argument": 1
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -80,15 +58,10 @@
             "p-4.1"
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "name": "1"
   },

--- a/tests/e2e/function_call_multi_args.json
+++ b/tests/e2e/function_call_multi_args.json
@@ -3,10 +3,6 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "name",
       "args": [
         {
@@ -27,38 +23,27 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4.1"
     },
     "4.1": {
       "method": "call",
       "ln": "4.1",
-      "output": null,
       "name": [
         "p-4.1"
       ],
       "service": "name",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -71,21 +56,14 @@
           "argument": 2
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -93,15 +71,10 @@
             "p-4.1"
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "name": "1"
   },

--- a/tests/e2e/function_call_nested.json
+++ b/tests/e2e/function_call_nested.json
@@ -3,10 +3,6 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "name",
       "args": [
         {
@@ -19,38 +15,27 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4.1"
     },
     "4.1": {
       "method": "call",
       "ln": "4.1",
-      "output": null,
       "name": [
         "p-4.1"
       ],
       "service": "name",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -58,21 +43,15 @@
           "argument": 4
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4.2"
     },
     "4.2": {
       "method": "call",
       "ln": "4.2",
-      "output": null,
       "name": [
         "p-4.2"
       ],
       "service": "name",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -85,21 +64,15 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4.3"
     },
     "4.3": {
       "method": "call",
       "ln": "4.3",
-      "output": null,
       "name": [
         "p-4.3"
       ],
       "service": "name",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -112,21 +85,14 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -134,15 +100,10 @@
             "p-4.3"
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "name": "1"
   },

--- a/tests/e2e/function_call_three_inline_exprs.json
+++ b/tests/e2e/function_call_three_inline_exprs.json
@@ -3,61 +3,41 @@
     "1.1": {
       "method": "execute",
       "ln": "1.1",
-      "output": [],
       "name": [
         "p-1.1"
       ],
       "service": "serv1",
       "command": "f1",
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1.2"
     },
     "1.2": {
       "method": "execute",
       "ln": "1.2",
-      "output": [],
       "name": [
         "p-1.2"
       ],
       "service": "serv2",
       "command": "f2",
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1.3"
     },
     "1.3": {
       "method": "execute",
       "ln": "1.3",
-      "output": [],
       "name": [
         "p-1.3"
       ],
       "service": "serv3",
       "command": "f3",
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "execute",
       "ln": "1",
-      "output": [],
       "name": [
         "b"
       ],
       "service": "my_service",
       "command": "command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -89,10 +69,7 @@
             ]
           }
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
@@ -102,7 +79,5 @@
     "serv3"
   ],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/function_call_with_service.json
+++ b/tests/e2e/function_call_with_service.json
@@ -6,29 +6,16 @@
       "output": [
         "int"
       ],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "random",
-      "args": [],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "return",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         28
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4"
     },
@@ -38,9 +25,6 @@
       "output": [
         "int"
       ],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "my_func",
       "args": [
         {
@@ -61,52 +45,32 @@
         }
       ],
       "enter": "5",
-      "exit": null,
-      "parent": null,
       "next": "5"
     },
     "5": {
       "method": "return",
       "ln": "5",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         28
       ],
-      "enter": null,
-      "exit": null,
       "parent": "4",
       "next": "7.1"
     },
     "7.1": {
       "method": "call",
       "ln": "7.1",
-      "output": null,
       "name": [
         "p-7.1"
       ],
       "service": "random",
-      "command": null,
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "7"
     },
     "7": {
       "method": "set",
       "ln": "7",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -115,37 +79,24 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "8.1"
     },
     "8.1": {
       "method": "call",
       "ln": "8.1",
-      "output": null,
       "name": [
         "p-8.1"
       ],
       "service": "random",
-      "command": null,
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "8.2"
     },
     "8.2": {
       "method": "call",
       "ln": "8.2",
-      "output": null,
       "name": [
         "p-8.2"
       ],
       "service": "random",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -158,37 +109,25 @@
           "argument": 2
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "8.3"
     },
     "8.3": {
       "method": "call",
       "ln": "8.3",
-      "output": null,
       "name": [
         "p-8.3"
       ],
       "service": "random",
-      "command": null,
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "8"
     },
     "8": {
       "method": "execute",
       "ln": "8",
-      "output": [],
       "name": [
         "b"
       ],
       "service": "my_service",
       "command": "command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -220,17 +159,13 @@
             ]
           }
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
     "my_service"
   ],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "random": "1",
     "my_func": "4"

--- a/tests/e2e/function_call_with_service_nested.json
+++ b/tests/e2e/function_call_with_service_nested.json
@@ -6,29 +6,16 @@
       "output": [
         "int"
       ],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "random",
-      "args": [],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "return",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         28
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4"
     },
@@ -38,9 +25,6 @@
       "output": [
         "int"
       ],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "my_func",
       "args": [
         {
@@ -61,52 +45,34 @@
         }
       ],
       "enter": "5",
-      "exit": null,
-      "parent": null,
       "next": "5"
     },
     "5": {
       "method": "return",
       "ln": "5",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         28
       ],
-      "enter": null,
-      "exit": null,
       "parent": "4",
       "next": "7.1"
     },
     "7.1": {
       "method": "call",
       "ln": "7.1",
-      "output": null,
       "name": [
         "p-7.1"
       ],
       "service": "random",
-      "command": null,
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "7.2"
     },
     "7.2": {
       "method": "execute",
       "ln": "7.2",
-      "output": [],
       "name": [
         "p-7.2"
       ],
       "service": "another_service",
       "command": "command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -124,21 +90,15 @@
           "argument": 2
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "7.3"
     },
     "7.3": {
       "method": "call",
       "ln": "7.3",
-      "output": null,
       "name": [
         "p-7.3"
       ],
       "service": "my_func",
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -151,21 +111,16 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "7"
     },
     "7": {
       "method": "execute",
       "ln": "7",
-      "output": [],
       "name": [
         "b"
       ],
       "service": "my_service",
       "command": "command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -182,10 +137,7 @@
           "name": "p2",
           "argument": 2
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
@@ -193,7 +145,6 @@
     "my_service"
   ],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "random": "1",
     "my_func": "4"

--- a/tests/e2e/function_call_zero_args.json
+++ b/tests/e2e/function_call_zero_args.json
@@ -3,10 +3,6 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "name",
       "args": [
         {
@@ -19,54 +15,35 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "4.1"
     },
     "4.1": {
       "method": "call",
       "ln": "4.1",
-      "output": null,
       "name": [
         "p-4.1"
       ],
       "service": "name",
-      "command": null,
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -74,15 +51,10 @@
             "p-4.1"
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "name": "1"
   },

--- a/tests/e2e/if_else.json
+++ b/tests/e2e/if_else.json
@@ -3,11 +3,6 @@
     "1": {
       "method": "if",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -28,62 +23,38 @@
       ],
       "enter": "2",
       "exit": "3",
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "3"
     },
     "3": {
       "method": "else",
       "ln": "3",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
       "enter": "4",
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1
       ],
-      "enter": null,
-      "exit": null,
       "parent": "3"
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/if_elseif.json
+++ b/tests/e2e/if_elseif.json
@@ -3,11 +3,6 @@
     "1": {
       "method": "if",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -28,35 +23,23 @@
       ],
       "enter": "2",
       "exit": "3",
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "3"
     },
     "3": {
       "method": "elif",
       "ln": "3",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -76,31 +59,20 @@
         }
       ],
       "enter": "4",
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "tx"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1
       ],
-      "enter": null,
-      "exit": null,
       "parent": "3"
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/if_inline_expression.json
+++ b/tests/e2e/if_inline_expression.json
@@ -3,27 +3,16 @@
     "1.1": {
       "method": "execute",
       "ln": "1.1",
-      "output": [],
       "name": [
         "p-1.1"
       ],
       "service": "random",
       "command": "numbers",
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "if",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -33,25 +22,17 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
@@ -59,7 +40,5 @@
     "random"
   ],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/if_with_mutation.json
+++ b/tests/e2e/if_with_mutation.json
@@ -3,31 +3,20 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "var"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2.1"
     },
     "2.1": {
       "method": "mutation",
       "ln": "2.1",
-      "output": null,
       "name": [
         "p-2.1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -41,21 +30,14 @@
           "arguments": []
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2.2"
     },
     "2.2": {
       "method": "mutation",
       "ln": "2.2",
-      "output": null,
       "name": [
         "p-2.2"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -69,19 +51,11 @@
           "arguments": []
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "if",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -92,35 +66,23 @@
       ],
       "enter": "3",
       "exit": "4",
-      "parent": null,
       "next": "3"
     },
     "3": {
       "method": "set",
       "ln": "3",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "2",
       "next": "4"
     },
     "4": {
       "method": "elif",
       "ln": "4",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -131,80 +93,50 @@
       ],
       "enter": "5",
       "exit": "6",
-      "parent": null,
       "next": "5"
     },
     "5": {
       "method": "set",
       "ln": "5",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1
       ],
-      "enter": null,
-      "exit": null,
       "parent": "4",
       "next": "6"
     },
     "6": {
       "method": "else",
       "ln": "6",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
       "enter": "7",
       "exit": "9",
-      "parent": null,
       "next": "7"
     },
     "7": {
       "method": "set",
       "ln": "7",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         2
       ],
-      "enter": null,
-      "exit": null,
       "parent": "6",
       "next": "9"
     },
     "9": {
       "method": "set",
       "ln": "9",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         3
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/if_with_service.json
+++ b/tests/e2e/if_with_service.json
@@ -3,13 +3,11 @@
     "1.1": {
       "method": "execute",
       "ln": "1.1",
-      "output": [],
       "name": [
         "p-1.1"
       ],
       "service": "my_service",
       "command": "command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -22,21 +20,16 @@
           "argument": 2
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1.2"
     },
     "1.2": {
       "method": "execute",
       "ln": "1.2",
-      "output": [],
       "name": [
         "p-1.2"
       ],
       "service": "my_service2",
       "command": "command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -49,19 +42,11 @@
           "argument": 4
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "if",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -72,35 +57,23 @@
       ],
       "enter": "2",
       "exit": "3",
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "3"
     },
     "3": {
       "method": "elif",
       "ln": "3",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -111,75 +84,48 @@
       ],
       "enter": "4",
       "exit": "5",
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1
       ],
-      "enter": null,
-      "exit": null,
       "parent": "3",
       "next": "5"
     },
     "5": {
       "method": "else",
       "ln": "5",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
       "enter": "6",
       "exit": "8",
-      "parent": null,
       "next": "6"
     },
     "6": {
       "method": "set",
       "ln": "6",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         2
       ],
-      "enter": null,
-      "exit": null,
       "parent": "5",
       "next": "8"
     },
     "8": {
       "method": "set",
       "ln": "8",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         3
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
@@ -187,7 +133,5 @@
     "my_service2"
   ],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/multi_line_function_arguments.json
+++ b/tests/e2e/multi_line_function_arguments.json
@@ -3,10 +3,6 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "name",
       "args": [
         {
@@ -43,49 +39,32 @@
         }
       ],
       "enter": "4",
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "5"
     },
     "5": {
       "method": "set",
       "ln": "5",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "name": "1"
   },

--- a/tests/e2e/multiline_comments.json
+++ b/tests/e2e/multiline_comments.json
@@ -3,42 +3,25 @@
     "6": {
       "method": "set",
       "ln": "6",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "18"
     },
     "18": {
       "method": "set",
       "ln": "18",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "6",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/multiline_comments2.json
+++ b/tests/e2e/multiline_comments2.json
@@ -3,96 +3,58 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "5"
     },
     "5": {
       "method": "set",
       "ln": "5",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "9"
     },
     "9": {
       "method": "set",
       "ln": "9",
-      "output": null,
       "name": [
         "c"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "13"
     },
     "13": {
       "method": "set",
       "ln": "13",
-      "output": null,
       "name": [
         "d"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "20"
     },
     "20": {
       "method": "set",
       "ln": "20",
-      "output": null,
       "name": [
         "f"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/multiline_comments3.json
+++ b/tests/e2e/multiline_comments3.json
@@ -3,60 +3,36 @@
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "6"
     },
     "6": {
       "method": "set",
       "ln": "6",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "10"
     },
     "10": {
       "method": "set",
       "ln": "10",
-      "output": null,
       "name": [
         "c"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "2",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/multiline_comments4.json
+++ b/tests/e2e/multiline_comments4.json
@@ -3,114 +3,69 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "6"
     },
     "6": {
       "method": "set",
       "ln": "6",
-      "output": null,
       "name": [
         "c"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "8"
     },
     "8": {
       "method": "set",
       "ln": "8",
-      "output": null,
       "name": [
         "d"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "11"
     },
     "11": {
       "method": "set",
       "ln": "11",
-      "output": null,
       "name": [
         "e"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "15"
     },
     "15": {
       "method": "set",
       "ln": "15",
-      "output": null,
       "name": [
         "f"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/multiline_comments_long_lines.json
+++ b/tests/e2e/multiline_comments_long_lines.json
@@ -3,96 +3,58 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "5"
     },
     "5": {
       "method": "set",
       "ln": "5",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         2
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "9"
     },
     "9": {
       "method": "set",
       "ln": "9",
-      "output": null,
       "name": [
         "c"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         4
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "13"
     },
     "13": {
       "method": "set",
       "ln": "13",
-      "output": null,
       "name": [
         "d"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         5
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "17"
     },
     "17": {
       "method": "set",
       "ln": "17",
-      "output": null,
       "name": [
         "e"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         5
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/multiline_comments_tabs_trailing.json
+++ b/tests/e2e/multiline_comments_tabs_trailing.json
@@ -3,78 +3,47 @@
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "9"
     },
     "9": {
       "method": "set",
       "ln": "9",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         2
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "12"
     },
     "12": {
       "method": "set",
       "ln": "12",
-      "output": null,
       "name": [
         "c"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         3
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "19"
     },
     "19": {
       "method": "set",
       "ln": "19",
-      "output": null,
       "name": [
         "d"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         4
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "2",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/normal_when.json
+++ b/tests/e2e/normal_when.json
@@ -6,14 +6,9 @@
       "output": [
         "s"
       ],
-      "name": null,
       "service": "http",
       "command": "server",
-      "function": null,
-      "args": [],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
@@ -22,10 +17,8 @@
       "output": [
         "client"
       ],
-      "name": null,
       "service": "s",
       "command": "listen",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -45,25 +38,18 @@
         }
       ],
       "enter": "3",
-      "exit": null,
       "parent": "1",
       "next": "3"
     },
     "3": {
       "method": "set",
       "ln": "3",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "2"
     }
   },
@@ -71,7 +57,5 @@
     "http"
   ],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/obj_with_mutation.json
+++ b/tests/e2e/obj_with_mutation.json
@@ -3,13 +3,9 @@
     "1.1": {
       "method": "mutation",
       "ln": "1.1",
-      "output": null,
       "name": [
         "p-1.1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         1,
         {
@@ -18,21 +14,14 @@
           "arguments": []
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "dict",
@@ -51,15 +40,9 @@
             ]
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/obj_with_service.json
+++ b/tests/e2e/obj_with_service.json
@@ -3,13 +3,11 @@
     "1.1": {
       "method": "execute",
       "ln": "1.1",
-      "output": [],
       "name": [
         "p-1.1"
       ],
       "service": "my_service",
       "command": "command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -17,21 +15,14 @@
           "argument": 1
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "dict",
@@ -57,17 +48,12 @@
             ]
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
     "my_service"
   ],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/return_with_mutation.json
+++ b/tests/e2e/return_with_mutation.json
@@ -3,45 +3,28 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "random",
-      "args": [],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "my_int"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         5
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "3.1"
     },
     "3.1": {
       "method": "mutation",
       "ln": "3.1",
-      "output": null,
       "name": [
         "p-3.1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -55,19 +38,12 @@
           "arguments": []
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "3"
     },
     "3": {
       "method": "return",
       "ln": "3",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -76,14 +52,10 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "random": "1"
   },

--- a/tests/e2e/return_with_service.json
+++ b/tests/e2e/return_with_service.json
@@ -3,41 +3,24 @@
     "1": {
       "method": "function",
       "ln": "1",
-      "output": [],
-      "name": null,
-      "service": null,
-      "command": null,
       "function": "random",
-      "args": [],
       "enter": "2.1",
-      "exit": null,
-      "parent": null,
       "next": "2.1"
     },
     "2.1": {
       "method": "execute",
       "ln": "2.1",
-      "output": [],
       "name": [
         "p-2.1"
       ],
       "service": "my_random_service",
       "command": "get_integer",
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
       "parent": "1",
       "next": "2"
     },
     "2": {
       "method": "return",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -46,8 +29,6 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
@@ -55,7 +36,6 @@
     "my_random_service"
   ],
   "entrypoint": "1",
-  "modules": {},
   "functions": {
     "random": "1"
   },

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -10,6 +10,7 @@ from click import unstyle
 from pytest import mark
 
 from storyscript.Api import Api
+from storyscript.App import _clean_dict
 from storyscript.exceptions import StoryError
 
 test_dir = path.dirname(path.realpath(__file__))
@@ -20,7 +21,7 @@ test_files = list(map(lambda e: path.relpath(e, test_dir),
 
 # compile a story and compare its tree with the expected tree
 def run_test_story(source, expected_story):
-    result = Api.loads(source)
+    result = _clean_dict(Api.loads(source))
     del result['version']
     del expected_story['version']
     assert result == expected_story

--- a/tests/e2e/service_mutation.json
+++ b/tests/e2e/service_mutation.json
@@ -3,13 +3,11 @@
     "1.1": {
       "method": "execute",
       "ln": "1.1",
-      "output": [],
       "name": [
         "p-1.1"
       ],
       "service": "http",
       "command": "get",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -22,21 +20,14 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "mutation",
       "ln": "1",
-      "output": null,
       "name": [
         "lines"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -58,17 +49,12 @@
             }
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
     "http"
   ],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/service_mutation2.json
+++ b/tests/e2e/service_mutation2.json
@@ -3,13 +3,11 @@
     "1": {
       "method": "execute",
       "ln": "1",
-      "output": [],
       "name": [
         "diff"
       ],
       "service": "http",
       "command": "get",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -22,21 +20,14 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "mutation",
       "ln": "2",
-      "output": null,
       "name": [
         "lines"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -58,17 +49,12 @@
             }
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
   "services": [
     "http"
   ],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/strings_with_pound.json
+++ b/tests/e2e/strings_with_pound.json
@@ -3,90 +3,59 @@
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "string",
           "string": "#"
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "6"
     },
     "6": {
       "method": "set",
       "ln": "6",
-      "output": null,
       "name": [
         "b"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "string",
           "string": ".#."
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "8"
     },
     "8": {
       "method": "set",
       "ln": "8",
-      "output": null,
       "name": [
         "c"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "string",
           "string": "###"
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "10"
     },
     "10": {
       "method": "set",
       "ln": "10",
-      "output": null,
       "name": [
         "d"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "string",
           "string": "###..###"
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "2",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/templated_strings.json
+++ b/tests/e2e/templated_strings.json
@@ -3,13 +3,9 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "t1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -32,21 +28,14 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "t2"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -83,21 +72,14 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "3"
     },
     "3": {
       "method": "set",
       "ln": "3",
-      "output": null,
       "name": [
         "t3"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -106,21 +88,14 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "t4"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -144,15 +119,9 @@
             }
           ]
         }
-      ],
-      "enter": null,
-      "exit": null,
-      "parent": null
+      ]
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/unary_not_if.json
+++ b/tests/e2e/unary_not_if.json
@@ -3,11 +3,6 @@
     "1": {
       "method": "if",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "expression",
@@ -23,27 +18,14 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "return",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/update
+++ b/tests/e2e/update
@@ -3,7 +3,7 @@
 # Small e2e update tool
 # This script can be used to automatically create or update the output/error
 # file of an e2e story test.
-# Required tools: 'parallel', 'jq'
+# Required tools: 'parallel' (for 'all')
 ################################################################################
 
 set -uo pipefail
@@ -44,11 +44,6 @@ if [ "${1:-x}" == "x" ] ; then
 	exit 1
 fi
 
-if ! command -v jq > /dev/null 2>&1 ; then
-    error "ERROR: 'jq' is not installed, but required."
-    exit 1
-fi
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # shortcut for running in parallel
@@ -83,7 +78,7 @@ story="${file}.story"
 output_json="${file}.json"
 output_error="${file}.error"
 
-output="$(cd "$SCRIPT_DIR/../.." && python -m storyscript compile -j --concise "${story}" 2>&1)"
+output="$(cd "$SCRIPT_DIR/../.." && python -m storyscript compile -j --concise --first "${story}" 2>&1)"
 exit_code=$?
 
 # depending on whether the compiler failed, we want to write the
@@ -91,8 +86,7 @@ exit_code=$?
 if [ $exit_code -eq 0 ] ; then
     echo "> $(relpath "$output_json")"
     echo "$output" | \
-    sed 's/"version": ".*"/"version": null/' | \
-    jq ".stories[\"${story}\"]"> "${output_json}"
+    sed 's/"version": ".*"/"version": null/' > "${output_json}"
 else
     echo "> $output_error"
     # SS failed, write error file

--- a/tests/e2e/update
+++ b/tests/e2e/update
@@ -83,7 +83,7 @@ story="${file}.story"
 output_json="${file}.json"
 output_error="${file}.error"
 
-output="$(cd "$SCRIPT_DIR/../.." && python -m storyscript compile -j "${story}" 2>&1)"
+output="$(cd "$SCRIPT_DIR/../.." && python -m storyscript compile -j --concise "${story}" 2>&1)"
 exit_code=$?
 
 # depending on whether the compiler failed, we want to write the

--- a/tests/e2e/when_enter_line_fake_assignment.json
+++ b/tests/e2e/when_enter_line_fake_assignment.json
@@ -6,14 +6,9 @@
       "output": [
         "s"
       ],
-      "name": null,
       "service": "http",
       "command": "server",
-      "function": null,
-      "args": [],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
@@ -22,10 +17,8 @@
       "output": [
         "req"
       ],
-      "name": null,
       "service": "s",
       "command": "listen",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -37,36 +30,26 @@
         }
       ],
       "enter": "3.1",
-      "exit": null,
       "parent": "1",
       "next": "3.1"
     },
     "3.1": {
       "method": "execute",
       "ln": "3.1",
-      "output": [],
       "name": [
         "p-3.1"
       ],
       "service": "fullcontact",
       "command": "person",
-      "function": null,
-      "args": [],
-      "enter": null,
-      "exit": null,
       "parent": "2",
       "next": "3"
     },
     "3": {
       "method": "set",
       "ln": "3",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -75,26 +58,18 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "2",
       "next": "4"
     },
     "4": {
       "method": "set",
       "ln": "4",
-      "output": null,
       "name": [
         "a"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         4
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
@@ -103,7 +78,5 @@
     "http"
   ],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/while_complex_expressions.json
+++ b/tests/e2e/while_complex_expressions.json
@@ -3,31 +3,20 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "i"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2.1"
     },
     "2.1": {
       "method": "mutation",
       "ln": "2.1",
-      "output": null,
       "name": [
         "p-2.1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -47,19 +36,11 @@
           ]
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "while",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -69,18 +50,13 @@
         }
       ],
       "enter": "3",
-      "exit": null,
-      "parent": null,
       "next": "3"
     },
     "3": {
       "method": "execute",
       "ln": "3",
-      "output": [],
-      "name": null,
       "service": "alpine",
       "command": "echo",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -93,8 +69,6 @@
           }
         }
       ],
-      "enter": null,
-      "exit": null,
       "parent": "2"
     }
   },
@@ -102,7 +76,5 @@
     "alpine"
   ],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/while_with_mutation.json
+++ b/tests/e2e/while_with_mutation.json
@@ -3,31 +3,20 @@
     "1": {
       "method": "set",
       "ln": "1",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         5
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2.1"
     },
     "2.1": {
       "method": "mutation",
       "ln": "2.1",
-      "output": null,
       "name": [
         "p-2.1"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -41,19 +30,11 @@
           "arguments": []
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "while",
       "ln": "2",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -63,27 +44,14 @@
         }
       ],
       "enter": "3",
-      "exit": null,
-      "parent": null,
       "next": "3"
     },
     "3": {
       "method": "break",
       "ln": "3",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
-      "args": null,
-      "enter": null,
-      "exit": null,
       "parent": "2"
     }
   },
-  "services": [],
   "entrypoint": "1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/e2e/while_with_service.json
+++ b/tests/e2e/while_with_service.json
@@ -3,13 +3,11 @@
     "1.1": {
       "method": "execute",
       "ln": "1.1",
-      "output": [],
       "name": [
         "p-1.1"
       ],
       "service": "my_service",
       "command": "my_command",
-      "function": null,
       "args": [
         {
           "$OBJECT": "argument",
@@ -17,19 +15,11 @@
           "argument": 42
         }
       ],
-      "enter": null,
-      "exit": null,
-      "parent": null,
       "next": "1"
     },
     "1": {
       "method": "while",
       "ln": "1",
-      "output": null,
-      "name": null,
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         {
           "$OBJECT": "path",
@@ -39,25 +29,17 @@
         }
       ],
       "enter": "2",
-      "exit": null,
-      "parent": null,
       "next": "2"
     },
     "2": {
       "method": "set",
       "ln": "2",
-      "output": null,
       "name": [
         "x"
       ],
-      "service": null,
-      "command": null,
-      "function": null,
       "args": [
         0
       ],
-      "enter": null,
-      "exit": null,
       "parent": "1"
     }
   },
@@ -65,7 +47,5 @@
     "my_service"
   ],
   "entrypoint": "1.1",
-  "modules": {},
-  "functions": {},
   "version": null
 }

--- a/tests/unittests/Cli.py
+++ b/tests/unittests/Cli.py
@@ -97,7 +97,8 @@ def test_cli_compile_with_ignore_option(runner, app):
     runner.invoke(Cli.compile, ['path/fake.story',
                                 '--ignore', 'path/sub_dir/my_fake.story'])
     App.compile.assert_called_with('path/fake.story', ebnf=None,
-                                   ignored_path='path/sub_dir/my_fake.story')
+                                   ignored_path='path/sub_dir/my_fake.story',
+                                   concise=False)
 
 
 def test_cli_parse_with_ignore_option(runner, app):
@@ -212,7 +213,7 @@ def test_cli_compile(patch, runner, echo, app):
     patch.object(click, 'style')
     runner.invoke(Cli.compile, [])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None)
+                                   ignored_path=None, concise=False)
     click.style.assert_called_with('Script syntax passed!', fg='green')
     click.echo.assert_called_with(click.style())
 
@@ -223,7 +224,7 @@ def test_cli_compile_path(patch, runner, app):
     """
     runner.invoke(Cli.compile, ['/path'])
     App.compile.assert_called_with('/path', ebnf=None,
-                                   ignored_path=None)
+                                   ignored_path=None, concise=False)
 
 
 def test_cli_compile_output_file(patch, runner, app):
@@ -243,15 +244,25 @@ def test_cli_compile_silent(runner, echo, app, option):
     """
     result = runner.invoke(Cli.compile, [option])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None)
+                                   ignored_path=None, concise=False)
     assert result.output == ''
     assert click.echo.call_count == 0
+
+
+@mark.parametrize('option', ['--concise', '-c'])
+def test_cli_compile_concise(runner, echo, app, option):
+    """
+    Ensures --concise makes everything concise
+    """
+    runner.invoke(Cli.compile, [option])
+    App.compile.assert_called_with(os.getcwd(), ebnf=None,
+                                   ignored_path=None, concise=True)
 
 
 def test_cli_compile_debug(runner, echo, app):
     runner.invoke(Cli.compile, ['--debug'])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None)
+                                   ignored_path=None, concise=False)
 
 
 @mark.parametrize('option', ['--json', '-j'])
@@ -261,14 +272,14 @@ def test_cli_compile_json(runner, echo, app, option):
     """
     runner.invoke(Cli.compile, [option])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None)
+                                   ignored_path=None, concise=False)
     click.echo.assert_called_with(App.compile())
 
 
 def test_cli_compile_ebnf(runner, echo, app):
     runner.invoke(Cli.compile, ['--ebnf', 'test.ebnf'])
     App.compile.assert_called_with(os.getcwd(), ebnf='test.ebnf',
-                                   ignored_path=None)
+                                   ignored_path=None, concise=False)
 
 
 def test_cli_compile_ice(runner, echo, app):

--- a/tests/unittests/Cli.py
+++ b/tests/unittests/Cli.py
@@ -98,7 +98,7 @@ def test_cli_compile_with_ignore_option(runner, app):
                                 '--ignore', 'path/sub_dir/my_fake.story'])
     App.compile.assert_called_with('path/fake.story', ebnf=None,
                                    ignored_path='path/sub_dir/my_fake.story',
-                                   concise=False)
+                                   concise=False, first=False)
 
 
 def test_cli_parse_with_ignore_option(runner, app):
@@ -213,7 +213,8 @@ def test_cli_compile(patch, runner, echo, app):
     patch.object(click, 'style')
     runner.invoke(Cli.compile, [])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None, concise=False)
+                                   ignored_path=None, concise=False,
+                                   first=False)
     click.style.assert_called_with('Script syntax passed!', fg='green')
     click.echo.assert_called_with(click.style())
 
@@ -224,7 +225,8 @@ def test_cli_compile_path(patch, runner, app):
     """
     runner.invoke(Cli.compile, ['/path'])
     App.compile.assert_called_with('/path', ebnf=None,
-                                   ignored_path=None, concise=False)
+                                   ignored_path=None, concise=False,
+                                   first=False)
 
 
 def test_cli_compile_output_file(patch, runner, app):
@@ -244,7 +246,8 @@ def test_cli_compile_silent(runner, echo, app, option):
     """
     result = runner.invoke(Cli.compile, [option])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None, concise=False)
+                                   ignored_path=None, concise=False,
+                                   first=False)
     assert result.output == ''
     assert click.echo.call_count == 0
 
@@ -256,13 +259,26 @@ def test_cli_compile_concise(runner, echo, app, option):
     """
     runner.invoke(Cli.compile, [option])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None, concise=True)
+                                   ignored_path=None, concise=True,
+                                   first=False)
+
+
+@mark.parametrize('option', ['--first', '-f'])
+def test_cli_compile_first(runner, echo, app, option):
+    """
+    Ensures --first only yields the first story
+    """
+    runner.invoke(Cli.compile, [option])
+    App.compile.assert_called_with(os.getcwd(), ebnf=None,
+                                   ignored_path=None, concise=False,
+                                   first=True)
 
 
 def test_cli_compile_debug(runner, echo, app):
     runner.invoke(Cli.compile, ['--debug'])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None, concise=False)
+                                   ignored_path=None, concise=False,
+                                   first=False)
 
 
 @mark.parametrize('option', ['--json', '-j'])
@@ -272,14 +288,16 @@ def test_cli_compile_json(runner, echo, app, option):
     """
     runner.invoke(Cli.compile, [option])
     App.compile.assert_called_with(os.getcwd(), ebnf=None,
-                                   ignored_path=None, concise=False)
+                                   ignored_path=None, concise=False,
+                                   first=False)
     click.echo.assert_called_with(App.compile())
 
 
 def test_cli_compile_ebnf(runner, echo, app):
     runner.invoke(Cli.compile, ['--ebnf', 'test.ebnf'])
     App.compile.assert_called_with(os.getcwd(), ebnf='test.ebnf',
-                                   ignored_path=None, concise=False)
+                                   ignored_path=None, concise=False,
+                                   first=False)
 
 
 def test_cli_compile_ice(runner, echo, app):


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/661

Adds:
- `--concise` (remove all falsy values in the JSON output)
- `--first` (only prints the JSON for the first story an thus removes the need for the manual filtering with `jq`) 