### PR TITLE
feat(semantics): check function without return type for their returns

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -131,6 +131,10 @@ class ErrorCodes:
         'E0108', 'Service output `{name}` must be unique. Use `as outputName`')
     service_no_inline_output = (
         'E0109', 'Inline service calls can\'t define an output')
+    function_without_output_return = (
+        'E0110',
+        ('Function has no return output defined. '
+         'Only `return` is allowed.'))
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/semantics/ReturnVisitor.py
+++ b/storyscript/compiler/semantics/ReturnVisitor.py
@@ -63,6 +63,14 @@ class ReturnVisitor:
                     target=self.return_type,
                     source=ret_type
                 )
+        else:
+            # function has no return output, so only `return` may be used
+            for ret in tree.find_data('return_statement'):
+                ret_type, obj = self.return_statement(ret, scope)
+                obj.expect(
+                    ret_type == NoneType.instance(),
+                    'function_without_output_return',
+                )
 
     @classmethod
     def check(cls, tree, scope, return_type):

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -71,10 +71,17 @@ class StoryError(SyntaxError):
         """
         Creates the repeated symbols that mark the error.
         """
-        end_column = int(self.error.column) + 1
-        if hasattr(self.error, 'end_column'):
-            end_column = int(self.error.end_column)
-        start_column = int(self.error.column)
+        if self.error.column != 'None':
+            end_column = int(self.error.column) + 1
+            if hasattr(self.error, 'end_column'):
+                end_column = int(self.error.end_column)
+            start_column = int(self.error.column)
+        else:
+            # if the column is not known, start at the first non-whitespace
+            # token
+            # columns are 1-indexed
+            start_column = len(line) - len(line.lstrip()) + 1
+            end_column = len(line) + 1
 
         # add tab offset
         start_column += line.count('\t', 0, start_column) * (self.tabwidth - 1)

--- a/tests/e2e/call_function_expression_nested.json
+++ b/tests/e2e/call_function_expression_nested.json
@@ -3,6 +3,9 @@
     "1": {
       "method": "function",
       "ln": "1",
+      "output": [
+        "int"
+      ],
       "function": "my_function",
       "args": [
         {
@@ -23,7 +26,7 @@
         }
       ],
       "enter": "2",
-      "exit": "4.1",
+      "exit": "4",
       "next": "2"
     },
     "2": {
@@ -36,13 +39,55 @@
         }
       ],
       "parent": "1",
-      "next": "4.1"
+      "next": "4"
     },
-    "4.1": {
-      "method": "call",
-      "ln": "4.1",
+    "4": {
+      "method": "expression",
+      "ln": "4",
       "name": [
-        "__p-4.1"
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "next": "6"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "next": "7.1"
+    },
+    "7.1": {
+      "method": "call",
+      "ln": "7.1",
+      "name": [
+        "__p-7.1"
       ],
       "function": "my_function",
       "args": [
@@ -109,16 +154,16 @@
           }
         }
       ],
-      "next": "4"
+      "next": "7"
     },
