### PR TITLE
feat(compiler): add support for default arguments

### DIFF
--- a/storyscript/compiler/json/Objects.py
+++ b/storyscript/compiler/json/Objects.py
@@ -214,7 +214,11 @@ class Objects:
         Compiles an argument tree to the corresponding object.
         """
         name = tree.child(0).value
-        value = self.expression(tree.child(1))
+        c = tree.child(1)
+        if c.data == 'entity':
+            value = self.entity(c)
+        else:
+            value = self.expression(c)
         return {'$OBJECT': 'arg', 'name': name, 'arg': value}
 
     def arguments(self, tree):
@@ -228,7 +232,7 @@ class Objects:
 
     def typed_argument(self, tree):
         name = tree.child(0).value
-        value = self.values(Tree('anon', [tree.child(1)]))
+        value = {'$OBJECT': 'type', 'type': str(tree.child(1))}
         return {'$OBJECT': 'arg', 'name': name, 'arg': value}
 
     def function_arguments(self, tree):

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from lark.lexer import Token
 
 from storyscript.compiler.visitors.ExpressionVisitor import ExpressionVisitor
 from storyscript.parser import Tree
@@ -71,6 +72,12 @@ class ExpressionResolver:
     def path(self, tree):
         assert tree.data == 'path'
         return self.path_resolver.path(tree).type()
+
+    def entity(self, tree):
+        """
+        Compiles an entity expression with the given tree
+        """
+        return self.expr_visitor.entity(tree)
 
     def number(self, tree):
         """
@@ -254,7 +261,12 @@ class ExpressionResolver:
                 type_ = self.expression(c.child(1))
                 sym = Symbol.from_path(name, type_)
                 args[sym.name()] = sym
-            fn.check_call(child, args)
+            to_be_added = fn.check_call(child, args)
+            for c in to_be_added:
+                child.children.append(Tree('arguments', [
+                    Token('NAME', c[0].name()),
+                    c[1],
+                ]))
             return fn.output()
         else:
             assert child.data == 'path'

--- a/storyscript/compiler/semantics/FunctionTable.py
+++ b/storyscript/compiler/semantics/FunctionTable.py
@@ -5,25 +5,43 @@ class Function:
     """
     An individual function.
     """
-    def __init__(self, name, args, output):
+    def __init__(self, name, args, default_args, output):
         self._name = name
         self._args = args
-        self._arg_names = set(args.keys())
+        self._arg_names = set([*args.keys(), *default_args.keys()])
+        self._default_args = default_args
         assert isinstance(output, SymbolType)
         self._output = output
 
+    def arg(self, name):
+        """
+        Returns an argument by name.
+        """
+        if name in self._args:
+            return self._args[name]
+        else:
+            return self._default_args[name][0]
+
     def check_call(self, tree, args):
+        args_to_be_added = []
         arg_names = set(args.keys())
         name_difference = self._arg_names.symmetric_difference(arg_names)
         # check arg names for differences
         for d in name_difference:
+            # check the origin of the difference
+            # A) from the callee
             if d in self._arg_names:
-                tree.expect(0, 'function_arg_required', name=self._name, arg=d)
+                if d in self._default_args:
+                    args_to_be_added.append(self._default_args[d])
+                else:
+                    tree.expect(0, 'function_arg_required',
+                                name=self._name, arg=d)
+            # A) from the caller
             else:
                 tree.expect(0, 'function_arg_invalid', name=self._name, arg=d)
         # check types
         for k in args.keys():
-            target = self._args[k].type()
+            target = self.arg(k).type()
             t = args[k].type()
             tree.expect(target.can_be_assigned(t) or t == AnyType.instance(),
                         'function_arg_type_mismatch',
@@ -31,6 +49,7 @@ class Function:
                         arg_name=k,
                         target=target,
                         source=t)
+        return sorted(args_to_be_added, key=lambda a: a[0].name())
 
     def output(self):
         return self._output
@@ -46,14 +65,14 @@ class FunctionTable:
     def __init__(self):
         self.functions = {}
 
