### PR TITLE
fix(compiler): lookup output types for foreach iterations

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -95,6 +95,14 @@ class ErrorCodes:
         'E0104',
         '`{left}` can\'t be indexed with `{right}`'
     )
+    foreach_output_children = (
+        'E0105',
+        '`foreach` can only have one or two outputs'
+    )
+    foreach_iterable_required = (
+        'E0106',
+        '`foreach` requires an iterable type, but `{target}` is not'
+    )
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -66,6 +66,10 @@ class ExpressionResolver:
         # how to resolve existing symbols
         self.path_resolver = PathResolver(symbol_resolver=symbol_resolver)
 
+    def entity(self, tree):
+        assert tree.data == 'entity'
+        return self.expr_visitor.entity(tree)
+
     def path(self, tree):
         assert tree.data == 'path'
         return self.path_resolver.path(tree).type()

--- a/storyscript/compiler/semantics/symbols/SymbolTypes.py
+++ b/storyscript/compiler/semantics/symbols/SymbolTypes.py
@@ -17,7 +17,7 @@ def singleton(fn):
 
 class SymbolType:
     """
-    Base class of a symbol
+    Base class of a type.
     """
 
     def op(self, other, op):
@@ -31,6 +31,12 @@ class SymbolType:
             return self
         if isinstance(other, AnyType):
             return other
+        return None
+
+    def output(self, n):
+        """
+        Output types of this type.
+        """
         return None
 
 
@@ -198,6 +204,14 @@ class ListType(SymbolType):
             return self.inner
         return None
 
+    def output(self, n):
+        """
+        Output types of the ListType.
+        """
+        if n == 1:
+            return self.inner,
+        return IntType.instance(), self.inner
+
 
 class ObjectType(SymbolType):
     """
@@ -228,6 +242,14 @@ class ObjectType(SymbolType):
         if self.key.op(other, op=None):
             return self.value
         return None
+
+    def output(self, n):
+        """
+        Output types of the ObjectType.
+        """
+        if n == 1:
+            return self.key,
+        return self.key, self.value
 
 
 class AnyType(SymbolType):
@@ -261,3 +283,11 @@ class AnyType(SymbolType):
         Returns a static instance of the AnyType.
         """
         return AnyType()
+
+    def output(self, n):
+        """
+        Output types of the AnyType.
+        """
+        if n == 1:
+            return AnyType.instance(),
+        return AnyType.instance(), AnyType.instance()

--- a/tests/e2e/exit_line.json
+++ b/tests/e2e/exit_line.json
@@ -1,8 +1,31 @@
 {
   "tree": {
     "1": {
-      "method": "for",
+      "method": "expression",
       "ln": "1",
+      "name": [
+        "items"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "int",
+              "int": 0
+            },
+            {
+              "$OBJECT": "int",
+              "int": 1
+            }
+          ]
+        }
+      ],
+      "next": "2"
+    },
+    "2": {
+      "method": "for",
+      "ln": "2",
       "output": [
         "item"
       ],
@@ -14,13 +37,13 @@
           ]
         }
       ],
-      "enter": "2",
-      "exit": "4",
-      "next": "2"
+      "enter": "3",
+      "exit": "5",
+      "next": "3"
     },
-    "2": {
+    "3": {
       "method": "expression",
-      "ln": "2",
+      "ln": "3",
       "name": [
         "x"
       ],
@@ -32,12 +55,12 @@
           ]
         }
       ],
-      "parent": "1",
-      "next": "4"
+      "parent": "2",
+      "next": "5"
     },
-    "4": {
+    "5": {
       "method": "expression",
-      "ln": "4",
+      "ln": "5",
       "name": [
         "a"
       ],
@@ -47,11 +70,11 @@
           "int": 2
         }
       ],
-      "next": "6"
+      "next": "7"
     },
-    "6": {
+    "7": {
       "method": "if",
-      "ln": "6",
+      "ln": "7",
       "args": [
         {
           "$OBJECT": "path",
@@ -60,13 +83,13 @@
           ]
         }
       ],
-      "enter": "7",
-      "exit": "8",
-      "next": "7"
+      "enter": "8",
+      "exit": "9",
+      "next": "8"
     },
-    "7": {
+    "8": {
       "method": "expression",
-      "ln": "7",
+      "ln": "8",
       "name": [
         "a"
       ],
@@ -76,19 +99,19 @@
           "int": 0
         }
       ],
-      "parent": "6",
-      "next": "8"
-    },
-    "8": {
-      "method": "else",
-      "ln": "8",
-      "enter": "9",
-      "exit": "11",
+      "parent": "7",
       "next": "9"
     },
     "9": {
-      "method": "expression",
+      "method": "else",
       "ln": "9",
+      "enter": "10",
+      "exit": "12",
+      "next": "10"
+    },
+    "10": {
+      "method": "expression",
+      "ln": "10",
       "name": [
         "b"
       ],
@@ -98,25 +121,25 @@
           "int": 0
         }
       ],
