### PR TITLE
fix(exceptions): show correct column location with tabs

### DIFF
--- a/tests/e2e/multi_line_function_arguments2.error
+++ b/tests/e2e/multi_line_function_arguments2.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 4
 
-3|    	a =0
-         ^
+3|      a =0
+          ^
 
 E0041: `=` is not allowed here

--- a/tests/e2e/semantics/foreach_dict_key_float.error
+++ b/tests/e2e/semantics/foreach_dict_key_float.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 2
 
-3|    	k = "a"
-       ^
+3|      k = "a"
+        ^
 
 E0100: Can't assign `string` to `float`

--- a/tests/e2e/semantics/foreach_dict_key_int.error
+++ b/tests/e2e/semantics/foreach_dict_key_int.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 2
 
-3|    	k = "a"
-       ^
+3|      k = "a"
+        ^
 
 E0100: Can't assign `string` to `int`

--- a/tests/e2e/semantics/foreach_invalid6.error
+++ b/tests/e2e/semantics/foreach_invalid6.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 6, column 2
 
-6|    	c = k
-       ^
+6|      c = k
+        ^
 
 E0100: Can't assign `any` to `int`

--- a/tests/e2e/semantics/foreach_invalid7.error
+++ b/tests/e2e/semantics/foreach_invalid7.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 8, column 2
 
-8|    	d = v
-       ^
+8|      d = v
+        ^
 
 E0100: Can't assign `any` to `int`

--- a/tests/e2e/semantics/return_null.error
+++ b/tests/e2e/semantics/return_null.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 2
 
-2|    	return
-       ^^^^^^
+2|      return
+        ^^^^^^
 
 E0102: `none` can't be implicitly converted to expected return type `int`.

--- a/tests/e2e/semantics/service_block_output_invalid.error
+++ b/tests/e2e/semantics/service_block_output_invalid.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 4, column 3
 
-4|    		a = b
-        ^
+4|        a = b
+          ^
 
 E0100: Can't assign `any` to `int`

--- a/tests/e2e/semantics/when_output_invalid.error
+++ b/tests/e2e/semantics/when_output_invalid.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 4, column 3
 
-4|    		a = req
-        ^
+4|        a = req
+          ^
 
 E0100: Can't assign `any` to `int`

--- a/tests/e2e/semantics/when_output_invalid2.error
+++ b/tests/e2e/semantics/when_output_invalid2.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 24
 
-3|    	when server listen as req, b
-                             ^^^
+3|      when server listen as req, b
+                              ^^^
 
 E0107: Only one output is allowed for `when` blocks.

--- a/tests/e2e/tab_error.error
+++ b/tests/e2e/tab_error.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 7
+
+2|        a = $
+              ^
+
+E0041: `$` is not allowed here

--- a/tests/e2e/tab_error.story
+++ b/tests/e2e/tab_error.story
@@ -1,0 +1,2 @@
+while true
+		a = $

--- a/tests/e2e/tab_error2.error
+++ b/tests/e2e/tab_error2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 7
+
+2|        a = '{}  '
+              ^^^^^^
+
+E0060: String templates can't be empty

--- a/tests/e2e/tab_error2.story
+++ b/tests/e2e/tab_error2.story
@@ -1,0 +1,2 @@
+while true
+		a = '{}	'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/573

Not super happy with this yet, but it does fix the issue.
The problem here is that tabs will align to the nearest tab unit and with the preceding spaces this happens:

![image](https://user-images.githubusercontent.com/4370550/55842813-66f16080-5b35-11e9-87e6-0637179e6f66.png)

In other words the `tab` is only one real space long. Moreover, for the location of the start and endcolumn, the tab character was counted as a single character.

So this solution, replaces all tabs in the printed line and adjusts the start and end_column accordingly.
This works, but is rather ugly and requires us to select a tab to space conversion width.