-    def insert(self, name, args, output=None):
+    def insert(self, name, args, default_args, output=None):
         """
         Insert a new function into the function table.
         """
         assert name not in self.functions
         if output is None:
             output = NoneType.instance()
-        fn = Function(name, args, output)
+        fn = Function(name, args, default_args, output)
         self.functions[name] = fn
 
     def resolve(self, name):

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -204,15 +204,17 @@ class Grammar:
 
     def function_block(self):
         self.ebnf._RETURNS = 'returns'
-        self.ebnf.typed_argument = 'name colon types'
+        self.ebnf.typed_argument = 'name colon (types|entity)'
+        self.ebnf.typed_argument2 = 'name colon types'
         self.ebnf.function_output = 'returns types'
         function_statement = ('function_type name typed_argument* '
                               'function_output?')
         self.ebnf.function_statement = function_statement
         self.ebnf._DOUBLE_DEDENT = '<DOUBLE_DEDENT>'
         self.ebnf.indented_typed_arguments = \
-            'indent (typed_argument+ nl)+ dedent _DOUBLE_DEDENT'
+            'indent (typed_argument2+ nl)+ dedent _DOUBLE_DEDENT'
         self.ebnf.function_block = (
+            # 'function_statement nl nested_block'
             'function_statement nl '
             '(indented_typed_arguments? block+ _DEDENT | '
             'nested_block)'

--- a/tests/e2e/function_default_arguments.json
+++ b/tests/e2e/function_default_arguments.json
@@ -1,0 +1,105 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "b",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4.1",
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "b"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "next": "4.1"
+    },
+    "4.1": {
+      "method": "call",
+      "ln": "4.1",
+      "name": [
+        "__p-4.1"
+      ],
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "int",
+            "int": 1
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "b",
+          "arg": {
+            "$OBJECT": "int",
+            "int": 2
+          }
+        }
+      ],
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-4.1"
+          ]
+        }
+      ]
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/function_default_arguments.story
+++ b/tests/e2e/function_default_arguments.story
@@ -1,0 +1,4 @@
+function foo a: 1 b: 2 returns int
+	return a + b
+
+c = foo()

--- a/tests/e2e/function_default_arguments2.json
+++ b/tests/e2e/function_default_arguments2.json
@@ -1,0 +1,105 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "b",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4.1",
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "b"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "next": "4.1"
+    },
+    "4.1": {
+      "method": "call",
+      "ln": "4.1",
+      "name": [
+        "__p-4.1"
+      ],
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "int",
+            "int": 1
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "b",
+          "arg": {
+            "$OBJECT": "int",
+            "int": 2
+          }
+        }
+      ],
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-4.1"
+          ]
+        }
+      ]
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/function_default_arguments2.story
+++ b/tests/e2e/function_default_arguments2.story
@@ -1,0 +1,4 @@
+function foo a: 1 b: 2 returns int
+	return a + b
+
+c = foo(a:1)

--- a/tests/e2e/multi_line_function_arguments.json
+++ b/tests/e2e/multi_line_function_arguments.json
@@ -12,30 +12,6 @@
             "$OBJECT": "type",
             "type": "int"
           }
-        },
-        {
-          "$OBJECT": "arg",
-          "name": "key2",
-          "arg": {
-            "$OBJECT": "type",
-            "type": "string"
-          }
-        },
-        {
-          "$OBJECT": "arg",
-          "name": "key3",
-          "arg": {
-            "$OBJECT": "type",
-            "type": "int"
-          }
-        },
-        {
-          "$OBJECT": "arg",
-          "name": "key4",
-          "arg": {
-            "$OBJECT": "type",
-            "type": "string"
-          }
         }
       ],
       "enter": "4",

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -56,10 +56,11 @@ foreach_statement: _FOREACH base_expression output?
 foreach_block: foreach_statement _NL nested_block
 while_statement: _WHILE base_expression
 while_block: while_statement _NL nested_block
