### PR TITLE
feat(parser): cache the instance of the Storyscript parser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,16 @@ jobs:
                   #  -not -name '*__init__.py')
 
             - run:
+                name: run pep8 linter
+                command: |
+                    . venv/bin/activate
+                    tox -e pep8
+
+            - run:
                 name: run unit tests
                 command: |
                     . venv/bin/activate
-                    tox -e pep8,unit
+                    tox -e unit
 
             - run:
                 name: collect unit coverage

--- a/storyscript/Bundle.py
+++ b/storyscript/Bundle.py
@@ -102,7 +102,9 @@ class Bundle:
         return services
 
     def parser(self, ebnf):
-        return Parser(ebnf=ebnf)
+        if ebnf is not None:
+            return Parser(ebnf=ebnf)
+        return None
 
     def parse(self, stories, parser):
         """

--- a/storyscript/parser/Indenter.py
+++ b/storyscript/parser/Indenter.py
@@ -7,6 +7,9 @@ from lark.lexer import Token
 
 class Indenter:
     def __init__(self):
+        self.reset()
+
+    def reset(self):
         self.paren_level = 0
         self.indent_level = [0]
 
@@ -38,6 +41,7 @@ class Indenter:
                         '%s != %s' % (indent, self.indent_level[-1])
 
     def process(self, stream):
+        self.reset()
         for token in stream:
             if token.type == self.NL_type:
                 for t in self.handle_nl(token):

--- a/tests/integration/Api.py
+++ b/tests/integration/Api.py
@@ -93,7 +93,7 @@ def test_api_load_ice():
 Please report at https://github.com/storyscript/storyscript/issues"""
 
 
-def test_compiler_only_comments(parser):
+def test_compiler_only_comments():
     api_result = Api.load_map({'a.story': '# foo\n'})
     result = api_result['stories']['a.story']
     assert result['tree'] == {}

--- a/tests/integration/compiler/Assignments.py
+++ b/tests/integration/compiler/Assignments.py
@@ -1,121 +1,110 @@
 # -*- coding: utf-8 -*-
-from storyscript.compiler import Compiler
+from storyscript.Api import Api
 
 
-def test_assignments_true(parser):
+def test_assignments_true():
     """
     Ensures that assignments to true are compiled correctly
     """
-    tree = parser.parse('a = true')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = true')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['1']['args'] == [True]
 
 
-def test_assignments_false(parser):
+def test_assignments_false():
     """
     Ensures that assignments to false are compiled correctly
     """
-    tree = parser.parse('a = false')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = false')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['1']['args'] == [False]
 
 
-def test_assignments_null(parser):
+def test_assignments_null():
     """
     Ensures that assignments to null are compiled correctly
     """
-    tree = parser.parse('a = null')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = null')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['1']['args'] == [None]
 
 
-def test_assignments_int(parser):
+def test_assignments_int():
     """
     Ensures that assignments to integers are compiled correctly
     """
-    tree = parser.parse('a = 0')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = 0')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['1']['args'] == [0]
 
 
-def test_assignments_int_positive(parser):
+def test_assignments_int_positive():
     """
     Ensures that assignments to positive integers are compiled correctly
     """
-    tree = parser.parse('a = +3')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = +3')
     assert result['tree']['1']['args'] == [3]
 
 
-def test_assignments_float(parser):
+def test_assignments_float():
     """
     Ensures that assignments to floats are compiled correctly
     """
-    tree = parser.parse('a = 3.14')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = 3.14')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['1']['args'] == [3.14]
 
 
-def test_assignments_string(parser):
+def test_assignments_string():
     """
     Ensures that assignments to strings are compiled correctly
     """
-    tree = parser.parse('a = "cake"')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = "cake"')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     expected = [{'$OBJECT': 'string', 'string': 'cake'}]
     assert result['tree']['1']['args'] == expected
 
 
-def test_assignments_list(parser):
+def test_assignments_list():
     """
     Ensures that assignments to lists are compiled correctly
     """
-    tree = parser.parse('a = [1, 2]')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = [1, 2]')
     args = [{'$OBJECT': 'list', 'items': [1, 2]}]
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == args
 
 
-def test_assignments_list_empty(parser):
+def test_assignments_list_empty():
     """
     Ensures that assignments to empty lists are compiled correctly
     """
-    tree = parser.parse('a = []')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = []')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{'$OBJECT': 'list', 'items': []}]
 
 
-def test_assignments_list_multiline(parser):
+def test_assignments_list_multiline():
     """
     Ensures that assignments to multiline lists are compiled correctly
     """
-    tree = parser.parse('a = [\n\t1,\n\t2\n]')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = [\n\t1,\n\t2\n]')
     args = [{'$OBJECT': 'list', 'items': [1, 2]}]
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == args
 
 
-def test_assignments_object(parser):
+def test_assignments_object():
     """
     Ensures that assignments to objects are compiled correctly
     """
-    tree = parser.parse("a = {'x': 1, 'y': 3}")
-    result = Compiler.compile(tree)
+    result = Api.loads("a = {'x': 1, 'y': 3}")
     items = [[{'$OBJECT': 'string', 'string': 'x'}, 1],
              [{'$OBJECT': 'string', 'string': 'y'}, 3]]
     arg = {'$OBJECT': 'dict', 'items': items}
@@ -124,22 +113,20 @@ def test_assignments_object(parser):
     assert result['tree']['1']['args'] == [arg]
 
 
-def test_assignments_object_empty(parser):
+def test_assignments_object_empty():
     """
     Ensures that assignments to empty objects are compiled correctly
     """
-    tree = parser.parse('a = {}')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = {}')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{'$OBJECT': 'dict', 'items': []}]
 
 
-def test_assignments_object_multiline(parser):
+def test_assignments_object_multiline():
     """
     Ensures that assignments to multiline objects are compiled correctly
     """
-    tree = parser.parse("a = {\n\t'x': 1,\n\t'y': 3\n}")
-    result = Compiler.compile(tree)
+    result = Api.loads("a = {\n\t'x': 1,\n\t'y': 3\n}")
     items = [[{'$OBJECT': 'string', 'string': 'x'}, 1],
              [{'$OBJECT': 'string', 'string': 'y'}, 3]]
     arg = {'$OBJECT': 'dict', 'items': items}
@@ -147,32 +134,29 @@ def test_assignments_object_multiline(parser):
     assert result['tree']['1']['args'] == [arg]
 
 
-def test_assignments_regular_expression(parser):
+def test_assignments_regular_expression():
     """
     Ensures regular expressions are compiled correctly
     """
-    tree = parser.parse('a = /^foo/')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = /^foo/')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['$OBJECT'] == 'regexp'
     assert result['tree']['1']['args'][0]['regexp'] == '/^foo/'
 
 
-def test_assignments_regular_expression_flags(parser):
+def test_assignments_regular_expression_flags():
     """
     Ensures regular expressions with flags are compiled correctly
     """
-    tree = parser.parse('a = /^foo/g')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = /^foo/g')
     assert result['tree']['1']['args'][0]['flags'] == 'g'
 
 
-def test_assignments_sum(parser):
+def test_assignments_sum():
     """
     Ensures assignments to sums are compiled correctly
     """
-    tree = parser.parse('a = 3 + 2')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = 3 + 2')
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['$OBJECT'] == 'expression'
@@ -180,12 +164,11 @@ def test_assignments_sum(parser):
     assert result['tree']['1']['args'][0]['values'] == [3, 2]
 
 
