### PR TITLE
fix(compiler): fix args/arguments inconsistency

### DIFF
--- a/storyscript/compiler/json/Objects.py
+++ b/storyscript/compiler/json/Objects.py
@@ -56,7 +56,7 @@ class Objects:
         if tree.command:
             mutation = tree.command.child(0).value
         return {'$OBJECT': 'mutation', 'mutation': mutation,
-                'arguments': arguments}
+                'args': arguments}
 
     @staticmethod
     def number(tree):
@@ -174,7 +174,7 @@ class Objects:
         """
         name = tree.child(0).value
         value = self.expression(tree.child(1))
-        return {'$OBJECT': 'argument', 'name': name, 'argument': value}
+        return {'$OBJECT': 'arg', 'name': name, 'arg': value}
 
     def arguments(self, tree):
         """
@@ -188,7 +188,7 @@ class Objects:
     def typed_argument(self, tree):
         name = tree.child(0).value
         value = self.values(Tree('anon', [tree.child(1)]))
-        return {'$OBJECT': 'argument', 'name': name, 'argument': value}
+        return {'$OBJECT': 'arg', 'name': name, 'arg': value}
 
     def function_arguments(self, tree):
         arguments = []

--- a/tests/e2e/assignments_mutation.json
+++ b/tests/e2e/assignments_mutation.json
@@ -11,11 +11,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "increase",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "by",
-              "argument": {
+              "arg": {
                 "$OBJECT": "int",
                 "int": 1
               }
@@ -39,11 +39,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "increase",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "by",
-              "argument": {
+              "arg": {
                 "$OBJECT": "int",
                 "int": 1
               }
@@ -80,11 +80,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "increase",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "by",
-              "argument": {
+              "arg": {
                 "$OBJECT": "int",
                 "int": 1
               }
@@ -110,11 +110,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "increase",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "by",
-              "argument": {
+              "arg": {
                 "$OBJECT": "int",
                 "int": 1
               }

--- a/tests/e2e/boolean_type.json
+++ b/tests/e2e/boolean_type.json
@@ -23,9 +23,9 @@
       "function": "is_even",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "n",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -112,9 +112,9 @@
       "function": "is_even",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "n",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "a"

--- a/tests/e2e/call_function_expression_nested.json
+++ b/tests/e2e/call_function_expression_nested.json
@@ -6,17 +6,17 @@
       "function": "my_function",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -47,9 +47,9 @@
       "function": "my_function",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "expression",
             "expression": "sum",
             "values": [
@@ -75,9 +75,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "expression",
             "expression": "subtraction",
             "values": [

--- a/tests/e2e/call_function_expression_unary_complex_4.json
+++ b/tests/e2e/call_function_expression_unary_complex_4.json
@@ -6,9 +6,9 @@
       "function": "my_function",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -39,9 +39,9 @@
       "function": "my_function",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "expression",
             "expression": "or",
             "values": [

--- a/tests/e2e/collection_with_mutation.json
+++ b/tests/e2e/collection_with_mutation.json
@@ -14,7 +14,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "increment",
-          "arguments": []
+          "args": []
         }
       ],
       "next": "1"

--- a/tests/e2e/collection_with_service.json
+++ b/tests/e2e/collection_with_service.json
@@ -10,9 +10,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }

--- a/tests/e2e/complex_assert.json
+++ b/tests/e2e/complex_assert.json
@@ -78,9 +78,9 @@
       "command": "info",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "msg",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "true"
           }
@@ -103,9 +103,9 @@
       "command": "info",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "msg",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "false"
           }
@@ -121,9 +121,9 @@
       "command": "info",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "msg",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "completed"
           }

--- a/tests/e2e/concise_when.json
+++ b/tests/e2e/concise_when.json
@@ -21,17 +21,17 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/health"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "method",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "get"
           }

--- a/tests/e2e/concise_when_no_output.json
+++ b/tests/e2e/concise_when_no_output.json
@@ -21,17 +21,17 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/health"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "method",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "get"
           }

--- a/tests/e2e/condensed_when.json
+++ b/tests/e2e/condensed_when.json
@@ -21,17 +21,17 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/health"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "method",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "get"
           }