-      "parent": "8",
-      "next": "11"
+      "parent": "9",
+      "next": "12"
     },
-    "11": {
+    "12": {
       "method": "while",
-      "ln": "11",
+      "ln": "12",
       "args": [
         {
           "$OBJECT": "boolean",
           "boolean": true
         }
       ],
-      "enter": "12",
-      "exit": "14",
-      "next": "12"
+      "enter": "13",
+      "exit": "15",
+      "next": "13"
     },
-    "12": {
+    "13": {
       "method": "expression",
-      "ln": "12",
+      "ln": "13",
       "name": [
         "x"
       ],
@@ -126,19 +149,19 @@
           "int": 0
         }
       ],
-      "parent": "11",
-      "next": "14"
-    },
-    "14": {
-      "method": "try",
-      "ln": "14",
-      "enter": "15",
-      "exit": "16",
+      "parent": "12",
       "next": "15"
     },
     "15": {
-      "method": "expression",
+      "method": "try",
       "ln": "15",
+      "enter": "16",
+      "exit": "17",
+      "next": "16"
+    },
+    "16": {
+      "method": "expression",
+      "ln": "16",
       "name": [
         "a"
       ],
@@ -148,22 +171,22 @@
           "int": 0
         }
       ],
-      "parent": "14",
-      "next": "16"
-    },
-    "16": {
-      "method": "catch",
-      "ln": "16",
-      "output": [
-        "e"
-      ],
-      "enter": "17",
-      "exit": "19",
+      "parent": "15",
       "next": "17"
     },
     "17": {
-      "method": "expression",
+      "method": "catch",
       "ln": "17",
+      "output": [
+        "e"
+      ],
+      "enter": "18",
+      "exit": "20",
+      "next": "18"
+    },
+    "18": {
+      "method": "expression",
+      "ln": "18",
       "name": [
         "b"
       ],
@@ -173,12 +196,12 @@
           "int": 0
         }
       ],
-      "parent": "16",
-      "next": "19"
+      "parent": "17",
+      "next": "20"
     },
-    "19": {
+    "20": {
       "method": "expression",
-      "ln": "19",
+      "ln": "20",
       "name": [
         "x"
       ],

--- a/tests/e2e/exit_line.story
+++ b/tests/e2e/exit_line.story
@@ -1,3 +1,4 @@
+items = [0, 1]
 foreach items as item
 	x = item
 

--- a/tests/e2e/foreach.json
+++ b/tests/e2e/foreach.json
@@ -1,8 +1,31 @@
 {
   "tree": {
     "1": {
-      "method": "for",
+      "method": "expression",
       "ln": "1",
+      "name": [
+        "items"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 2
+            }
+          ]
+        }
+      ],
+      "next": "2"
+    },
+    "2": {
+      "method": "for",
+      "ln": "2",
       "output": [
         "item"
       ],
@@ -14,12 +37,12 @@
           ]
         }
       ],
-      "enter": "2",
-      "next": "2"
+      "enter": "3",
+      "next": "3"
     },
-    "2": {
+    "3": {
       "method": "expression",
-      "ln": "2",
+      "ln": "3",
       "name": [
         "x"
       ],
@@ -29,7 +52,7 @@
           "int": 0
         }
       ],
-      "parent": "1"
+      "parent": "2"
     }
   },
   "entrypoint": "1",

--- a/tests/e2e/foreach_key_value.json
+++ b/tests/e2e/foreach_key_value.json
@@ -1,8 +1,33 @@
 {
   "tree": {
     "1": {
-      "method": "for",
+      "method": "expression",
       "ln": "1",
+      "name": [
+        "items"
+      ],
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": [
+            [
+              {
+                "$OBJECT": "string",
+                "string": "2"
+              },
+              {
+                "$OBJECT": "int",
+                "int": 0
+              }
+            ]
+          ]
+        }
+      ],
+      "next": "2"
+    },
+    "2": {
+      "method": "for",
+      "ln": "2",
       "output": [
         "key",
         "value"
@@ -15,12 +40,12 @@
           ]
         }
       ],
-      "enter": "2",
-      "next": "2"
+      "enter": "3",
+      "next": "3"
     },
-    "2": {
+    "3": {
       "method": "expression",
-      "ln": "2",
+      "ln": "3",
       "name": [
         "x"
       ],
@@ -30,7 +55,7 @@
           "int": 0
         }
       ],
-      "parent": "1"
+      "parent": "2"
     }
   },
   "entrypoint": "1",