-typed_argument: NAME _COLON types
+typed_argument: NAME _COLON (types|entity)
+typed_argument2: NAME _COLON types
 function_output: _RETURNS types
 function_statement: FUNCTION_TYPE NAME typed_argument* function_output?
-indented_typed_arguments: _INDENT (typed_argument+ _NL)+ _DEDENT _DOUBLE_DEDENT
+indented_typed_arguments: _INDENT (typed_argument2+ _NL)+ _DEDENT _DOUBLE_DEDENT
 function_block: function_statement _NL (indented_typed_arguments? block+ _DEDENT | nested_block)
 catch_statement: _CATCH _AS NAME
 catch_block: catch_statement _NL nested_block

--- a/tests/unittests/compiler/json/Objects.py
+++ b/tests/unittests/compiler/json/Objects.py
@@ -295,9 +295,8 @@ def test_objects_arguments(patch, tree):
 def test_objects_typed_argument(patch, tree):
     patch.object(Objects, 'values')
     result = Objects().typed_argument(tree)
-    Objects.values.assert_called_with(Tree('anon', [tree.child(1)]))
     expected = {'$OBJECT': 'arg', 'name': tree.child().value,
-                'arg': Objects.values()}
+                'arg': {'$OBJECT': 'type', 'type': str(tree.child())}}
     assert result == expected
 
 

--- a/tests/unittests/compiler/semantics/FunctionTable.py
+++ b/tests/unittests/compiler/semantics/FunctionTable.py
@@ -3,5 +3,5 @@ from storyscript.compiler.semantics.symbols.SymbolTypes import AnyType
 
 
 def test_function__to_str():
-    fn = Function('foo', {}, AnyType.instance())
+    fn = Function('foo', {}, {}, AnyType.instance())
     assert str(fn) == 'Function(foo)'


### PR DESCRIPTION
Fixes: https://github.com/storyscript/storyscript/issues/783

This will require no changes for the engine:

```coffee
function foo a: 1 b: 2 returns int
	return a + b

c = foo(a:11)
```

yields:

<details>

```json
{
  "tree": {
    "1": {
      "method": "function",
      "ln": "1",
      "output": [
        "int"
      ],
      "function": "foo",
      "args": [
        {
          "$OBJECT": "arg",
          "name": "a",
          "arg": {
            "$OBJECT": "type",
            "type": "int"
          }
        },
        {
          "$OBJECT": "arg",
          "name": "b",
          "arg": {
            "$OBJECT": "type",
            "type": "int"
          }
        }
      ],
      "enter": "2",
      "exit": "4.1",
      "next": "2"
    },
    "2": {
      "method": "return",
      "ln": "2",
      "args": [
        {
          "$OBJECT": "expression",
          "expression": "sum",
          "values": [
            {
              "$OBJECT": "path",
              "paths": [
                "a"
              ]
            },
            {
              "$OBJECT": "path",
              "paths": [
                "b"
              ]
            }
          ]
        }
      ],
      "parent": "1",
      "next": "4.1"
    },
    "4.1": {
      "method": "call",
      "ln": "4.1",
      "name": [
        "__p-4.1"
      ],
      "function": "foo",
      "args": [
        {
          "$OBJECT": "arg",
          "name": "a",
          "arg": {
            "$OBJECT": "int",
            "int": 11
          }
        },
        {
          "$OBJECT": "arg",
          "name": "b",
          "arg": {
            "$OBJECT": "int",
            "int": 2
          }
        }
      ],
      "next": "4"
    },
    "4": {
      "method": "expression",
      "ln": "4",
      "name": [
        "c"
      ],
      "args": [
        {
          "$OBJECT": "path",
          "paths": [
            "__p-4.1"
          ]
        }
      ]
    }
  },
  "entrypoint": "1",
  "functions": {
    "foo": "1"
  },
  "version": "0.15.1-5-g2e5d964"
}
```

</details>

TODO: 
- [ ] figure out how to resolve the grammar conflict for multi-line arguments
- [ ] decide whether it's a good idea to mutate the tree in ExpressionResolver
- [ ] set line number for newly generated tokens