-def test_assignments_multiplications(parser):
+def test_assignments_multiplications():
     """
     Ensures assignments to multiplications are compiled correctly
     """
-    tree = parser.parse('a = 3 * 2')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = 3 * 2')
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['$OBJECT'] == 'expression'
@@ -193,65 +176,59 @@ def test_assignments_multiplications(parser):
     assert result['tree']['1']['args'][0]['values'] == [3, 2]
 
 
-def test_assignments_service(parser):
+def test_assignments_service():
     """
     Ensures that service assignments are compiled correctly
     """
-    tree = parser.parse('a = alpine echo')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = alpine echo')
     assert result['tree']['1']['method'] == 'execute'
     assert result['tree']['1']['name'] == ['a']
 
 
-def test_assignments_inline_expression(parser):
-    tree = parser.parse('a = (alpine echo)')
-    result = Compiler.compile(tree)
+def test_assignments_inline_expression():
+    result = Api.loads('a = (alpine echo)')
     entry = result['entrypoint']
     path = result['tree'][entry]['name']
     assert result['tree']['1']['args'] == [{'$OBJECT': 'path', 'paths': path}]
 
 
-def test_assignments_mutation(parser):
+def test_assignments_mutation():
     """
     Ensures that assigning a mutation on a value is compiled correctly
     """
-    tree = parser.parse('0 increase by:1')
-    result = Compiler.compile(tree)
+    result = Api.loads('0 increase by:1')
     assert result['services'] == []
     assert result['tree']['1']['method'] == 'mutation'
     assert result['tree']['1']['args'][1]['$OBJECT'] == 'mutation'
 
 
-def test_assignments_mutation_variable(parser):
+def test_assignments_mutation_variable():
     """
     Ensures that applying a mutation on a variable is not compiled as a
     service
     """
-    tree = parser.parse('a = 0\na increase by:1')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = 0\na increase by:1')
     assert result['services'] == []
     assert result['tree']['2']['method'] == 'mutation'
     assert result['tree']['2']['args'][1]['$OBJECT'] == 'mutation'
 
 
-def test_assignments_string_escape_single(parser):
+def test_assignments_string_escape_single():
     """
     Ensures that assignments to strings with escaping are compiled correctly
     """
-    tree = parser.parse('a = \'b.\\n.\\\\.\\\'.c\'')
-    result = Compiler.compile(tree)
+    result = Api.loads('a = \'b.\\n.\\\\.\\\'.c\'')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     expected = [{'$OBJECT': 'string', 'string': 'b.\n.\\.\'.c'}]
     assert result['tree']['1']['args'] == expected
 
 
-def test_assignments_string_escape_double(parser):
+def test_assignments_string_escape_double():
     """
     Ensures that assignments to strings with escaping are compiled correctly
     """
-    tree = parser.parse(r'a = "b.\n.\\.\".c"')
-    result = Compiler.compile(tree)
+    result = Api.loads(r'a = "b.\n.\\.\".c"')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     expected = [{'$OBJECT': 'string', 'string': 'b.\n.\\.".c'}]

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 from pytest import mark
 
-from storyscript.compiler import Compiler
+from storyscript.Api import Api
 
 
-def test_compiler_expression_sum(parser):
+def test_compiler_expression_sum():
     """
     Ensures that sums are compiled correctly
     """
-    tree = parser.parse('3 + 2')
-    result = Compiler.compile(tree)
+    result = Api.loads('3 + 2')
     args = [
         {'$OBJECT': 'expression', 'expression': 'sum', 'values': [3, 2]}
     ]