--- a/tests/e2e/semantics/foreach_infer.json
+++ b/tests/e2e/semantics/foreach_infer.json
@@ -1,0 +1,108 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 2
+            },
+            {
+              "$OBJECT": "int",
+              "int": 3
+            },
+            {
+              "$OBJECT": "int",
+              "int": 4
+            },
+            {
+              "$OBJECT": "int",
+              "int": 5
+            }
+          ]
+        }
+      ],
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "next": "4"
+    },
+    "4": {
+      "method": "for",
+      "ln": "4",
+      "output": [
+        "elem"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "enter": "5",
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "b"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "elem"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "4"
+    }
+  },
+  "entrypoint": "1",
+  "version": null
+}

--- a/tests/e2e/semantics/foreach_infer.story
+++ b/tests/e2e/semantics/foreach_infer.story
@@ -1,0 +1,5 @@
+a = [1, 1, 1, 2, 3, 4, 5]
+b = 0
+
+foreach a as elem
+    b = b + elem

--- a/tests/e2e/semantics/foreach_infer_list.json
+++ b/tests/e2e/semantics/foreach_infer_list.json
@@ -1,0 +1,61 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "next": "3"
+    },
+    "3": {
+      "method": "for",
+      "ln": "3",
+      "output": [
+        "k",
+        "v"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "boolean",
+              "boolean": true
+            },
+            {
+              "$OBJECT": "boolean",
+              "boolean": false
+            }
+          ]
+        }
+      ],
+      "enter": "4",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "v"
+          ]
+        }
+      ],
+      "parent": "3"
+    }
+  },
+  "entrypoint": "1",
+  "version": null
+}

--- a/tests/e2e/semantics/foreach_infer_list.story
+++ b/tests/e2e/semantics/foreach_infer_list.story
@@ -1,0 +1,4 @@
+b = true
+
+foreach [true, false] as k, v
+	b = v

--- a/tests/e2e/semantics/foreach_infer_list2.json
+++ b/tests/e2e/semantics/foreach_infer_list2.json
@@ -1,0 +1,73 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "next": "3"
+    },
+    "3": {
+      "method": "for",
+      "ln": "3",
+      "output": [
+        "k",
+        "v"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "boolean",
+              "boolean": true
+            },
+            {
+              "$OBJECT": "boolean",
+              "boolean": false
+            }
+          ]
+        }
+      ],
+      "enter": "4",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "k"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "3"
+    }
+  },
+  "entrypoint": "1",
+  "version": null
+}

--- a/tests/e2e/semantics/foreach_infer_list2.story
+++ b/tests/e2e/semantics/foreach_infer_list2.story
@@ -1,0 +1,4 @@
+a = 0
+
+foreach [true, false] as k, v
+	a = a + k

--- a/tests/e2e/semantics/foreach_infer_object.json
+++ b/tests/e2e/semantics/foreach_infer_object.json
@@ -1,0 +1,74 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": ""
+        }
+      ],
+      "next": "3"
+    },
+    "3": {
+      "method": "for",
+      "ln": "3",
+      "output": [
+        "elem"
+      ],
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": [
+            [
+              {
+                "$OBJECT": "string",
+                "string": "1"
+              },
+              {
+                "$OBJECT": "int",
+                "int": 2
+              }
+            ]
+          ]
+        }
+      ],
+      "enter": "4",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "b"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "elem"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "3"
+    }
+  },
+  "entrypoint": "1",
+  "version": null
+}

--- a/tests/e2e/semantics/foreach_infer_object.story
+++ b/tests/e2e/semantics/foreach_infer_object.story
@@ -1,0 +1,4 @@
+b = ""
+
+foreach {"1": 2} as elem
+    b = b + elem

--- a/tests/e2e/semantics/foreach_infer_object_kv.json
+++ b/tests/e2e/semantics/foreach_infer_object_kv.json
@@ -1,0 +1,75 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "next": "3"
+    },
+    "3": {
+      "method": "for",
+      "ln": "3",
+      "output": [
+        "k",
+        "v"
+      ],
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": [
+            [
+              {
+                "$OBJECT": "string",
+                "string": "1"
+              },
+              {
+                "$OBJECT": "int",
+                "int": 2
+              }
+            ]
+          ]
+        }
+      ],
+      "enter": "4",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "b"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "v"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "3"
+    }
+  },
+  "entrypoint": "1",
+  "version": null
+}

--- a/tests/e2e/semantics/foreach_infer_object_kv.story
+++ b/tests/e2e/semantics/foreach_infer_object_kv.story
@@ -1,0 +1,4 @@
+b = 0
+
+foreach {"1": 2} as k, v
+    b = b + v

