### PR TITLE
fix(grammar): allow list indexing with arbitrary expressions

### DIFF
--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -83,11 +83,13 @@ class Grammar:
         self.ebnf._DOT = '.'
         path_fragment = 'dot name, osb int csb, osb string csb, osb path csb'
         self.ebnf.path_fragment = path_fragment
-        self.ebnf.path = ('name (path_fragment)* | '
+        self.ebnf.path = ('(values | name) (path_fragment)* | '
                           'inline_expression (path_fragment)*')
+        self.ebnf.name_path = ('name (path_fragment)* | '
+                               'inline_expression (path_fragment)*')
         assignment_fragment = 'equals base_expression'
         self.ebnf.assignment_fragment = assignment_fragment
-        self.ebnf.assignment = 'path assignment_fragment'
+        self.ebnf.assignment = 'name_path assignment_fragment'
 
     def imports(self):
         self.ebnf._AS = 'as'
@@ -151,7 +153,7 @@ class Grammar:
         self.ebnf.BREAK = 'break'
         self.ebnf.return_statement = 'return base_expression?'
         self.ebnf.break_statement = 'break'
-        self.ebnf.entity = 'values, path'
+        self.ebnf.entity = 'path'
         rules = ('absolute_expression, assignment, imports, return_statement, '
                  'throw_statement, break_statement, block')
         self.ebnf.rules = rules

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -72,6 +72,18 @@ class Transformer(LarkTransformer):
 
     @classmethod
     def path(cls, matches):
+        match = matches[0]
+        if isinstance(match, Tree) and match.data == 'values':
+            assert len(matches) == 1
+            return match
+
+        cls.is_keyword(matches[0])
+        return Tree('path', matches)
+
+    def name_path(cls, matches):
+        """
+        A name path is a path without any possibility of having an entity.
+        """
         cls.is_keyword(matches[0])
         return Tree('path', matches)
 


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/522

This is not ready yet, because I still need to figure out:
- how to this change without creating conflicts in Lark (the tests fail because the existing path references should be replaced with `path_name`, but that creates conflicts)
- what json to emit (fake lines again?)