@@ -17,12 +16,11 @@ def test_compiler_expression_sum(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_expression_sum_many(parser):
+def test_compiler_expression_sum_many():
     """
     Ensures that sums of N-numbers are compiled correctly
     """
-    tree = parser.parse('3 + 2 + 1')
-    result = Compiler.compile(tree)
+    result = Api.loads('3 + 2 + 1')
     first_sum = {'$OBJECT': 'expression', 'expression': 'sum',
                  'values': [3, 2]}
     args = [{'$OBJECT': 'expression', 'expression': 'sum',
@@ -31,12 +29,11 @@ def test_compiler_expression_sum_many(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_expression_multiplication(parser):
+def test_compiler_expression_multiplication():
     """
     Ensures that multiplications are compiled correctly
     """
-    tree = parser.parse('3 * 2')
-    result = Compiler.compile(tree)
+    result = Api.loads('3 * 2')
     args = [
         {'$OBJECT': 'expression', 'expression': 'multiplication',
          'values': [3, 2]}
@@ -45,12 +42,11 @@ def test_compiler_expression_multiplication(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_expression_multiplication_many(parser):
+def test_compiler_expression_multiplication_many():
     """
     Ensures that sums of N-numbers are compiled correctly
     """
-    tree = parser.parse('3 * 2 * 1')
-    result = Compiler.compile(tree)
+    result = Api.loads('3 * 2 * 1')
     first_node = {'$OBJECT': 'expression', 'expression': 'multiplication',
                   'values': [3, 2]}
     args = [{'$OBJECT': 'expression', 'expression': 'multiplication',
@@ -59,9 +55,8 @@ def test_compiler_expression_multiplication_many(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_expression_complex(parser):
-    tree = parser.parse('3 * 2 + 1 ^ 5')
-    result = Compiler.compile(tree)
+def test_compiler_expression_complex():
+    result = Api.loads('3 * 2 + 1 ^ 5')
     lhs = {'$OBJECT': 'expression', 'expression': 'multiplication',
            'values': [3, 2]}
     rhs = {'$OBJECT': 'expression', 'expression': 'exponential',
@@ -72,9 +67,8 @@ def test_compiler_expression_complex(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_expression_sum_to_parenthesis(parser):
-    tree = parser.parse('1 + (2 + 3)')
-    result = Compiler.compile(tree)
+def test_compiler_expression_sum_to_parenthesis():
+    result = Api.loads('1 + (2 + 3)')
     rhs = {'$OBJECT': 'expression', 'expression': 'sum', 'values': [2, 3]}
     args = [{'$OBJECT': 'expression', 'expression': 'sum',
              'values': [1, rhs]}]
@@ -82,9 +76,8 @@ def test_compiler_expression_sum_to_parenthesis(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_expression_multiplication_to_parenthesis(parser):
-    tree = parser.parse('1 * (2 + 3)')
-    result = Compiler.compile(tree)
+def test_compiler_expression_multiplication_to_parenthesis():
+    result = Api.loads('1 * (2 + 3)')
     rhs = {'$OBJECT': 'expression', 'expression': 'sum', 'values': [2, 3]}
     args = [{'$OBJECT': 'expression', 'expression': 'multiplication',
              'values': [1, rhs]}]
@@ -92,12 +85,11 @@ def test_compiler_expression_multiplication_to_parenthesis(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_mutation(parser):
+def test_compiler_mutation():
     """
     Ensures that mutations are compiled correctly
     """
-    tree = parser.parse("'hello' length")
-    result = Compiler.compile(tree)
+    result = Api.loads("'hello' length")
     args = [
         {'$OBJECT': 'string', 'string': 'hello'},
         {'$OBJECT': 'mutation', 'mutation': 'length', 'arguments': []}
@@ -110,12 +102,11 @@ def test_compiler_mutation(parser):
     '1 increment then format to:"string"',
     '1 increment\n\tthen format to:"string"'
 ])
-def test_compiler_mutation_chained(parser, source):
+def test_compiler_mutation_chained(source):
     """
     Ensures that chained mutations are compiled correctly
     """
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     args = [1,
             {'$OBJECT': 'mutation', 'mutation': 'increment', 'arguments': []},
             {'$OBJECT': 'mutation', 'mutation': 'format', 'arguments': [
@@ -124,19 +115,17 @@ def test_compiler_mutation_chained(parser, source):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_expression_path(parser):
+def test_compiler_expression_path():
     """
     Ensures that expressions with paths are compiled correctly.
     """
-    tree = parser.parse('x = 3\nx + 2')
-    result = Compiler.compile(tree)
+    result = Api.loads('x = 3\nx + 2')
     path = {'$OBJECT': 'path', 'paths': ['x']}
     assert result['tree']['2']['args'][0]['values'][0] == path
 
 
-def test_compiler_foreach(parser):
-    tree = parser.parse('foreach items as item\n\tx = 0')
-    result = Compiler.compile(tree)
+def test_compiler_foreach():
+    result = Api.loads('foreach items as item\n\tx = 0')
     args = [{'$OBJECT': 'path', 'paths': ['items']}]
     assert result['tree']['1']['method'] == 'for'
     assert result['tree']['1']['output'] == ['item']
@@ -145,15 +134,13 @@ def test_compiler_foreach(parser):
     assert result['tree']['2']['parent'] == '1'
 
 
-def test_compiler_foreach_key_value(parser):
-    tree = parser.parse('foreach items as key, value\n\tx = 0')
-    result = Compiler.compile(tree)
+def test_compiler_foreach_key_value():
+    result = Api.loads('foreach items as key, value\n\tx = 0')
     assert result['tree']['1']['output'] == ['key', 'value']
 
 
-def test_compiler_while(parser):
-    tree = parser.parse('while cond\n\tx = 0')
-    result = Compiler.compile(tree)
+def test_compiler_while():
+    result = Api.loads('while cond\n\tx = 0')
     args = [{'$OBJECT': 'path', 'paths': ['cond']}]
     assert result['tree']['1']['method'] == 'while'
     assert result['tree']['1']['args'] == args
@@ -161,12 +148,11 @@ def test_compiler_while(parser):
     assert result['tree']['2']['parent'] == '1'
 
 
-def test_compiler_service(parser):
+def test_compiler_service():
     """
     Ensures that services are compiled correctly
     """
-    tree = parser.parse("alpine echo message:'hello'")
-    result = Compiler.compile(tree)
+    result = Api.loads("alpine echo message:'hello'")
     args = [
         {'$OBJECT': 'argument', 'name': 'message', 'argument':
          {'$OBJECT': 'string', 'string': 'hello'}}
@@ -177,12 +163,11 @@ def test_compiler_service(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_service_indented_arguments(parser):
+def test_compiler_service_indented_arguments():
     """
     Ensures that services with indented arguments are compiled correctly
     """
-    tree = parser.parse('alpine echo message:"hello"\n\tcolour:"red"')
-    result = Compiler.compile(tree)
+    result = Api.loads('alpine echo message:"hello"\n\tcolour:"red"')
     args = [
         {'$OBJECT': 'argument', 'name': 'message', 'argument':
          {'$OBJECT': 'string', 'string': 'hello'}},
@@ -192,13 +177,12 @@ def test_compiler_service_indented_arguments(parser):
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_service_streaming(parser):
+def test_compiler_service_streaming():
     """
     Ensures that streaming services are compiled correctly
     """
     source = 'api stream as client\n\twhen client event as e\n\t\tx=0'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     assert result['tree']['1']['output'] == ['client']
     assert result['tree']['1']['enter'] == '2'
     assert result['tree']['2']['method'] == 'when'
@@ -207,13 +191,12 @@ def test_compiler_service_streaming(parser):
     assert result['tree']['3']['method'] == 'expression'
 
 
-def test_compiler_service_inline_expression(parser):
+def test_compiler_service_inline_expression():
     """
     Ensures that inline expressions in services are compiled correctly
     """
     source = 'alpine echo text:(random strings)'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     entry = result['entrypoint']
     name = result['tree'][entry]['name']
     assert result['tree'][entry]['method'] == 'execute'
@@ -225,13 +208,12 @@ def test_compiler_service_inline_expression(parser):
     assert result['tree']['1']['args'] == [argument]
 
 
-def test_compiler_service_inline_expression_nested(parser):
+def test_compiler_service_inline_expression_nested():
     """
     Ensures that nested inline expressions are compiled correctly
     """
     source = 'slack message text:(twitter get id:(sql select))'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     entry = result['entrypoint']
     next = result['tree'][entry]['next']
     last = result['tree'][next]['next']
@@ -240,32 +222,29 @@ def test_compiler_service_inline_expression_nested(parser):
     assert result['tree'][last]['service'] == 'slack'
 
 
-def test_compiler_inline_expression_access(parser):
+def test_compiler_inline_expression_access():
     """
     Ensures that inline expressions followed a bracket accessor are compiled
     correctly.
     """
-    tree = parser.parse('x = (random array)[0]')
-    result = Compiler.compile(tree)
+    result = Api.loads('x = (random array)[0]')
     entry = result['entrypoint']
     name = result['tree'][entry]['name'][0]
     args = [{'$OBJECT': 'path', 'paths': [name, '0']}]
     assert result['tree']['1']['args'] == args
 
 
-def test_compiler_try(parser):
+def test_compiler_try():
     source = 'try\n\tx=0'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'try'
     assert result['tree']['1']['enter'] == '2'
     assert result['tree']['2']['parent'] == '1'
 
 
-def test_compiler_try_catch(parser):
+def test_compiler_try_catch():
     source = 'try\n\tx=0\ncatch as error\n\tx=1'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     assert result['tree']['1']['exit'] == '3'
     assert result['tree']['3']['method'] == 'catch'
     assert result['tree']['3']['output'] == ['error']
@@ -273,29 +252,26 @@ def test_compiler_try_catch(parser):
     assert result['tree']['4']['parent'] == '3'
 
 
-def test_compiler_try_finally(parser):
+def test_compiler_try_finally():
     source = 'try\n\tx=0\nfinally\n\tx=1'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     assert result['tree']['3']['method'] == 'finally'
     assert result['tree']['3']['enter'] == '4'
     assert result['tree']['4']['parent'] == '3'
 
 
-def test_compiler_try_throw(parser):
+def test_compiler_try_throw():
     source = 'try\n\tx=0\ncatch as error\n\tthrow'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     assert result['tree']['1']['exit'] == '3'
     assert result['tree']['3']['method'] == 'catch'
     assert result['tree']['4']['method'] == 'throw'
     assert result['tree']['4']['parent'] == '3'
 
 
-def test_compiler_try_throw_error(parser):
+def test_compiler_try_throw_error():
     source = 'try\n\tx=0\ncatch as error\n\tthrow error'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     args = [{'$OBJECT': 'path', 'paths': ['error']}]
     assert result['tree']['1']['exit'] == '3'
     assert result['tree']['3']['method'] == 'catch'
@@ -305,10 +281,9 @@ def test_compiler_try_throw_error(parser):
     assert result['tree']['4']['args'] == args
 
 
-def test_compiler_try_nested_throw_error(parser):
+def test_compiler_try_nested_throw_error():
     source = 'try\n\tx=0\ncatch as error\n\tif TRUE\n\t\tthrow error'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     args = [{'$OBJECT': 'path', 'paths': ['error']}]
     assert result['tree']['1']['exit'] == '3'
     assert result['tree']['3']['method'] == 'catch'
@@ -318,120 +293,118 @@ def test_compiler_try_nested_throw_error(parser):
     assert result['tree']['5']['args'] == args
 
 
-def test_compiler_break(parser):
+def test_compiler_break():
     source = 'while true\n\tbreak'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     assert result['tree']['2']['method'] == 'break'
     assert result['tree']['2']['parent'] == '1'
 
 
-def test_compiler_empty_files(parser):
-    tree = parser.parse('\n\n')
-    result = Compiler.compile(tree)
+def test_compiler_empty_files():
+    result = Api.loads('\n\n')
     assert result['tree'] == {}
     assert result['entrypoint'] is None
 
 
-def test_compiler_expression_signed_number(parser):
+def test_compiler_expression_signed_number():
     """
     Ensures that signed numbers are compiled correctly
     """
-    result = Compiler.compile(parser.parse('a = -2'))
+    result = Api.loads('a = -2')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [-2]
 
-    result = Compiler.compile(parser.parse('a = +2'))
+    result = Api.loads('a = +2')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [2]
 
 
-def test_compiler_expression_signed_number_complex(parser):
+def test_compiler_expression_signed_number_complex():
     """
     Ensures that signed numbers are compiled correctly
     """
-    result = Compiler.compile(parser.parse('a = 2 + -3'))
+    result = Api.loads('a = 2 + -3')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['expression'] == 'sum'
     assert result['tree']['1']['args'][0]['values'] == [2, -3]
 
-    result = Compiler.compile(parser.parse('a = -2 + 3'))
+    result = Api.loads('a = -2 + 3')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['expression'] == 'sum'
     assert result['tree']['1']['args'][0]['values'] == [-2, 3]
 
 
-def test_compiler_expression_signed_number_absolute(parser):
+def test_compiler_expression_signed_number_absolute():
     """
     Ensures that absolute signed numbers are compiled correctly
     """
-    result = Compiler.compile(parser.parse('-2'))
+    result = Api.loads('-2')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [-2]
 
-    result = Compiler.compile(parser.parse('+2'))
+    result = Api.loads('+2')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [2]
 
 
-def test_compiler_expression_signed_float(parser):
+def test_compiler_expression_signed_float():
     """
     Ensures that signed numbers are compiled correctly
     """
-    result = Compiler.compile(parser.parse('a = -5.5'))
+    result = Api.loads('a = -5.5')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [-5.5]
 
-    result = Compiler.compile(parser.parse('a = +5.5'))
+    result = Api.loads('a = +5.5')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [5.5]
 
 
-def test_compiler_expression_signed_float_absolute(parser):
+def test_compiler_expression_signed_float_absolute():
     """
     Ensures that absolute signed numbers are compiled correctly
     """
-    result = Compiler.compile(parser.parse('-5.5'))
+    result = Api.loads('-5.5')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [-5.5]
 
-    result = Compiler.compile(parser.parse('+5.5'))
+    result = Api.loads('+5.5')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [5.5]
 
 
-def test_compiler_expression_signed_float_complex(parser):
+def test_compiler_expression_signed_float_complex():
     """
     Ensures that signed numbers are compiled correctly
     """
-    result = Compiler.compile(parser.parse('a = 2.5 + -3.5'))
+    result = Api.loads('a = 2.5 + -3.5')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['expression'] == 'sum'
     assert result['tree']['1']['args'][0]['values'] == [2.5, -3.5]
 
-    result = Compiler.compile(parser.parse('a = -2.5 + 3.5'))
+    result = Api.loads('a = -2.5 + 3.5')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['expression'] == 'sum'
     assert result['tree']['1']['args'][0]['values'] == [-2.5, 3.5]
 
 
-def test_compiler_expression_exponential_flat(parser):
+def test_compiler_expression_exponential_flat():
     """
     Ensures that exponential expressions are not nested
     """
-    result = Compiler.compile(parser.parse('2 ^ 3'))
+    result = Api.loads('2 ^ 3')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'][0]['$OBJECT'] == 'expression'
     assert result['tree']['1']['args'][0]['expression'] == 'exponential'
     assert result['tree']['1']['args'][0]['values'] == [2, 3]
 
 
-def test_compiler_complex_nested_expression(parser):
+def test_compiler_complex_nested_expression():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '2 + 3 / 4'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -450,12 +423,12 @@ def test_compiler_complex_nested_expression(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_2(parser):
+def test_compiler_complex_nested_expression_2():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = 'true and 1 + 1 == 2 or 3'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -488,12 +461,12 @@ def test_compiler_complex_nested_expression_2(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_3(parser):
+def test_compiler_complex_nested_expression_3():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '0 + 1 * 2 - 3 / 4 % 5 == 6 ^ 2 > 7 or 8'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -561,12 +534,12 @@ def test_compiler_complex_nested_expression_3(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_4(parser):
+def test_compiler_complex_nested_expression_4():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '1 % 2 + 3 - -4'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -592,13 +565,13 @@ def test_compiler_complex_nested_expression_4(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_5(parser):
+def test_compiler_complex_nested_expression_5():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = ('1 + 0.1 < 2 - 0.2 <= 3 / 0.3 '
               '== 4 * 0.4 != 5 * 0.5 > 6 * 0.6 >= 7 * 0.7')
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -694,12 +667,12 @@ def test_compiler_complex_nested_expression_5(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_6(parser):
+def test_compiler_complex_nested_expression_6():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '1 and 2 or 3 and 4 or 5'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -732,12 +705,12 @@ def test_compiler_complex_nested_expression_6(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_7(parser):
+def test_compiler_complex_nested_expression_7():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '1 and (2 or 3) and (4 or 5)'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -770,12 +743,12 @@ def test_compiler_complex_nested_expression_7(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_8(parser):
+def test_compiler_complex_nested_expression_8():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '(1 + 2) == (0 - -3) and -4 - (-5 + -6)'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -822,12 +795,12 @@ def test_compiler_complex_nested_expression_8(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_9(parser):
+def test_compiler_complex_nested_expression_9():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = 'foo[0] > 5 + foo[1] and foo[1]'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -871,12 +844,12 @@ def test_compiler_complex_nested_expression_9(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_10(parser):
+def test_compiler_complex_nested_expression_10():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = """d['a'] + list[0] / list[1] * d['a'] % d['b']"""
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -948,12 +921,12 @@ def test_compiler_complex_nested_expression_10(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_11(parser):
+def test_compiler_complex_nested_expression_11():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '1 == 2 != 3 < 4 == 5 + 6 - 7 * 8 > 9 <= 10'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1021,12 +994,12 @@ def test_compiler_complex_nested_expression_11(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_12(parser):
+def test_compiler_complex_nested_expression_12():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '1 == (foo contains)'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1.1']['service'] == 'foo'
     assert result['tree']['1.1']['name'] == ['p-1.1']
@@ -1046,12 +1019,12 @@ def test_compiler_complex_nested_expression_12(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_13(parser):
+def test_compiler_complex_nested_expression_13():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = 'a + b -c / d'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1097,12 +1070,12 @@ def test_compiler_complex_nested_expression_13(parser):
     }]
 
 
-def test_compiler_complex_nested_expression_14(parser):
+def test_compiler_complex_nested_expression_14():
     """
     Ensures that complex nested expressions are compiled correctly
     """
     source = '((0 == 1)) + (d[\'a\'])'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1130,11 +1103,11 @@ def test_compiler_complex_nested_expression_14(parser):
     }]
 
 
-def test_compiler_list_expression(parser):
+def test_compiler_list_expression():
     """
     Ensures that list accept arbitrary expressions
     """
-    result = Compiler.compile(parser.parse('a = [b + c, 1 / 2 + 3]'))
+    result = Api.loads('a = [b + c, 1 / 2 + 3]')
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'list',
@@ -1176,12 +1149,12 @@ def test_compiler_list_expression(parser):
     }]
 
 
-def test_compiler_object_expression(parser):
+def test_compiler_object_expression():
     """
     Ensures that objects accept arbitrary expressions
     """
     source = 'a = {"1": b - c, "2": 1 % 2 - 3}'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'dict',
@@ -1235,12 +1208,12 @@ def test_compiler_object_expression(parser):
     }]
 
 
-def test_compiler_mutation_assignment(parser):
+def test_compiler_mutation_assignment():
     """
     Ensures that mutation assignments compile correctly
     """
     source = 'a = "hello world"\nb = a uppercase'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['2']['method'] == 'mutation'
@@ -1305,13 +1278,13 @@ def path(name):
     ('b<=c', 'less_equal', [path('b'), path('c')]),
     ('b>=c', 'greater_equal', [path('b'), path('c')]),
 ])
-def test_compiler_expression_whitespace(parser, source_pair):
+def test_compiler_expression_whitespace(source_pair):
     """
     Ensures that expression isn't whitespace sensitive
     """
     source, expression, values = source_pair
     source = 'a=' + source
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     assert len(result['tree']['1']['args']) == 1
@@ -1320,11 +1293,11 @@ def test_compiler_expression_whitespace(parser, source_pair):
     assert result['tree']['1']['args'][0]['values'] == values
 
 
-def test_compiler_complex_while(parser):
+def test_compiler_complex_while():
     """
     Ensures that while statements with an expression are compiled correctly
     """
-    result = Compiler.compile(parser.parse('while i < 10\n\ti = i + 1'))
+    result = Api.loads('while i < 10\n\ti = i + 1')
     assert result['tree']['1']['method'] == 'while'
     assert result['tree']['1']['args'][0]['$OBJECT'] == 'expression'
     assert result['tree']['1']['args'][0]['expression'] == 'less'
@@ -1338,12 +1311,12 @@ def test_compiler_complex_while(parser):
     ]
 
 
-def test_compiler_complex_while_2(parser):
+def test_compiler_complex_while_2():
     """
     Ensures that while statements with an expression are compiled correctly
     """
     source = 'while a + b == c or d\n\ti = i + 1'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'while'
     assert result['tree']['1']['args'] == [{
           '$OBJECT': 'expression',
@@ -1389,13 +1362,13 @@ def test_compiler_complex_while_2(parser):
     }]
 
 
-def test_compiler_mutation_expression(parser):
+def test_compiler_mutation_expression():
     """
     Ensures that mutations with expressions are compiled correctly
     """
     source = ('a = ["opened", "labeled"]\n'
               'a contains item: req.body["action"] == false')
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['name'] == ['a']
     assert result['tree']['2']['method'] == 'mutation'
@@ -1437,12 +1410,12 @@ def test_compiler_mutation_expression(parser):
     ]
 
 
-def test_compiler_service_expression(parser):
+def test_compiler_service_expression():
     """
     Ensures that mutations with expressions are compiled correctly
     """
     source = 'my_service my_command k1: 2 + 2 k2: a == b'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'execute'
     assert result['tree']['1']['command'] == 'my_command'
     assert result['tree']['1']['service'] == 'my_service'
@@ -1484,12 +1457,12 @@ def test_compiler_service_expression(parser):
     ]
 
 
-def test_compiler_mutation_expression_list(parser):
+def test_compiler_mutation_expression_list():
     """
     Ensures that mutations on lists work
     """
     source = '["opened", "labeled"] contains item: "opened"'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'mutation'
     assert result['tree']['1']['args'] == [
         {
@@ -1522,12 +1495,12 @@ def test_compiler_mutation_expression_list(parser):
     ]
 
 
-def test_compiler_mutation_expression_object(parser):
+def test_compiler_mutation_expression_object():
     """
     Ensures that mutations on objects work
     """
     source = '{"opened":1, "labeled":1} has key: "opened"'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'mutation'
     assert result['tree']['1']['args'] == [
         {
@@ -1566,12 +1539,12 @@ def test_compiler_mutation_expression_object(parser):
     ]
 
 
-def test_compiler_return_complex_expression(parser):
+def test_compiler_return_complex_expression():
     """
     Ensures that return accepts arbitrary expressions
     """
     source = 'function name key:int\n\treturn 2 + 2'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'function'
     assert result['tree']['1']['function'] == 'name'
     assert result['tree']['2']['method'] == 'return'
@@ -1585,12 +1558,12 @@ def test_compiler_return_complex_expression(parser):
     }]
 
 
-def test_compiler_return_complex_expression_2(parser):
+def test_compiler_return_complex_expression_2():
     """
     Ensures that return accepts arbitrary expressions
     """
     source = 'function name key:int\n\treturn a / b + c or d'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'function'
     assert result['tree']['1']['function'] == 'name'
     assert result['tree']['2']['method'] == 'return'
@@ -1638,12 +1611,12 @@ def test_compiler_return_complex_expression_2(parser):
     }]
 
 
-def test_compiler_unary_not(parser):
+def test_compiler_unary_not():
     """
     Ensures that unary expressions are compiled correctly
     """
     source = 'a = !b'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1659,12 +1632,12 @@ def test_compiler_unary_not(parser):
     }]
 
 
-def test_compiler_unary_double(parser):
+def test_compiler_unary_double():
     """
     Ensures that double unary expressions are compiled correctly
     """
     source = 'a = !!b'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1686,12 +1659,12 @@ def test_compiler_unary_double(parser):
     }]
 
 
-def test_compiler_unary_complex(parser):
+def test_compiler_unary_complex():
     """
     Ensures that complex unary expressions are compiled correctly
     """
     source = 'a = b and !c'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1719,12 +1692,12 @@ def test_compiler_unary_complex(parser):
     }]
 
 
-def test_compiler_unary_complex_2(parser):
+def test_compiler_unary_complex_2():
     """
     Ensures that complex unary expressions are compiled correctly
     """
     source = 'a = ! 2 == !3 or ! 4'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1761,12 +1734,12 @@ def test_compiler_unary_complex_2(parser):
     }]
 
 
-def test_compiler_unary_complex_3(parser):
+def test_compiler_unary_complex_3():
     """
     Ensures that complex unary expressions are compiled correctly
     """
     source = 'a = [! b, !2] <= ! t + t'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1824,13 +1797,13 @@ def test_compiler_unary_complex_3(parser):
     }]
 
 
-def test_compiler_unary_complex_5(parser):
+def test_compiler_unary_complex_5():
     """
     Ensures that complex unary expressions are compiled correctly
     """
     source = ('a = ! (my_service command k1: !b) or '
               '!(my_service2 command k2: ! !c)')
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1902,12 +1875,12 @@ def test_compiler_unary_complex_5(parser):
     }]
 
 
-def test_compiler_unary_complex_6(parser):
+def test_compiler_unary_complex_6():
     """
     Ensures that complex unary expressions are compiled correctly
     """
     source = 'a = !-2 or ! -3 - -4'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1938,12 +1911,12 @@ def test_compiler_unary_complex_6(parser):
     }]
 
 
-def test_compiler_expression_is(parser):
+def test_compiler_expression_is():
     """
     Ensures that 'is' expressions compile correctly
     """
     source = 'a = 1 == 2'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -1955,12 +1928,12 @@ def test_compiler_expression_is(parser):
     }]
 
 
