### PR TITLE
fix(transformer): return nested block for multi-line indented function arguments

### DIFF
--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -240,6 +240,7 @@ class Transformer(LarkTransformer):
             if matches[1].data == 'indented_typed_arguments':
                 for argument in matches.pop(1).find_data('typed_argument'):
                     matches[0].children.append(argument)
+                matches[-1] = Tree('nested_block', [matches[-1]])
 
         return Tree('function_block', matches)
 

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -245,9 +245,14 @@ def test_transformer_function_block(patch, tree, magic):
     """
     function_block = magic()
     m = magic()
+    block = magic()
     m.data = 'indented_typed_arguments'
     m.find_data.return_value = ['.indented.node.']
-    r = Transformer.function_block([function_block, m])
+    r = Transformer.function_block([function_block, m, block])
     m.find_data.assert_called_with('typed_argument')
     function_block.children.append.assert_called_with('.indented.node.')
-    assert r == Tree('function_block', [function_block])
+    assert r.data == 'function_block'
+    assert r.children == [
+        function_block,
+        Tree('nested_block', [block])
+    ]


### PR DESCRIPTION
A first step towards fixing https://github.com/storyscript/storyscript/issues/728