--- a/tests/e2e/semantics/foreach_infer_object_kv2.json
+++ b/tests/e2e/semantics/foreach_infer_object_kv2.json
@@ -1,0 +1,75 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": ""
+        }
+      ],
+      "next": "3"
+    },
+    "3": {
+      "method": "for",
+      "ln": "3",
+      "output": [
+        "k",
+        "v"
+      ],
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": [
+            [
+              {
+                "$OBJECT": "string",
+                "string": "1"
+              },
+              {
+                "$OBJECT": "int",
+                "int": 2
+              }
+            ]
+          ]
+        }
+      ],
+      "enter": "4",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "k"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "3"
+    }
+  },
+  "entrypoint": "1",
+  "version": null
+}

--- a/tests/e2e/semantics/foreach_infer_object_kv2.story
+++ b/tests/e2e/semantics/foreach_infer_object_kv2.story
@@ -1,0 +1,4 @@
+a = ""
+
+foreach {"1": 2} as k, v
+	a = a + k

--- a/tests/e2e/semantics/foreach_invalid1.error
+++ b/tests/e2e/semantics/foreach_invalid1.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 4, column 5
+
+4|        b = b + elem
+          ^
+
+E0100: Can't assign `string` to `int`

--- a/tests/e2e/semantics/foreach_invalid1.story
+++ b/tests/e2e/semantics/foreach_invalid1.story
@@ -1,0 +1,4 @@
+b = 0
+
+foreach ["foo"] as elem
+    b = b + elem

--- a/tests/e2e/semantics/foreach_invalid2.error
+++ b/tests/e2e/semantics/foreach_invalid2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 3, column 18
+
+3|    foreach "foo" as elem
+                       ^^^^
+
+E0106: `foreach` requires an iterable type, but `string` is not

--- a/tests/e2e/semantics/foreach_invalid2.story
+++ b/tests/e2e/semantics/foreach_invalid2.story
@@ -1,0 +1,4 @@
+b = 0
+
+foreach "foo" as elem
+    b = b + elem

--- a/tests/e2e/semantics/foreach_invalid3.error
+++ b/tests/e2e/semantics/foreach_invalid3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 4, column 5
+
+4|        b = b + elem
+          ^
+
+E0100: Can't assign `string` to `int`

--- a/tests/e2e/semantics/foreach_invalid3.story
+++ b/tests/e2e/semantics/foreach_invalid3.story
@@ -1,0 +1,4 @@
+b = 0
+
+foreach {"1": 2} as elem
+    b = b + elem

--- a/tests/e2e/semantics/foreach_invalid4.error
+++ b/tests/e2e/semantics/foreach_invalid4.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 9
+
+1|    foreach items as item
+              ^^^^^
+
+E0101: Variable `items` has not been defined.

--- a/tests/e2e/semantics/foreach_invalid4.story
+++ b/tests/e2e/semantics/foreach_invalid4.story
@@ -1,3 +1,2 @@
-items = [1, 2]
 foreach items as item
 	x = 0

--- a/tests/e2e/semantics/foreach_invalid5.error
+++ b/tests/e2e/semantics/foreach_invalid5.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 9
+
+1|    foreach items as key, value
+              ^^^^^
+
+E0101: Variable `items` has not been defined.

--- a/tests/e2e/semantics/foreach_invalid5.story
+++ b/tests/e2e/semantics/foreach_invalid5.story
@@ -1,3 +1,2 @@
-items = {"2": 0}
 foreach items as key, value
 	x = 0

--- a/tests/e2e/semantics/foreach_invalid6.error
+++ b/tests/e2e/semantics/foreach_invalid6.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 6, column 2
+
+6|    	c = k
+       ^
+
+E0100: Can't assign `any` to `int`

--- a/tests/e2e/semantics/foreach_invalid6.story
+++ b/tests/e2e/semantics/foreach_invalid6.story
@@ -1,0 +1,6 @@
+b = {}
+a = b[0]
+c = 0
+
+foreach a as k
+	c = k

--- a/tests/e2e/semantics/foreach_invalid7.error
+++ b/tests/e2e/semantics/foreach_invalid7.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 8, column 2
+
+8|    	d = v
+       ^
+
+E0100: Can't assign `any` to `int`

--- a/tests/e2e/semantics/foreach_invalid7.story
+++ b/tests/e2e/semantics/foreach_invalid7.story
@@ -1,0 +1,8 @@
+b = {}
+a = b[0]
+c = b[0]
+d = 0
+
+foreach a as k, v
+	c = k
+	d = v

--- a/tests/e2e/semantics/foreach_three_outputs.error
+++ b/tests/e2e/semantics/foreach_three_outputs.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 26
+
+1|    foreach [true, false] as a, b, c
+                               ^
+
+E0105: `foreach` can only have one or two outputs

--- a/tests/e2e/semantics/foreach_three_outputs.story
+++ b/tests/e2e/semantics/foreach_three_outputs.story
@@ -1,0 +1,2 @@
+foreach [true, false] as a, b, c
+	a = a + k


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/742

This uses the expression resolver to lookup the type of the entity used in `foreach` and thus infer the type of either its List or Object type.