-def test_compiler_expression_is_nested(parser):
+def test_compiler_expression_is_nested():
     """
     Ensures that nested 'is' expressions compile correctly
     """
     source = 'a = 1 + 2 == 3/4 == 5*6 == 7%8 or 9'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',
@@ -2021,12 +1994,12 @@ def test_compiler_expression_is_nested(parser):
     }]
 
 
-def test_compiler_expression_is_nested_2(parser):
+def test_compiler_expression_is_nested_2():
     """
     Ensures that nested 'is' expressions compile correctly
     """
     source = 'a = 1 == 2 < 3 or 4 > 0.5+5 == -6 and 7 == 8'
-    result = Compiler.compile(parser.parse(source))
+    result = Api.loads(source)
     assert result['tree']['1']['method'] == 'expression'
     assert result['tree']['1']['args'] == [{
         '$OBJECT': 'expression',

--- a/tests/integration/compiler/Functions.py
+++ b/tests/integration/compiler/Functions.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 from lark.lexer import Token
 
-from storyscript.compiler import Compiler
+from storyscript.Api import Api
 
 
-def test_functions_function(parser):
+def test_functions_function():
     """
     Ensures that functions are compiled correctly.
     """
-    tree = parser.parse('function f\n\tx = 0')
-    result = Compiler.compile(tree)
+    result = Api.loads('function f\n\tx = 0')
     assert result['tree']['1']['method'] == 'function'
     assert result['tree']['1']['function'] == 'f'
     assert result['tree']['1']['next'] == '2'
@@ -18,12 +17,11 @@ def test_functions_function(parser):
     assert result['tree']['2']['parent'] == '1'
 
 
-def test_functions_function_argument(parser):
+def test_functions_function_argument():
     """
     Ensures that functions with an argument are compiled correctly
     """
-    tree = parser.parse('function echo a:string\n\tx = a')
-    result = Compiler.compile(tree)
+    result = Api.loads('function echo a:string\n\tx = a')
     args = [{
         '$OBJECT': 'argument',
         'argument': {'$OBJECT': 'type', 'type': 'string'}, 'name': 'a'
@@ -33,35 +31,32 @@ def test_functions_function_argument(parser):
     assert result['tree']['2']['args'] == [{'$OBJECT': 'path', 'paths': ['a']}]
 
 
-def test_functions_function_returns(parser):
+def test_functions_function_returns():
     """
     Ensures that functions with a return type are compiled correctly
     """
-    tree = parser.parse('function f returns int\n\tx = 0')
-    result = Compiler.compile(tree)
+    result = Api.loads('function f returns int\n\tx = 0')
     assert result['tree']['1']['method'] == 'function'
     assert result['tree']['1']['function'] == 'f'
     assert result['tree']['1']['output'] == ['int']
 
 
-def test_functions_function_return(parser):
+def test_functions_function_return():
     """
     Ensures that return statements are compiled correctly
     """
-    tree = parser.parse('function f\n\treturn 0')
-    result = Compiler.compile(tree)
+    result = Api.loads('function f\n\treturn 0')
     assert result['tree']['2']['method'] == 'return'
     assert result['tree']['2']['args'] == [0]
     assert result['tree']['2']['parent'] == '1'
 
 
-def test_functions_function_call_arguments(parser):
+def test_functions_function_call_arguments():
     """
     Ensures that functions with arguments can be called
     """
     source = 'function f n:int\n\tx = 0\nf(n:1)\n'
-    tree = parser.parse(source)
-    result = Compiler.compile(tree)
+    result = Api.loads(source)
     args = [{'$OBJECT': 'argument', 'name': 'n', 'argument': 1}]
     assert result['tree']['3.1']['method'] == 'call'
     assert result['tree']['3.1']['service'] == 'f'

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,1 @@
 # -*- coding: utf-8 -*-
-from pytest import fixture
-
-from storyscript.parser import Parser
-
-
-@fixture
-def parser():
-    return Parser()

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -3,7 +3,15 @@ from lark.lexer import Token
 
 from pytest import mark
 
+from storyscript.Story import _parser
 from storyscript.parser import Tree
+
+
+def parse(source):
+    """
+    Don't regenerate the parser on every call
+    """
+    return _parser().parse(source)
 
 
 def get_entity(obj):
@@ -23,8 +31,8 @@ def arith_exp(exp):
         arith_expression
 
 
-def test_parser_sum(parser):
-    result = parser.parse('3 + 4\n')
+def test_parser_sum():
+    result = parse('3 + 4\n')
     ar_exp = arith_exp(result.block.rules.absolute_expression)
     lhs = get_entity(ar_exp.child(0)).values.number
     assert lhs.child(0) == Token('INT', 3)
@@ -35,11 +43,11 @@ def test_parser_sum(parser):
     assert rhs.child(0) == Token('INT', 4)
 
 
-def test_parser_list_path(parser):
+def test_parser_list_path():
     """
     Ensures that paths in lists can be parsed.
     """
-    result = parser.parse('x = 0\n[3, x]\n')
+    result = parse('x = 0\n[3, x]\n')
     expression = result.child(1).rules.absolute_expression
     entity = get_entity(arith_exp(expression))
     list = arith_exp(Tree('absolute_expression',
@@ -54,8 +62,8 @@ def test_parser_list_path(parser):
     ('var=3\n', Token('INT', 3)),
     ('var = 3\n', Token('INT', 3))
 ])
-def test_parser_assignment(parser, code, token):
-    result = parser.parse(code)
+def test_parser_assignment(code, token):
+    result = parse(code)
     assignment = result.block.rules.assignment
     assert assignment.path.child(0) == Token('NAME', 'var')
     assert assignment.assignment_fragment.child(0) == Token('EQUALS', '=')
@@ -64,27 +72,27 @@ def test_parser_assignment(parser, code, token):
     assert entity.values.child(0).child(0) == token
 
 
-def test_parser_assignment_path(parser):
-    result = parser.parse('rainbow.colors[0]="blue"\n')
+def test_parser_assignment_path():
+    result = parse('rainbow.colors[0]="blue"\n')
     path = result.block.rules.assignment.path
     assert path.child(0) == Token('NAME', 'rainbow')
     assert path.path_fragment.child(0) == Token('NAME', 'colors')
     assert path.child(2).child(0) == Token('INT', 0)
 
 
-def test_parser_assignment_indented_arguments(parser):
+def test_parser_assignment_indented_arguments():
     """
     Ensures that assignments to a service with indented arguments are parsed
     correctly
     """
-    result = parser.parse('x = alpine echo\n\tmessage:"hello"')
+    result = parse('x = alpine echo\n\tmessage:"hello"')
     exp = result.child(1).indented_arguments.arguments.expression
     values = get_entity(arith_exp(Tree('an_exp', [exp]))).values
     assert values.string.child(0) == Token('DOUBLE_QUOTED', '"hello"')
 
 
-def test_parser_foreach_block(parser):
-    result = parser.parse('foreach items as one, two\n\tvar=3\n')
+def test_parser_foreach_block():
+    result = parse('foreach items as one, two\n\tvar=3\n')
     block = result.block.foreach_block
     foreach = block.foreach_statement
     assert foreach.entity.path.child(0) == Token('NAME', 'items')
@@ -93,8 +101,8 @@ def test_parser_foreach_block(parser):
     assert block.nested_block.data == 'nested_block'
 
 
-def test_parser_while_block(parser):
-    result = parser.parse('while cond\n\tvar=3\n')
+def test_parser_while_block():
+    result = parse('while cond\n\tvar=3\n')
     block = result.block.while_block
     exp = arith_exp(block.while_statement.base_expression)
     entity = get_entity(exp)
@@ -102,30 +110,30 @@ def test_parser_while_block(parser):
     assert block.nested_block.data == 'nested_block'
 
 
-def test_parser_service(parser):
-    result = parser.parse('org/container-name command\n')
+def test_parser_service():
+    result = parse('org/container-name command\n')
     service = result.block.service_block.service
     assert service.path.child(0) == 'org/container-name'
     assert service.service_fragment.command.child(0) == 'command'
 
 
-def test_parser_service_arguments(parser):
-    result = parser.parse('container key:"value"\n')
+def test_parser_service_arguments():
+    result = parse('container key:"value"\n')
     args = result.block.service_block.service.service_fragment.arguments
     assert args.child(0) == Token('NAME', 'key')
     entity = get_entity(arith_exp(Tree('an_exp', [args.expression])))
     assert entity.values.string.child(0) == Token('DOUBLE_QUOTED', '"value"')
 
 
-def test_parser_service_output(parser):
-    result = parser.parse('container command as request, response\n')
+def test_parser_service_output():
+    result = parse('container command as request, response\n')
     node = result.block.service_block.service.service_fragment.output
     assert node.child(0) == Token('NAME', 'request')
     assert node.child(1) == Token('NAME', 'response')
 
 
-def test_parser_if_block(parser):
-    result = parser.parse('if expr\n\tvar=3\n')
+def test_parser_if_block():
+    result = parse('if expr\n\tvar=3\n')
     if_block = result.block.if_block
     ar_exp = arith_exp(if_block.if_statement.base_expression)
     entity = get_entity(ar_exp)
@@ -135,8 +143,8 @@ def test_parser_if_block(parser):
     assert assignment.path.child(0) == Token('NAME', 'var')
 
 
-def test_parser_if_block_nested(parser):
-    result = parser.parse('if expr\n\tif things\n\t\tvar=3\n')
+def test_parser_if_block_nested():
+    result = parse('if expr\n\tif things\n\t\tvar=3\n')
     if_block = result.block.if_block.nested_block.block.if_block
     ar_exp = arith_exp(if_block.if_statement.base_expression)
     entity = get_entity(ar_exp)
@@ -146,57 +154,57 @@ def test_parser_if_block_nested(parser):
     assert assignment.path.child(0) == Token('NAME', 'var')
 
 
-def test_parser_if_block_else(parser):
-    result = parser.parse('if expr\n\tvar=3\nelse\n\tvar=4\n')
+def test_parser_if_block_else():
+    result = parse('if expr\n\tvar=3\nelse\n\tvar=4\n')
     node = result.block.if_block.else_block.nested_block.block.rules
     assert node.assignment.path.child(0) == Token('NAME', 'var')
 
 
-def test_parser_if_block_elseif(parser):
-    result = parser.parse('if expr\n\tvar=3\nelse if magic\n\tvar=4\n')
+def test_parser_if_block_elseif():
+    result = parse('if expr\n\tvar=3\nelse if magic\n\tvar=4\n')
     node = result.block.if_block.elseif_block.nested_block.block.rules
     assert node.assignment.path.child(0) == Token('NAME', 'var')
 
 
-def test_parser_function(parser):
-    result = parser.parse('function test\n\tvar = 3\n')
+def test_parser_function():
+    result = parse('function test\n\tvar = 3\n')
     node = result.block.function_block
     path = node.nested_block.block.rules.assignment.path
     assert node.function_statement.child(1) == Token('NAME', 'test')
     assert path.child(0) == Token('NAME', 'var')
 
 
-def test_parser_function_arguments(parser):
-    result = parser.parse('function test n:int\n\tvar = 3\n')
+def test_parser_function_arguments():
+    result = parse('function test n:int\n\tvar = 3\n')
     typed_argument = result.block.function_block.find('typed_argument')[0]
     assert typed_argument.child(0) == Token('NAME', 'n')
     assert typed_argument.types.child(0) == Token('INT_TYPE', 'int')
 
 
-def test_parser_function_output(parser):
-    result = parser.parse('function test n:string returns int\n\tvar = 1\n')
+def test_parser_function_output():
+    result = parse('function test n:string returns int\n\tvar = 1\n')
     statement = result.block.function_block.function_statement
     assert statement.function_output.types.child(0) == Token('INT_TYPE', 'int')
 
 
-def test_parser_try(parser):
-    result = parser.parse('try\n\tx=0')
+def test_parser_try():
+    result = parse('try\n\tx=0')
     try_block = result.block.try_block
     assert try_block.try_statement.child(0) == Token('TRY', 'try')
     path = try_block.nested_block.block.rules.assignment.path
     assert path.child(0) == Token('NAME', 'x')
 
 
-def test_parser_try_catch(parser):
-    result = parser.parse('try\n\tx=0\ncatch as error\n\tx=1')
+def test_parser_try_catch():
+    result = parse('try\n\tx=0\ncatch as error\n\tx=1')
     catch_block = result.block.try_block.catch_block
     assert catch_block.catch_statement.child(0) == Token('NAME', 'error')
     path = catch_block.nested_block.block.rules.assignment.path
     assert path.child(0) == Token('NAME', 'x')
 
 
-def test_parser_try_finally(parser):
-    result = parser.parse('try\n\tx=0\nfinally\n\tx=1')
+def test_parser_try_finally():
+    result = parse('try\n\tx=0\nfinally\n\tx=1')
     finally_block = result.block.try_block.finally_block
     token = Token('FINALLY', 'finally')
     assert finally_block.finally_statement.child(0) == token
@@ -204,22 +212,22 @@ def test_parser_try_finally(parser):
     assert path.child(0) == Token('NAME', 'x')
 
 
-def test_parser_try_throw(parser):
-    result = parser.parse('try\n\tx=0\ncatch as error\n\tthrow')
+def test_parser_try_throw():
+    result = parse('try\n\tx=0\ncatch as error\n\tthrow')
     nested_block = result.block.try_block.catch_block.nested_block
     assert nested_block.block.rules.throw_statement.child(0) == 'throw'
 
 
-def test_parser_try_throw_error(parser):
-    result = parser.parse('try\n\tx=0\ncatch as error\n\tthrow error')
+def test_parser_try_throw_error():
+    result = parse('try\n\tx=0\ncatch as error\n\tthrow error')
     nested_block = result.block.try_block.catch_block.nested_block
     throw_statement = nested_block.block.rules.throw_statement
     assert throw_statement.child(0) == 'throw'
     assert throw_statement.entity.path.child(0) == Token('NAME', 'error')
 
 
-def test_parser_try_throw_error_message(parser):
-    result = parser.parse('try\n\tx=0\ncatch as error\n\tthrow "error"')
+def test_parser_try_throw_error_message():
+    result = parse('try\n\tx=0\ncatch as error\n\tthrow "error"')
     nested_block = result.block.try_block.catch_block.nested_block
     throw_statement = nested_block.block.rules.throw_statement
     print(throw_statement.pretty())
@@ -229,8 +237,8 @@ def test_parser_try_throw_error_message(parser):
 
 
 @mark.parametrize('number', ['+10', '-10'])
-def test_parser_number_int(parser, number):
-    result = parser.parse(number)
+def test_parser_number_int(number):
+    result = parse(number)
     ar_exp = arith_exp(result.block.rules.absolute_expression)
     entity = get_entity(ar_exp)
     f = entity.values.number
@@ -238,16 +246,16 @@ def test_parser_number_int(parser, number):
 
 
 @mark.parametrize('number', ['+10.0', '-10.0'])
-def test_parser_number_float(parser, number):
-    result = parser.parse(number)
+def test_parser_number_float(number):
+    result = parse(number)
     ar_exp = arith_exp(result.block.rules.absolute_expression)
     entity = get_entity(ar_exp)
     f = entity.values.number
     assert f.child(0) == Token('FLOAT', number)
 
 
-def test_parser_string_double_quoted(parser):
-    result = parser.parse(r'a = "b\n.\\.\".c"')
+def test_parser_string_double_quoted():
+    result = parse(r'a = "b\n.\\.\".c"')
     result = result.block.rules.assignment.assignment_fragment
     result = result.base_expression
     ar_exp = arith_exp(result)
@@ -255,8 +263,8 @@ def test_parser_string_double_quoted(parser):
     assert lhs == r'"b\n.\\.\".c"'
 
 
-def test_parser_string_single_quoted(parser):
-    result = parser.parse(r"""a = 'b.\n.\\.\'.c'""")
+def test_parser_string_single_quoted():
+    result = parse(r"""a = 'b.\n.\\.\'.c'""")
     result = result.block.rules.assignment.assignment_fragment
     result = result.base_expression
     ar_exp = arith_exp(result)

--- a/tests/integration/parser/Values.py
+++ b/tests/integration/parser/Values.py
@@ -2,6 +2,15 @@
 from lark.lexer import Token
 from lark.tree import Tree
 
+from storyscript.Story import _parser
+
+
+def parse(source):
+    """
+    Don't regenerate the parser on every call
+    """
+    return _parser().parse(source)
+
 
 def get_entity(obj):
     """
@@ -12,86 +21,86 @@ def get_entity(obj):
         entity
 
 
-def test_values_true(parser):
-    result = parser.parse('true\n')
+def test_values_true():
+    result = parse('true\n')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.boolean.child(0) == Token('TRUE', 'true')
 
 
-def test_values_false(parser):
-    result = parser.parse('false\n')
+def test_values_false():
+    result = parse('false\n')
     token = Token('FALSE', 'false')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.boolean.child(0) == token
 
 
-def test_values_null(parser):
-    result = parser.parse('null\n')
+def test_values_null():
+    result = parse('null\n')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.void.child(0) == Token('NULL', 'null')
 
 
-def test_values_int(parser):
+def test_values_int():
     """
     Ensures that parsing an int produces the expected tree
     """
-    result = parser.parse('3\n')
+    result = parse('3\n')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.number.child(0) == Token('INT', 3)
 
 
-def test_values_int_negative(parser):
+def test_values_int_negative():
     """
     Ensures that parsing a negative int produces the expected tree
     """
-    result = parser.parse('-3\n')
+    result = parse('-3\n')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.number.child(0) == Token('INT', '-3')
 
 
-def test_values_float(parser):
+def test_values_float():
     """
     Ensures that parsing a float produces the expected tree
     """
-    result = parser.parse('3.14\n')
+    result = parse('3.14\n')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.number.child(0) == Token('FLOAT', 3.14)
 
 
-def test_values_float_negative(parser):
+def test_values_float_negative():
     """
     Ensures that parsing a negative float produces the expected tree
     """
-    result = parser.parse('-3.14\n')
+    result = parse('-3.14\n')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.number.child(0) == Token('FLOAT', '-3.14')
 
 
-def test_values_single_quoted_string(parser):
-    result = parser.parse("'red'\n")
+def test_values_single_quoted_string():
+    result = parse("'red'\n")
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     expected = entity.values.string.child(0)
     assert expected == Token('SINGLE_QUOTED', "'red'")
 
 
-def test_values_double_quoted_string(parser):
-    result = parser.parse('"red"\n')
+def test_values_double_quoted_string():
+    result = parse('"red"\n')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     expected = entity.values.string.child(0)
     assert expected == Token('DOUBLE_QUOTED', '"red"')
 
 
-def test_values_list(parser):
-    result = parser.parse('[3,4]\n')
+def test_values_list():
+    result = parse('[3,4]\n')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     list = entity.values.list
@@ -101,16 +110,16 @@ def test_values_list(parser):
     assert c2.values.number.child(0) == Token('INT', 4)
 
 
-def test_values_list_empty(parser):
-    result = parser.parse('[]\n')
+def test_values_list_empty():
+    result = parse('[]\n')
     expected = Tree('list', [Token('_OSB', '['), Token('_CSB', ']')])
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.list == expected
 
 
-def test_values_object(parser):
-    result = parser.parse("{'color':'red','shape':1}\n")
+def test_values_object():
+    result = parse("{'color':'red','shape':1}\n")
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     values = entity.values
@@ -120,22 +129,22 @@ def test_values_object(parser):
     assert entity.values.string.child(0) == Token('SINGLE_QUOTED', "'red'")
 
 
-def test_values_regular_expression(parser):
+def test_values_regular_expression():
     """
     Ensures regular expressions are parsed correctly
     """
-    result = parser.parse('/^foo/')
+    result = parse('/^foo/')
     token = Token('REGEXP', '/^foo/')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     assert entity.values.regular_expression.child(0) == token
 
 
-def test_values_regular_expression_flags(parser):
+def test_values_regular_expression_flags():
     """
     Ensures regular expressions with flags are parsed correctly
     """
-    result = parser.parse('/^foo/i')
+    result = parse('/^foo/i')
     token = Token('NAME', 'i')
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)

--- a/tests/unittests/Bundle.py
+++ b/tests/unittests/Bundle.py
@@ -7,6 +7,7 @@ from pytest import fixture
 from storyscript.Bundle import Bundle
 from storyscript.Story import Story
 from storyscript.compiler.Preprocessor import Preprocessor
+from storyscript.parser import Parser
 
 
 @fixture
@@ -280,3 +281,23 @@ def test_bundle_bundle_preprocess(patch, bundle, magic):
                                     parser=Bundle.parser())
     Preprocessor.process.assert_called_with(a_story)
     assert bundle.stories == {'foo': Preprocessor.process(a_story)}
+
+
+def test_bundle_parser_default(patch, bundle):
+    """
+    Ensures Bundle.parser creates no new instance of the parser by default
+    """
+    patch.init(Parser)
+    assert bundle.parser(None) is None
+    Parser.__init__.assert_not_called()
+
+
+def test_bundle_parser_ebnf(patch, bundle):
+    """
+    Ensures Bundle.parser creates a new instance of a parser for custom
+    EBNF files
+    """
+    patch.init(Parser)
+    result = bundle.parser(ebnf='ebnf')
+    Parser.__init__.assert_called_with(ebnf='ebnf')
+    assert isinstance(result, Parser)

--- a/tests/unittests/Story.py
+++ b/tests/unittests/Story.py
@@ -155,6 +155,13 @@ def test_story_lex_parser(patch, story, parser):
     parser.lex.assert_called_with(story.story)
 
 
+def test_story_lex_parser_cached(patch, story, magic):
+    my_parser = magic()
+    patch.object(Story, '_parser', return_value=my_parser)
+    story.lex(parser=None)
+    my_parser.lex.assert_called_with(story.story)
+
+
 def test_story_process(patch, story):
     patch.many(Story, ['parse', 'compile'])
     story.compiled = 'compiled'


### PR DESCRIPTION
This should greatly improve the runtime of the tests as creation the parser takes about 0.3-0.6s and we currently do this for __every__ integration test.

See also: https://github.com/storyscript/storyscript/issues/685