--- a/tests/e2e/condensed_when_as.json
+++ b/tests/e2e/condensed_when_as.json
@@ -21,17 +21,17 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/health"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "method",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "get"
           }

--- a/tests/e2e/condensed_when_nested.json
+++ b/tests/e2e/condensed_when_nested.json
@@ -58,17 +58,17 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/health"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "method",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "get"
           }

--- a/tests/e2e/condensed_when_nested2.json
+++ b/tests/e2e/condensed_when_nested2.json
@@ -21,9 +21,9 @@
       "command": "log",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "level",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "normal"
           }
@@ -55,9 +55,9 @@
       "command": "log",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "level",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "normal"
           }

--- a/tests/e2e/condensed_when_nested_path.json
+++ b/tests/e2e/condensed_when_nested_path.json
@@ -31,9 +31,9 @@
       "command": "log",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "level",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "normal"
           }
@@ -65,9 +65,9 @@
       "command": "log",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "level",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "normal"
           }

--- a/tests/e2e/expression_is_if_statement.json
+++ b/tests/e2e/expression_is_if_statement.json
@@ -10,9 +10,9 @@
       "command": "tommorow",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "where",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "Amsterdam"
           }
@@ -51,9 +51,9 @@
       "command": "echo",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "message",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "oh no!"
           }

--- a/tests/e2e/expression_mutation_nested.json
+++ b/tests/e2e/expression_mutation_nested.json
@@ -23,11 +23,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "contains",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "item",
-              "argument": {
+              "arg": {
                 "$OBJECT": "string",
                 "string": "a"
               }

--- a/tests/e2e/expression_mutation_while.json
+++ b/tests/e2e/expression_mutation_while.json
@@ -27,11 +27,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "contains",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "item",
-              "argument": {
+              "arg": {
                 "$OBJECT": "int",
                 "int": 1
               }

--- a/tests/e2e/full_string_interpolation_mutation.json
+++ b/tests/e2e/full_string_interpolation_mutation.json
@@ -30,7 +30,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "my_mutation",
-          "arguments": []
+          "args": []
         }
       ],
       "next": "2"

--- a/tests/e2e/full_string_interpolation_service2.json
+++ b/tests/e2e/full_string_interpolation_service2.json
@@ -10,9 +10,9 @@
       "command": "ask",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "q",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "question"
           }

--- a/tests/e2e/full_string_interpolation_services_multiple3.json
+++ b/tests/e2e/full_string_interpolation_services_multiple3.json
@@ -30,9 +30,9 @@
       "command": "c1",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.2"
@@ -40,9 +40,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.3"
@@ -72,9 +72,9 @@
       "command": "c2",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "serv11_c21"
@@ -82,9 +82,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.5"

--- a/tests/e2e/full_string_interpolation_services_multiple4.json
+++ b/tests/e2e/full_string_interpolation_services_multiple4.json
@@ -30,9 +30,9 @@
       "command": "c11",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.2"
@@ -40,9 +40,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.3"
@@ -82,9 +82,9 @@
       "command": "c12",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.5"
@@ -92,9 +92,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.6"
@@ -114,9 +114,9 @@
       "command": "c1",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.4"
@@ -124,9 +124,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.7"
@@ -166,9 +166,9 @@
       "command": "c21",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.9"
@@ -176,9 +176,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.10"
@@ -218,9 +218,9 @@
       "command": "c21",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.12"
@@ -228,9 +228,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.13"
@@ -250,9 +250,9 @@
       "command": "c2",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.11"
@@ -260,9 +260,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.14"

--- a/tests/e2e/function_call.json
+++ b/tests/e2e/function_call.json
@@ -6,9 +6,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -42,9 +42,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }

--- a/tests/e2e/function_call_arguments.json
+++ b/tests/e2e/function_call_arguments.json
@@ -6,9 +6,9 @@
       "function": "f",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "n",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -42,9 +42,9 @@
       "function": "f",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "n",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }

--- a/tests/e2e/function_call_assignment.json
+++ b/tests/e2e/function_call_assignment.json
@@ -6,9 +6,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -42,9 +42,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }

--- a/tests/e2e/function_call_multi_args.json
+++ b/tests/e2e/function_call_multi_args.json
@@ -6,17 +6,17 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -50,17 +50,17 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }

--- a/tests/e2e/function_call_nested.json
+++ b/tests/e2e/function_call_nested.json
@@ -6,9 +6,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -42,9 +42,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 4
           }
@@ -61,9 +61,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-4.1"
@@ -82,9 +82,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-4.2"

--- a/tests/e2e/function_call_three_inline_exprs.json
+++ b/tests/e2e/function_call_three_inline_exprs.json
@@ -40,9 +40,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.1"
@@ -50,9 +50,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.2"
@@ -60,9 +60,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p3",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.3"

--- a/tests/e2e/function_call_with_service.json
+++ b/tests/e2e/function_call_with_service.json
@@ -32,17 +32,17 @@
       "function": "my_func",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -107,17 +107,17 @@
       "function": "random",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }
@@ -144,9 +144,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "param1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-8.1"
@@ -154,9 +154,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "param2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-8.2"
@@ -164,9 +164,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "param3",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-8.3"

--- a/tests/e2e/function_call_with_service_nested.json
+++ b/tests/e2e/function_call_with_service_nested.json
@@ -32,17 +32,17 @@
       "function": "my_func",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
@@ -83,9 +83,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-7.1"
@@ -93,9 +93,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }
@@ -112,9 +112,9 @@
       "function": "my_func",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-7.2"
@@ -134,9 +134,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p0",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-7.3"
@@ -144,9 +144,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p2",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }

--- a/tests/e2e/function_call_zero_args.json
+++ b/tests/e2e/function_call_zero_args.json
@@ -6,9 +6,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }

--- a/tests/e2e/if_with_mutation.json
+++ b/tests/e2e/if_with_mutation.json
@@ -30,7 +30,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "increment",
-          "arguments": []
+          "args": []
         }
       ],
       "next": "2.2"
@@ -51,7 +51,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "decrement",
-          "arguments": []
+          "args": []
         }
       ],
       "next": "2"

--- a/tests/e2e/if_with_nested_service.json
+++ b/tests/e2e/if_with_nested_service.json
@@ -10,9 +10,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }
@@ -30,9 +30,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }
@@ -50,9 +50,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.1"
@@ -60,9 +60,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.2"
@@ -82,9 +82,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }
@@ -102,9 +102,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }
@@ -122,9 +122,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.4"
@@ -132,9 +132,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.5"
@@ -154,9 +154,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }
@@ -174,9 +174,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }
@@ -194,9 +194,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.7"
@@ -204,9 +204,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.8"
@@ -226,9 +226,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }
@@ -246,9 +246,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }
@@ -266,9 +266,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.10"
@@ -276,9 +276,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.11"

--- a/tests/e2e/if_with_service.json
+++ b/tests/e2e/if_with_service.json
@@ -10,17 +10,17 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p2",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 2
           }
@@ -38,17 +38,17 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p3",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 3
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p4",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 4
           }

--- a/tests/e2e/multi_line_function_arguments.json
+++ b/tests/e2e/multi_line_function_arguments.json
@@ -6,33 +6,33 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key2",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "string"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key3",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key4",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "string"
           }

--- a/tests/e2e/mutation_assignment.json
+++ b/tests/e2e/mutation_assignment.json
@@ -30,7 +30,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "uppercase",
-          "arguments": []
+          "args": []
         }
       ]
     }