-    "4": {
+    "7": {
       "method": "expression",
-      "ln": "4",
+      "ln": "7",
       "args": [
         {
           "$OBJECT": "path",
           "paths": [
-            "__p-4.1"
+            "__p-7.1"
           ]
         }
       ]

--- a/tests/e2e/call_function_expression_nested.story
+++ b/tests/e2e/call_function_expression_nested.story
@@ -1,4 +1,7 @@
-function my_function k1: int k2:int
+function my_function k1: int k2:int returns int
 	return 0
 
+a = 0
+b = 1
+c = 0
 my_function (k1: 2 + 2 % 4 k2: a / b - c)

--- a/tests/e2e/call_function_expression_unary_complex_4.json
+++ b/tests/e2e/call_function_expression_unary_complex_4.json
@@ -3,6 +3,9 @@
     "1": {
       "method": "function",
       "ln": "1",
+      "output": [
+        "int"
+      ],
       "function": "my_function",
       "args": [
         {

--- a/tests/e2e/call_function_expression_unary_complex_4.story
+++ b/tests/e2e/call_function_expression_unary_complex_4.story
@@ -1,4 +1,4 @@
-function my_function k1:int
+function my_function k1:int returns int
 	return 0
 
 a = my_function(k1: !b or 2)

--- a/tests/e2e/function_invalid_return.error
+++ b/tests/e2e/function_invalid_return.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 9
+
+2|      return a / b + c or d
+               ^
+
+E0101: Variable `a` has not been defined.

--- a/tests/e2e/function_invalid_return.story
+++ b/tests/e2e/function_invalid_return.story
@@ -1,0 +1,2 @@
+function name key:int
+	return a / b + c or d

--- a/tests/e2e/function_return_mutation_without_type.error
+++ b/tests/e2e/function_return_mutation_without_type.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 3, column None
+
+3|      return my_int decrement
+        ^^^^^^^^^^^^^^^^^^^^^^^
+
+E0110: Function has no return output defined. Only `return` is allowed.

--- a/tests/e2e/function_return_mutation_without_type.story
+++ b/tests/e2e/function_return_mutation_without_type.story
@@ -1,3 +1,3 @@
-function random returns any
+function random
 	my_int = 5
 	return my_int decrement

--- a/tests/e2e/function_return_service_without_type.error
+++ b/tests/e2e/function_return_service_without_type.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column None
+
+2|      return my_random_service get_integer
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+E0110: Function has no return output defined. Only `return` is allowed.

--- a/tests/e2e/function_return_service_without_type.story
+++ b/tests/e2e/function_return_service_without_type.story
@@ -1,2 +1,2 @@
-function random returns any
+function random
 	return my_random_service get_integer

--- a/tests/e2e/function_without_return_returns_value.error
+++ b/tests/e2e/function_without_return_returns_value.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 9
+
+2|      return 0
+               ^
+
+E0110: Function has no return output defined. Only `return` is allowed.

--- a/tests/e2e/function_without_return_returns_value.story
+++ b/tests/e2e/function_without_return_returns_value.story
@@ -1,0 +1,2 @@
+function my_function k1:int
+	return 0

--- a/tests/e2e/function_without_return_returns_value2.error
+++ b/tests/e2e/function_without_return_returns_value2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 5, column 11
+
+5|          return 0
+                   ^
+
+E0110: Function has no return output defined. Only `return` is allowed.

--- a/tests/e2e/function_without_return_returns_value2.story
+++ b/tests/e2e/function_without_return_returns_value2.story
@@ -1,0 +1,5 @@
+function my_function k1:int
+	items = [1]
+	if true
+		foreach items as i
+			return 0

--- a/tests/e2e/return_complex_expression.json
+++ b/tests/e2e/return_complex_expression.json
@@ -3,6 +3,9 @@
     "1": {
       "method": "function",
       "ln": "1",
+      "output": [
+        "int"
+      ],
       "function": "name",
       "args": [
         {

--- a/tests/e2e/return_complex_expression.story
+++ b/tests/e2e/return_complex_expression.story
@@ -1,2 +1,2 @@
-function name key:int
+function name key:int returns int
 	return 2 + 2

--- a/tests/e2e/return_complex_expression_2.json
+++ b/tests/e2e/return_complex_expression_2.json
@@ -3,6 +3,9 @@
     "1": {
       "method": "function",
       "ln": "1",
+      "output": [
+        "int"
+      ],
       "function": "name",
       "args": [
         {
@@ -18,8 +21,68 @@
       "next": "2"
     },
     "2": {
-      "method": "return",
+      "method": "expression",
       "ln": "2",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "parent": "1",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "parent": "1",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "parent": "1",
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "parent": "1",
+      "next": "6"
+    },
+    "6": {
+      "method": "return",
+      "ln": "6",
       "args": [
         {
           "$OBJECT": "expression",

--- a/tests/e2e/return_complex_expression_2.story
+++ b/tests/e2e/return_complex_expression_2.story
@@ -1,2 +1,6 @@
-function name key:int
+function name key:int returns int
+	a = 0
+	b = 0
+	c = 0
+	d = 0
 	return a / b + c or d

--- a/tests/e2e/return_with_mutation.json
+++ b/tests/e2e/return_with_mutation.json
@@ -3,6 +3,9 @@
     "1": {
       "method": "function",
       "ln": "1",
+      "output": [
+        "any"
+      ],
       "function": "random",
       "enter": "2",
       "next": "2"

--- a/tests/e2e/return_with_service.json
+++ b/tests/e2e/return_with_service.json
@@ -3,6 +3,9 @@
     "1": {
       "method": "function",
       "ln": "1",
+      "output": [
+        "any"
+      ],
       "function": "random",
       "enter": "2.1",
       "next": "2.1"

--- a/tests/e2e/time_type.json
+++ b/tests/e2e/time_type.json
@@ -3,6 +3,9 @@
     "1": {
       "method": "function",
       "ln": "1",
+      "output": [
+        "time"
+      ],
       "function": "foo",
       "args": [
         {

--- a/tests/e2e/time_type.story
+++ b/tests/e2e/time_type.story
@@ -1,4 +1,4 @@
-function foo arg1: time
+function foo arg1: time returns time
 	return 5s
 
 foo(arg1: 10s)

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -88,11 +88,12 @@ def test_exceptions_dollar(capsys):
 
 def test_exceptions_function_redeclared(capsys):
     with raises(StoryError) as e:
-        Story('function f1\n\treturn 42\nfunction f1\n\treturn 42\n').process()
+        Story('function f1 returns int\n\treturn 42\n'
+              'function f1 returns int\n\treturn 42\n').process()
     e.value.with_color = False
     lines = e.value.message().splitlines()
     assert lines[0] == 'Error: syntax error in story at line 3, column 10'
-    assert lines[2] == '3|    function f1'
+    assert lines[2] == '3|    function f1 returns int'
     assert lines[5] == 'E0042: `f1` has already been declared at line 1'
 
 

--- a/tests/integration/compiler/Functions.py
+++ b/tests/integration/compiler/Functions.py
@@ -43,7 +43,7 @@ def test_functions_function_return():
     """
     Ensures that return statements are compiled correctly
     """
-    result = Api.loads('function f\n\treturn 0')
+    result = Api.loads('function f returns int\n\treturn 0')
     assert result['tree']['2']['method'] == 'return'
     assert result['tree']['2']['args'] == [{'$OBJECT': 'int', 'int': 0}]
     assert result['tree']['2']['parent'] == '1'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/780

This is no longer allowed:

```coffee
function my_function
	return 0

my_function ()
```

yields:

<details>

```json
Error: syntax error in story at line 2, column 9

2|      return 0
               ^

E0110: Function has no return output defined. Only `return` is allowed.
```

</details>
