### PR TITLE
refactor(Parser): don't recreate instances of the parser

### DIFF
--- a/storyscript/App.py
+++ b/storyscript/App.py
@@ -2,7 +2,6 @@
 import json
 
 from .Bundle import Bundle
-from .compiler.Preprocessor import Preprocessor
 from .exceptions import StoryError
 from .parser import Grammar
 
@@ -18,11 +17,7 @@ class App:
         Parses stories found in path, returning their trees
         """
         bundle = Bundle.from_path(path, ignored_path=ignored_path)
-        stories = bundle.bundle_trees(ebnf=ebnf)
-        if preprocess:
-            for story, tree in stories.items():
-                stories[story] = Preprocessor.process(tree)
-        return stories
+        return bundle.bundle_trees(ebnf=ebnf, preprocess=preprocess)
 
     @staticmethod
     def compile(path, ignored_path=None, ebnf=None, concise=False,

--- a/storyscript/Story.py
+++ b/storyscript/Story.py
@@ -56,11 +56,10 @@ class Story:
         """
         return StoryError(error, self.story, path=self.path)
 
-    def parse(self, ebnf=None):
+    def parse(self, parser):
         """
         Parses the story, storing the tree
         """
-        parser = Parser(ebnf=ebnf)
         e = None
         try:
             self.tree = parser.parse(self.story)
@@ -97,16 +96,18 @@ class Story:
         if e is not None:
             raise e
 
-    def lex(self, ebnf=None):
+    def lex(self, parser):
         """
         Lexes a story
         """
-        return Parser(ebnf=ebnf).lex(self.story)
+        return parser.lex(self.story)
 
-    def process(self, ebnf=None):
+    def process(self, parser=None):
         """
         Parse and compile a story, returning the compiled JSON
         """
-        self.parse(ebnf=ebnf)
+        if parser is None:
+            parser = Parser()
+        self.parse(parser=parser)
         self.compile()
         return self.compiled

--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -440,7 +440,7 @@ class Compiler:
 
     @classmethod
     def compile(cls, tree, debug=False):
-        tree = Preprocessor.process(tree)
+        tree = Preprocessor(parser=tree.parser).process(tree)
         compiler = cls.compiler()
         compiler.parse_tree(tree)
         lines = compiler.lines

--- a/storyscript/compiler/Preprocessor.py
+++ b/storyscript/compiler/Preprocessor.py
@@ -9,6 +9,9 @@ class Preprocessor:
     too complicated for the Transformer, before the tree is compiled.
     """
 
+    def __init__(self, parser):
+        self.parser = parser
+
     @staticmethod
     def fake_tree(block):
         """
@@ -92,8 +95,8 @@ class Preprocessor:
     def is_inline_expression(n):
         return hasattr(n, 'data') and n.data == 'inline_expression'
 
-    @classmethod
-    def process(cls, tree):
+    def process(self, tree):
         pred = Preprocessor.is_inline_expression
-        cls.visit(tree, None, None, pred, cls.replace_expression, parent=None)
+        self.visit(tree, None, None, pred, self.replace_expression,
+                   parent=None)
         return tree

--- a/storyscript/parser/Parser.py
+++ b/storyscript/parser/Parser.py
@@ -17,6 +17,7 @@ class Parser:
     def __init__(self, algo='lalr', ebnf=None):
         self.algo = algo
         self.ebnf = ebnf
+        self.lark = self._lark()
 
     @staticmethod
     def indenter():
@@ -38,7 +39,7 @@ class Parser:
                 return f.read()
         return Grammar().build()
 
-    def lark(self):
+    def _lark(self):
         """
         Get the grammar and initialize Lark.
         """
@@ -51,12 +52,14 @@ class Parser:
         if source == '':
             return Tree('empty', [])
         source = '{}\n'.format(source)
-        lark = self.lark()
+        lark = self.lark
         tree = lark.parse(source)
-        return self.transformer().transform(tree)
+        result = self.transformer().transform(tree)
+        result.parser = self
+        return result
 
     def lex(self, source):
         """
         Lexes the source string
         """
-        return self.lark().lex(source)
+        return self.lark.lex(source)

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -915,11 +915,14 @@ def test_compiler_compiler(patch):
     assert isinstance(result, Compiler)
 
 
-def test_compiler_compile(patch):
+def test_compiler_compile(patch, magic):
+    patch.init(Preprocessor)
     patch.object(Preprocessor, 'process')
     patch.many(Compiler, ['parse_tree', 'compiler'])
-    result = Compiler.compile('tree')
-    Preprocessor.process.assert_called_with('tree')
+    tree = magic()
+    result = Compiler.compile(tree)
+    Preprocessor.__init__.assert_called_with(parser=tree.parser)
+    Preprocessor.process.assert_called_with(tree)
     Compiler.compiler().parse_tree.assert_called_with(Preprocessor.process())
     lines = Compiler.compiler().lines
     expected = {'tree': lines.lines, 'version': version,

--- a/tests/unittests/compiler/Preprocessor.py
+++ b/tests/unittests/compiler/Preprocessor.py
@@ -11,7 +11,7 @@ from storyscript.parser import Tree
 def preprocessor(patch):
     patch.init(FakeTree)
     patch.object(Preprocessor, 'fake_tree', return_value=FakeTree(None))
-    return Preprocessor()
+    return Preprocessor(parser=None)
 
 
 @fixture


### PR DESCRIPTION
Required for https://github.com/storyscript/storyscript/pull/678, fixes https://github.com/storyscript/storyscript/issues/685

Creating the parser (i.e. building the EBNF grammar and parsing it by Lark) is very expensive. This should only be done once. This PR moves creating the instance of `parser` up in the call tree and saves an instances of the `parser` in the root node of the tree for easy access by the compiler.