--- a/tests/e2e/mutation_expression.json
+++ b/tests/e2e/mutation_expression.json
@@ -36,11 +36,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "contains",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "item",
-              "argument": {
+              "arg": {
                 "$OBJECT": "expression",
                 "expression": "equal",
                 "values": [

--- a/tests/e2e/mutation_expression_list.json
+++ b/tests/e2e/mutation_expression_list.json
@@ -20,11 +20,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "contains",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "item",
-              "argument": {
+              "arg": {
                 "$OBJECT": "string",
                 "string": "opened"
               }

--- a/tests/e2e/mutation_expression_object.json
+++ b/tests/e2e/mutation_expression_object.json
@@ -32,11 +32,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "has",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "key",
-              "argument": {
+              "arg": {
                 "$OBJECT": "string",
                 "string": "opened"
               }

--- a/tests/e2e/mutation_value.json
+++ b/tests/e2e/mutation_value.json
@@ -11,7 +11,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "length",
-          "arguments": []
+          "args": []
         }
       ]
     }

--- a/tests/e2e/nested_services.json
+++ b/tests/e2e/nested_services.json
@@ -30,9 +30,9 @@
       "command": "c11",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.1"
@@ -40,9 +40,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.2"
@@ -82,9 +82,9 @@
       "command": "c12",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.4"
@@ -92,9 +92,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.5"
@@ -114,9 +114,9 @@
       "command": "c1",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.3"
@@ -124,9 +124,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.6"
@@ -166,9 +166,9 @@
       "command": "c21",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.8"
@@ -176,9 +176,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.9"
@@ -218,9 +218,9 @@
       "command": "c21",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.11"
@@ -228,9 +228,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.12"
@@ -250,9 +250,9 @@
       "command": "c2",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.10"
@@ -260,9 +260,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.13"

--- a/tests/e2e/normal_when.json
+++ b/tests/e2e/normal_when.json
@@ -21,17 +21,17 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/health"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "method",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "get"
           }

--- a/tests/e2e/obj_with_mutation.json
+++ b/tests/e2e/obj_with_mutation.json
@@ -14,7 +14,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "increment",
-          "arguments": []
+          "args": []
         }
       ],
       "next": "1"

--- a/tests/e2e/obj_with_service.json
+++ b/tests/e2e/obj_with_service.json
@@ -10,9 +10,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 1
           }

--- a/tests/e2e/regex_after_name5.json
+++ b/tests/e2e/regex_after_name5.json
@@ -7,9 +7,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "item",
-          "argument": {
+          "arg": {
             "$OBJECT": "regexp",
             "regexp": "/regexp/"
           }

--- a/tests/e2e/return_complex_expression.json
+++ b/tests/e2e/return_complex_expression.json
@@ -6,9 +6,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }

--- a/tests/e2e/return_complex_expression_2.json
+++ b/tests/e2e/return_complex_expression_2.json
@@ -6,9 +6,9 @@
       "function": "name",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "key",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }

--- a/tests/e2e/return_required4.json
+++ b/tests/e2e/return_required4.json
@@ -9,9 +9,9 @@
       "function": "sum",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "a",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }

--- a/tests/e2e/return_required6.json
+++ b/tests/e2e/return_required6.json
@@ -9,9 +9,9 @@
       "function": "sum",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "a",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }

--- a/tests/e2e/return_required7.json
+++ b/tests/e2e/return_required7.json
@@ -9,9 +9,9 @@
       "function": "sum",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "a",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }

--- a/tests/e2e/return_required8.json
+++ b/tests/e2e/return_required8.json
@@ -9,9 +9,9 @@
       "function": "sum",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "a",
-          "argument": {
+          "arg": {
             "$OBJECT": "type",
             "type": "int"
           }

--- a/tests/e2e/return_with_mutation.json
+++ b/tests/e2e/return_with_mutation.json
@@ -38,7 +38,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "decrement",
-          "arguments": []
+          "args": []
         }
       ],
       "parent": "1",

--- a/tests/e2e/service.json
+++ b/tests/e2e/service.json
@@ -7,9 +7,9 @@
       "command": "echo",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "message",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "hello"
           }

