### PR TITLE
feat(compiler): don't allow 'as <output>' in service inline expressions

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -111,6 +111,8 @@ class ErrorCodes:
     )
     output_unique = (
         'E0108', 'Service output `{name}` must be unique. Use `as outputName`')
+    service_no_inline_output = (
+        'E0109', 'Inline service calls can\'t define an output')
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -224,6 +224,9 @@ class ExpressionResolver:
             return self.expression(child)
         elif child.data == 'service':
             # unknown for now
+            if child.service_fragment.output is not None:
+                child.service_fragment.output.expect(
+                    0, 'service_no_inline_output')
             return AnyType.instance()
         elif child.data == 'mutation':
             # unknown for now

--- a/tests/e2e/inline_service_output.error
+++ b/tests/e2e/inline_service_output.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 22
+
+1|    a = (listen command) as client
+                           ^
+
+E0007: Missing value after `=`

--- a/tests/e2e/inline_service_output.story
+++ b/tests/e2e/inline_service_output.story
@@ -1,0 +1,1 @@
+a = (listen command) as client

--- a/tests/e2e/inline_service_output2.error
+++ b/tests/e2e/inline_service_output2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 24
+
+1|    a = (listen command as client)
+                             ^^^^^^
+
+E0109: Inline service calls can't define an output

--- a/tests/e2e/inline_service_output2.story
+++ b/tests/e2e/inline_service_output2.story
@@ -1,0 +1,1 @@
+a = (listen command as client)

--- a/tests/e2e/inline_service_output3.error
+++ b/tests/e2e/inline_service_output3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 24
+
+1|    a = (listen command as client) + 0
+                             ^^^^^^
+
+E0109: Inline service calls can't define an output

--- a/tests/e2e/inline_service_output3.story
+++ b/tests/e2e/inline_service_output3.story
@@ -1,0 +1,1 @@
+a = (listen command as client) + 0

--- a/tests/e2e/inline_service_output4.error
+++ b/tests/e2e/inline_service_output4.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 25
+
+1|    a = "{listen command as client}"
+                              ^^^^^^
+
+E0109: Inline service calls can't define an output

--- a/tests/e2e/inline_service_output4.story
+++ b/tests/e2e/inline_service_output4.story
@@ -1,0 +1,1 @@
+a = "{listen command as client}"


### PR DESCRIPTION
Fixes #662 

Supersedes https://github.com/storyscript/storyscript/pull/717