### PR TITLE
refactor(compiler): Remove sorting in Lines

### DIFF
--- a/storyscript/compiler/Compiler.py
+++ b/storyscript/compiler/Compiler.py
@@ -113,12 +113,11 @@ class Compiler:
         """
         Compiles arguments. This is called only for nested arguments.
         """
-        previous_line = self.lines.last()
-        if previous_line:
-            line = self.lines.lines[previous_line]
-            if line['method'] != 'execute':
+        prev_line = self.lines.last()
+        if prev_line is not None:
+            if prev_line['method'] != 'execute':
                 raise StorySyntaxError('arguments_noservice', tree=tree)
-            line['args'] = line['args'] + Objects.arguments(tree)
+            prev_line['args'] = prev_line['args'] + Objects.arguments(tree)
             return
         raise StorySyntaxError('arguments_noservice', tree=tree)
 
@@ -193,7 +192,7 @@ class Compiler:
                 output_name = self.find_parent_with_output(tree, parent)
                 tree.service.path = Objects.name_to_path(output_name[0])
             self.service(tree.service, nested_block, parent)
-            self.lines.lines[self.lines.last()]['method'] = 'when'
+            self.lines.last()['method'] = 'when'
         elif tree.path:
             args = [Objects.path(tree.path)]
             output = self.output(tree.output)
@@ -323,12 +322,12 @@ class Compiler:
         """
         Compiles an indented mutation.
         """
-        previous_line = self.lines.last()
-        if previous_line:
-            line = self.lines.lines[previous_line]
-            if line['method'] != 'mutation':
+        prev_line = self.lines.last()
+        if prev_line is not None:
+            if prev_line['method'] != 'mutation':
                 raise StorySyntaxError('arguments_nomutation', tree=tree)
-            line['args'] = line['args'] + self.chained_mutations(tree)
+            prev_line['args'] = prev_line['args'] + \
+                self.chained_mutations(tree)
             return
         raise StorySyntaxError('arguments_nomutation', tree=tree)
 
@@ -445,5 +444,5 @@ class Compiler:
         compiler.parse_tree(tree)
         lines = compiler.lines
         return {'tree': lines.lines, 'services': lines.get_services(),
-                'entrypoint': lines.first(), 'modules': lines.modules,
+                'entrypoint': lines.entrypoint(), 'modules': lines.modules,
                 'functions': lines.functions, 'version': version}

--- a/tests/unittests/compiler/Compiler.py
+++ b/tests/unittests/compiler/Compiler.py
@@ -161,8 +161,8 @@ def test_compiler_assignment_function_call(patch, compiler, lines, tree):
 
 def test_compiler_arguments(patch, compiler, lines, tree):
     patch.object(Objects, 'arguments')
-    lines.last.return_value = '1'
     lines.lines = {'1': {'method': 'execute', 'args': ['args']}}
+    lines.last.return_value = lines.lines['1']
     compiler.arguments(tree, '0')
     Objects.arguments.assert_called_with(tree)
     assert lines.lines['1']['args'] == ['args'] + Objects.arguments()
@@ -186,8 +186,8 @@ def test_compiler_arguments_not_execute(patch, compiler, lines, tree):
     """
     patch.init(StorySyntaxError)
     patch.object(Objects, 'arguments')
-    lines.last.return_value = '1'
     lines.lines = {'1': {'method': 'whatever'}}
+    lines.last.return_value = lines.lines['1']
     with raises(StorySyntaxError):
         compiler.arguments(tree, '0')
     error = 'arguments_noservice'
@@ -481,7 +481,7 @@ def test_compiler_find_parent_with_no_service(patch, compiler, lines, tree,
 def test_compiler_when(patch, compiler, lines, tree):
     patch.object(Compiler, 'service')
     lines.lines = {'1': {}}
-    lines.last.return_value = '1'
+    lines.last.return_value = lines.lines['1']
     compiler.when(tree, 'nested_block', '1')
     Compiler.service.assert_called_with(tree.service, 'nested_block', '1')
     assert lines.lines['1']['method'] == 'when'
@@ -497,7 +497,7 @@ def test_compiler_when_condensed(patch, compiler, lines, tree, magic):
     tree.service.path = '.path.'
     sf.command = None
     lines.lines = {'1': {}}
-    lines.last.return_value = '1'
+    lines.last.return_value = lines.lines['1']
     compiler.when(tree, 'nested_block', '1')
     Compiler.service.assert_called_with(tree.service, 'nested_block', '1')
     assert lines.lines['1']['method'] == 'when'
@@ -730,8 +730,8 @@ def test_compiler_mutation_block_from_service(patch, compiler, lines, tree):
 
 def test_compiler_indented_chain(patch, compiler, lines, tree):
     patch.object(Compiler, 'chained_mutations')
-    lines.last.return_value = '1'
     lines.lines = {'1': {'method': 'mutation', 'args': ['args']}}
+    lines.last.return_value = lines.lines['1']
     compiler.indented_chain(tree, '0')
     Compiler.chained_mutations.assert_called_with(tree)
     assert lines.lines['1']['args'] == ['args'] + Compiler.chained_mutations()
@@ -755,7 +755,6 @@ def test_compiler_indented_chain_not_mutation(patch, compiler, lines, tree):
     """
     patch.init(StorySyntaxError)
     patch.object(Compiler, 'chained_mutations')
-    lines.last.return_value = '1'
     lines.lines = {'1': {'method': 'whatever'}}
     with raises(StorySyntaxError):
         compiler.indented_chain(tree, '0')
@@ -919,6 +918,7 @@ def test_compiler_compile(patch, magic):
     patch.init(Preprocessor)
     patch.object(Preprocessor, 'process')
     patch.many(Compiler, ['parse_tree', 'compiler'])
+    patch.object(Lines, 'entrypoint')
     tree = magic()
     result = Compiler.compile(tree)
     Preprocessor.__init__.assert_called_with(parser=tree.parser)
@@ -927,5 +927,5 @@ def test_compiler_compile(patch, magic):
     lines = Compiler.compiler().lines
     expected = {'tree': lines.lines, 'version': version,
                 'services': lines.get_services(), 'functions': lines.functions,
-                'entrypoint': lines.first(), 'modules': lines.modules}
+                'entrypoint': lines.entrypoint(), 'modules': lines.modules}
     assert result == expected


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/658

Lines are not longer constantly resorted. This is good for performance, reduced complexity and also required for https://github.com/storyscript/storyscript/issues/688