--- a/tests/e2e/service_expression.json
+++ b/tests/e2e/service_expression.json
@@ -7,9 +7,9 @@
       "command": "my_command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "expression",
             "expression": "sum",
             "values": [
@@ -25,9 +25,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "expression",
             "expression": "equal",
             "values": [

--- a/tests/e2e/service_indented.json
+++ b/tests/e2e/service_indented.json
@@ -10,17 +10,17 @@
       "command": "echo",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "message",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "hello"
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "colour",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "red"
           }

--- a/tests/e2e/service_inline_expression.json
+++ b/tests/e2e/service_inline_expression.json
@@ -17,9 +17,9 @@
       "command": "echo",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "text",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.1"

--- a/tests/e2e/service_inline_expression_nested.json
+++ b/tests/e2e/service_inline_expression_nested.json
@@ -20,9 +20,9 @@
       "command": "get",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "id",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.1"
@@ -39,9 +39,9 @@
       "command": "message",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "text",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.2"

--- a/tests/e2e/service_mutation.json
+++ b/tests/e2e/service_mutation.json
@@ -10,9 +10,9 @@
       "command": "get",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "url",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "diff_url"
@@ -38,11 +38,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "split",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "by",
-              "argument": {
+              "arg": {
                 "$OBJECT": "string",
                 "string": "\n"
               }

--- a/tests/e2e/service_mutation2.json
+++ b/tests/e2e/service_mutation2.json
@@ -10,9 +10,9 @@
       "command": "get",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "url",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "diff_url"
@@ -38,11 +38,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "split",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "by",
-              "argument": {
+              "arg": {
                 "$OBJECT": "string",
                 "string": "\n"
               }

--- a/tests/e2e/string_templates_complicated_concat.json
+++ b/tests/e2e/string_templates_complicated_concat.json
@@ -74,9 +74,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "expression",
             "expression": "sum",
             "values": [

--- a/tests/e2e/string_templates_if_else_service.json
+++ b/tests/e2e/string_templates_if_else_service.json
@@ -20,9 +20,9 @@
       "command": "inline1",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.5"
@@ -52,9 +52,9 @@
       "command": "inline2",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.6"
@@ -84,9 +84,9 @@
       "command": "inline1",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.7"
@@ -116,9 +116,9 @@
       "command": "inline2",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.8"
@@ -148,9 +148,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.9"
@@ -158,9 +158,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.1"
@@ -190,9 +190,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.11"
@@ -200,9 +200,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.2"
@@ -232,9 +232,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.13"
@@ -242,9 +242,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.3"
@@ -274,9 +274,9 @@
       "command": "call",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg1",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.15"
@@ -284,9 +284,9 @@
           }
         },
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "arg2",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "__p-1.4"

--- a/tests/e2e/unary_complex_5.json
+++ b/tests/e2e/unary_complex_5.json
@@ -10,9 +10,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k1",
-          "argument": {
+          "arg": {
             "$OBJECT": "expression",
             "expression": "not",
             "values": [
@@ -38,9 +38,9 @@
       "command": "command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "k2",
-          "argument": {
+          "arg": {
             "$OBJECT": "expression",
             "expression": "not",
             "values": [

--- a/tests/e2e/when_complex.json
+++ b/tests/e2e/when_complex.json
@@ -36,9 +36,9 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/foo"
           }
@@ -64,9 +64,9 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/foo"
           }
@@ -136,9 +136,9 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/foo"
           }
@@ -164,9 +164,9 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/foo"
           }
@@ -275,9 +275,9 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/foo"
           }
@@ -315,9 +315,9 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/foo"
           }

--- a/tests/e2e/when_enter_line_fake_assignment.json
+++ b/tests/e2e/when_enter_line_fake_assignment.json
@@ -21,9 +21,9 @@
       "command": "listen",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "path",
-          "argument": {
+          "arg": {
             "$OBJECT": "string",
             "string": "/test"
           }

--- a/tests/e2e/while_complex_expressions.json
+++ b/tests/e2e/while_complex_expressions.json
@@ -30,11 +30,11 @@
         {
           "$OBJECT": "mutation",
           "mutation": "increment",
-          "arguments": [
+          "args": [
             {
-              "$OBJECT": "argument",
+              "$OBJECT": "arg",
               "name": "by",
-              "argument": {
+              "arg": {
                 "$OBJECT": "int",
                 "int": 1
               }
@@ -65,9 +65,9 @@
       "command": "echo",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "message",
-          "argument": {
+          "arg": {
             "$OBJECT": "path",
             "paths": [
               "i"

--- a/tests/e2e/while_with_mutation.json
+++ b/tests/e2e/while_with_mutation.json
@@ -30,7 +30,7 @@
         {
           "$OBJECT": "mutation",
           "mutation": "is_odd",
-          "arguments": []
+          "args": []
         }
       ],
       "next": "2"

--- a/tests/e2e/while_with_service.json
+++ b/tests/e2e/while_with_service.json
@@ -10,9 +10,9 @@
       "command": "my_command",
       "args": [
         {
-          "$OBJECT": "argument",
+          "$OBJECT": "arg",
           "name": "p1",
-          "argument": {
+          "arg": {
             "$OBJECT": "int",
             "int": 42
           }

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -14,10 +14,10 @@ def test_compiler_mutation_chained(source):
     """
     result = Api.loads(source)
     args = [{'$OBJECT': 'int', 'int': 1},
-            {'$OBJECT': 'mutation', 'mutation': 'increment', 'arguments': []},
-            {'$OBJECT': 'mutation', 'mutation': 'format', 'arguments': [
-                {'$OBJECT': 'argument', 'name': 'to',
-                 'argument': {'$OBJECT': 'string', 'string': 'string'}}]}]
+            {'$OBJECT': 'mutation', 'mutation': 'increment', 'args': []},
+            {'$OBJECT': 'mutation', 'mutation': 'format', 'args': [
+                {'$OBJECT': 'arg', 'name': 'to',
+                 'arg': {'$OBJECT': 'string', 'string': 'string'}}]}]
     assert result['tree']['1']['args'] == args
 
 

--- a/tests/integration/compiler/Functions.py
+++ b/tests/integration/compiler/Functions.py
@@ -21,8 +21,8 @@ def test_functions_function_argument():
     """
     result = Api.loads('function echo a:string\n\tx = a')
     args = [{
-        '$OBJECT': 'argument',
-        'argument': {'$OBJECT': 'type', 'type': 'string'}, 'name': 'a'
+        '$OBJECT': 'arg',
+        'arg': {'$OBJECT': 'type', 'type': 'string'}, 'name': 'a'
     }]
     assert result['tree']['1']['function'] == 'echo'
     assert result['tree']['1']['args'] == args

--- a/tests/unittests/compiler/json/Objects.py
+++ b/tests/unittests/compiler/json/Objects.py
@@ -71,7 +71,7 @@ def test_objects_mutation_fragment(token):
     """
     tree = Tree('mutation', [token])
     expected = {'$OBJECT': 'mutation', 'mutation': token.value,
-                'arguments': []}
+                'args': []}
     assert Objects().mutation_fragment(tree) == expected
 
 
@@ -81,7 +81,7 @@ def test_objects_mutation_fragment_from_service(token):
     """
     tree = Tree('service_fragment', [Tree('command', [token])])
     expected = {'$OBJECT': 'mutation', 'mutation': token.value,
-                'arguments': []}
+                'args': []}
     assert Objects().mutation_fragment(tree) == expected
 
 
@@ -94,7 +94,7 @@ def test_objects_mutation_fragment_arguments(patch, magic):
     tree = magic()
     result = Objects().mutation_fragment(tree)
     Objects.arguments.assert_called_with(tree)
-    assert result['arguments'] == Objects.arguments()
+    assert result['args'] == Objects.arguments()
 
 
 def test_objects_path_fragments(magic):
@@ -279,8 +279,8 @@ def test_objects_argument(patch, tree):
     result = Objects().argument(tree)
     assert tree.child.call_count == 2
     Objects.expression.assert_called_with(tree.child())
-    expected = {'$OBJECT': 'argument', 'name': tree.child().value,
-                'argument': Objects.expression()}
+    expected = {'$OBJECT': 'arg', 'name': tree.child().value,
+                'arg': Objects.expression()}
     assert result == expected
 
 
@@ -297,8 +297,8 @@ def test_objects_typed_argument(patch, tree):
     patch.object(Objects, 'values')
     result = Objects().typed_argument(tree)
     Objects.values.assert_called_with(Tree('anon', [tree.child(1)]))
-    expected = {'$OBJECT': 'argument', 'name': tree.child().value,
-                'argument': Objects.values()}
+    expected = {'$OBJECT': 'arg', 'name': tree.child().value,
+                'arg': Objects.values()}
     assert result == expected
 
 


### PR DESCRIPTION
Second part of https://github.com/storyscript/storyscript/issues/591

**- Description for the changelog**

- `arguments` are now always named `args` in the JSON output (and similarly `argument` is always named `arg`)
