### PR TITLE
feat(compiler): allow the user to return nested types

### DIFF
--- a/storyscript/compiler/json/JSONCompiler.py
+++ b/storyscript/compiler/json/JSONCompiler.py
@@ -48,9 +48,11 @@ class JSONCompiler:
             mutations.append(m)
         return mutations
 
-    @classmethod
-    def function_output(cls, tree):
-        return cls.output(tree.node('function_output.types'))
+    def function_output(self, tree):
+        function_output = tree.function_output
+        if function_output is not None:
+            output_types = self.objects.types(function_output.types)
+            return [output_types['type']]
 
     def imports(self, tree, parent):
         """

--- a/storyscript/compiler/json/Objects.py
+++ b/storyscript/compiler/json/Objects.py
@@ -176,7 +176,15 @@ class Objects:
 
     @staticmethod
     def types(tree):
-        return {'$OBJECT': 'type', 'type': tree.child(0).value}
+        assert tree.data == 'types'
+        c = tree.first_child()
+        if c.data == 'map_type':
+            t = 'object'
+        elif c.data == 'list_type':
+            t = 'list'
+        else:
+            t = c.child(0).value
+        return {'$OBJECT': 'type', 'type': t}
 
     def entity(self, tree):
         return self.values(tree.child(0))

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -167,6 +167,38 @@ class ExpressionResolver:
         Resolves a type expression to a type
         """
         assert tree.data == 'types'
+        c = tree.first_child()
+        if c.data == 'map_type':
+            return self.map_type(c)
+        elif c.data == 'list_type':
+            return self.list_type(c)
+        else:
+            assert c.data == 'base_type'
+            return self.base_type(c)
+
+    def map_type(self, tree):
+        """
+        Resolves a map type expression to a type
+        """
+        assert tree.data == 'map_type'
+        key_type = self.base_type(tree.child(0))
+        value_type = self.types(tree.child(1))
+        return ObjectType(key_type, value_type)
+
+    def list_type(self, tree):
+        """
+        Resolves a list type expression to a type
+        """
+        assert tree.data == 'list_type'
+        c = tree.first_child()
+        item = self.types(c)
+        return ListType(item)
+
+    def base_type(self, tree):
+        """
+        Resolves a base type expression to a type
+        """
+        assert tree.data == 'base_type'
         tok = tree.first_child()
         if tok.type == 'BOOLEAN_TYPE':
             return BooleanType.instance()
@@ -176,8 +208,6 @@ class ExpressionResolver:
             return StringType.instance()
         elif tok.type == 'ANY_TYPE':
             return AnyType.instance()
-        elif tok.type == 'LIST_TYPE':
-            return ListType(AnyType.instance())
         elif tok.type == 'OBJECT_TYPE':
             return ObjectType(AnyType.instance(), AnyType.instance())
         elif tok.type == 'FUNCTION_TYPE':

--- a/storyscript/compiler/semantics/symbols/SymbolTypes.py
+++ b/storyscript/compiler/semantics/symbols/SymbolTypes.py
@@ -257,7 +257,7 @@ class ObjectType(SymbolType):
         if not isinstance(other, ObjectType):
             return False
         key_res = self.key.can_be_assigned(other.key)
-        val_res = self.key.can_be_assigned(other.value)
+        val_res = self.value.can_be_assigned(other.value)
         return key_res and val_res
 
     def index(self, other):

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -28,16 +28,22 @@ class Grammar:
         self.ebnf.BOOLEAN_TYPE = 'boolean'
         self.ebnf.FLOAT_TYPE = 'float'
         self.ebnf.STRING_TYPE = 'string'
-        self.ebnf.LIST_TYPE = 'list'
         self.ebnf.OBJECT_TYPE = 'object'
         self.ebnf.REGEXP_TYPE = 'regex'
         self.ebnf.FUNCTION_TYPE = 'function'
         self.ebnf.TIME_TYPE = 'time'
         self.ebnf.ANY_TYPE = 'any'
-        rule = ('int_type, float_type, string_type, list_type, object_type, '
-                'regexp_type, function_type, any_type, boolean_type, '
-                'time_type')
-        self.ebnf.types = rule
+        self.ebnf.base_type = ('int_type, float_type, string_type, '
+                               'object_type, regexp_type, function_type, '
+                               'any_type, boolean_type, time_type')
+        self.ebnf._OSB = '['
+        self.ebnf._CSB = ']'
+        self.ebnf.list_type = 'types osb csb'
+        self.ebnf._OCB = '{'
+        self.ebnf._CCB = '}'
+        self.ebnf._COLON = ':'
+        self.ebnf.map_type = 'ocb base_type colon types ccb'
+        self.ebnf.types = 'list_type , map_type, base_type'
 
     def values(self):
         self.ebnf._NL = r'/(\r?\n[\t ]*)+/'
@@ -55,11 +61,6 @@ class Grammar:
         self.ebnf.set_token('REGEXP.10', r'/\/([^\/]*)\//')
         self.ebnf.set_token('NAME.1', r'/[a-zA-Z_][a-zA-Z-\/_0-9]*/')
         self.ebnf.set_token('RAW_TIME.3', r'/([0-9]+(ms|[smhdw]))+/')
-        self.ebnf._OSB = '['
-        self.ebnf._CSB = ']'
-        self.ebnf._OCB = '{'
-        self.ebnf._CCB = '}'
-        self.ebnf._COLON = ':'
         self.ebnf._COMMA = ','
         self.ebnf._OP = '('
         self.ebnf._CP = ')'

--- a/tests/e2e/invalid_return_type.error
+++ b/tests/e2e/invalid_return_type.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 22
+
+1|    function foo returns list
+                           ^
+
+E0046: An indented block is required to be before here

--- a/tests/e2e/invalid_return_type.story
+++ b/tests/e2e/invalid_return_type.story
@@ -1,0 +1,2 @@
+function foo returns list
+	return ""

--- a/tests/e2e/semantics/nested_types.json
+++ b/tests/e2e/semantics/nested_types.json
@@ -1,0 +1,127 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [
+        "object"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "exit": "4",
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": [
+            [
+              {
+                "$OBJECT": "int",
+                "int": 20
+              },
+              {
+                "$OBJECT": "list",
+                "items": [
+                  {
+                    "$OBJECT": "string",
+                    "string": "foo"
+                  },
+                  {
+                    "$OBJECT": "string",
+                    "string": "bar"
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "parent": "1",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "next": "5.1"
+    },
+    "5.1": {
+      "method": "call",
+      "ln": "5.1",
+      "name": [
+        "__p-5.1"
+      ],
+      "function": "foo",
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-5.1"
+          ]
+        }
+      ],
+      "next": "6"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "any string"
+        }
+      ],
+      "next": "7"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b",
+            {
+              "$OBJECT": "int",
+              "int": 20
+            },
+            {
+              "$OBJECT": "int",
+              "int": 0
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/semantics/nested_types.story
+++ b/tests/e2e/semantics/nested_types.story
@@ -1,0 +1,7 @@
+function foo returns {int:string[]}
+	return {20: ["foo", "bar"]}
+
+a = 0
+b = foo()
+c = "any string"
+c = b[20][0]

--- a/tests/e2e/semantics/nested_types2.error
+++ b/tests/e2e/semantics/nested_types2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 7, column 5
+
+7|    c = b["foo"][0]
+          ^
+
+E0104: `{int:string[]}` can't be indexed with `string`

--- a/tests/e2e/semantics/nested_types2.story
+++ b/tests/e2e/semantics/nested_types2.story
@@ -1,0 +1,7 @@
+function foo returns {int:string[]}
+	return {20: ["foo", "bar"]}
+
+a = 0
+b = foo()
+c = "any string"
+c = b["foo"][0]

--- a/tests/e2e/semantics/nested_types3.error
+++ b/tests/e2e/semantics/nested_types3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 7, column 5
+
+7|    c = b[20]["bar"]
+          ^
+
+E0104: `string[]` can't be indexed with `string`

--- a/tests/e2e/semantics/nested_types3.story
+++ b/tests/e2e/semantics/nested_types3.story
@@ -1,0 +1,7 @@
+function foo returns {int:string[]}
+	return {20: ["foo", "bar"]}
+
+a = 0
+b = foo()
+c = "any string"
+c = b[20]["bar"]

--- a/tests/e2e/semantics/nested_types4.error
+++ b/tests/e2e/semantics/nested_types4.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 10
+
+2|      return {20: ["foo", "bar"]}
+                ^^
+
+E0102: `{int:string[]}` can't be implicitly converted to expected return type `{string:string[]}`.

--- a/tests/e2e/semantics/nested_types4.story
+++ b/tests/e2e/semantics/nested_types4.story
@@ -1,0 +1,4 @@
+function foo returns {string:string[]}
+	return {20: ["foo", "bar"]}
+
+a = foo()

--- a/tests/e2e/semantics/nested_types5.error
+++ b/tests/e2e/semantics/nested_types5.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 10
+
+2|      return {20: ["foo", "bar"]}
+                ^^
+
+E0102: `{int:string[]}` can't be implicitly converted to expected return type `{int:int[]}`.

--- a/tests/e2e/semantics/nested_types5.story
+++ b/tests/e2e/semantics/nested_types5.story
@@ -1,0 +1,4 @@
+function foo returns {int:int[]}
+	return {20: ["foo", "bar"]}
+
+a = foo()

--- a/tests/e2e/semantics/nested_types6.error
+++ b/tests/e2e/semantics/nested_types6.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 9
+
+2|      return [0]
+               ^
+
+E0102: `int[]` can't be implicitly converted to expected return type `int[][]`.

--- a/tests/e2e/semantics/nested_types6.story
+++ b/tests/e2e/semantics/nested_types6.story
@@ -1,0 +1,4 @@
+function foo returns int[][]
+	return [0]
+
+a = foo()

--- a/tests/e2e/semantics/nested_types7.error
+++ b/tests/e2e/semantics/nested_types7.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 9
+
+2|      return [["foo"]]
+               ^
+
+E0102: `string[][]` can't be implicitly converted to expected return type `int[][]`.

--- a/tests/e2e/semantics/nested_types7.story
+++ b/tests/e2e/semantics/nested_types7.story
@@ -1,0 +1,4 @@
+function foo returns int[][]
+	return [["foo"]]
+
+a = foo()

--- a/tests/e2e/semantics/nested_types8.error
+++ b/tests/e2e/semantics/nested_types8.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 5, column 1
+
+5|    a = foo()[0][0]
+      ^
+
+E0100: Can't assign `int` to `string`

--- a/tests/e2e/semantics/nested_types8.story
+++ b/tests/e2e/semantics/nested_types8.story
@@ -1,0 +1,5 @@
+function foo returns int[][]
+	return [[0]]
+
+a = "foo"
+a = foo()[0][0]

--- a/tests/e2e/semantics/nested_types9.json
+++ b/tests/e2e/semantics/nested_types9.json
@@ -1,0 +1,87 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [
+        "list"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "exit": "4",
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "list",
+              "items": [
+                {
+                  "$OBJECT": "int",
+                  "int": 0
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "next": "5.1"
+    },
+    "5.1": {
+      "method": "call",
+      "ln": "5.1",
+      "name": [
+        "__p-5.1"
+      ],
+      "function": "foo",
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-5.1",
+            {
+              "$OBJECT": "int",
+              "int": 0
+            },
+            {
+              "$OBJECT": "int",
+              "int": 0
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/semantics/nested_types9.story
+++ b/tests/e2e/semantics/nested_types9.story
@@ -1,0 +1,5 @@
+function foo returns int[][]
+	return [[0]]
+
+a = 1
+a = foo()[0][0]

--- a/tests/e2e/semantics/return_types.error
+++ b/tests/e2e/semantics/return_types.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 9, column 20
+
+9|    function e returns list
+                         ^
+
+E0046: An indented block is required to be before here

--- a/tests/e2e/semantics/return_types.story
+++ b/tests/e2e/semantics/return_types.story
@@ -6,5 +6,5 @@ function c returns any
 	return 1
 function d returns object
 	return {}
-function e returns list
+function e returns int[]
 	return [1]

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -180,13 +180,14 @@ def test_parser_function_arguments():
     result = parse('function test n:int\n\tvar = 3\n')
     typed_argument = result.block.function_block.find('typed_argument')[0]
     assert typed_argument.child(0) == Token('NAME', 'n')
-    assert typed_argument.types.child(0) == Token('INT_TYPE', 'int')
+    assert typed_argument.types.base_type.child(0) == Token('INT_TYPE', 'int')
 
 
 def test_parser_function_output():
     result = parse('function test n:string returns int\n\tvar = 1\n')
     statement = result.block.function_block.function_statement
-    assert statement.function_output.types.child(0) == Token('INT_TYPE', 'int')
+    assert statement.function_output.types.base_type.child(0) == \
+        Token('INT_TYPE', 'int')
 
 
 def test_parser_try():

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -1,4 +1,7 @@
-types: INT_TYPE| FLOAT_TYPE| STRING_TYPE| LIST_TYPE| OBJECT_TYPE| REGEXP_TYPE| FUNCTION_TYPE| ANY_TYPE| BOOLEAN_TYPE| TIME_TYPE
+base_type: INT_TYPE| FLOAT_TYPE| STRING_TYPE| OBJECT_TYPE| REGEXP_TYPE| FUNCTION_TYPE| ANY_TYPE| BOOLEAN_TYPE| TIME_TYPE
+list_type: types _OSB _CSB
+map_type: _OCB base_type _COLON types _CCB
+types: list_type | map_type| base_type
 boolean: TRUE| FALSE
 void: NULL
 number: INT| FLOAT
@@ -80,12 +83,16 @@ INT_TYPE: "int"
 BOOLEAN_TYPE: "boolean"
 FLOAT_TYPE: "float"
 STRING_TYPE: "string"
-LIST_TYPE: "list"
 OBJECT_TYPE: "object"
 REGEXP_TYPE: "regex"
 FUNCTION_TYPE: "function"
 TIME_TYPE: "time"
 ANY_TYPE: "any"
+_OSB: "["
+_CSB: "]"
+_OCB: "{"
+_CCB: "}"
+_COLON: ":"
 _NL: /(\r?\n[\t ]*)+/
 _INDENT: "<INDENT>"
 _DEDENT: "<DEDENT>"
@@ -100,11 +107,6 @@ DOUBLE_QUOTED: /"([^"\\]*(?:\\.[^"\\]*)*)"/
 REGEXP.10: /\/([^\/]*)\//
 NAME.1: /[a-zA-Z_][a-zA-Z-\/_0-9]*/
 RAW_TIME.3: /([0-9]+(ms|[smhdw]))+/
-_OSB: "["
-_CSB: "]"
-_OCB: "{"
-_CCB: "}"
-_COLON: ":"
 _COMMA: ","
 _OP: "("
 _CP: ")"

--- a/tests/unittests/compiler/json/Compiler.py
+++ b/tests/unittests/compiler/json/Compiler.py
@@ -72,11 +72,12 @@ def test_compiler_chained_mutations(patch, magic, tree):
     assert result == [Objects.mutation_fragment()]
 
 
-def test_compiler_function_output(patch, tree):
+def test_compiler_function_output(patch, compiler, tree):
     patch.object(JSONCompiler, 'output')
-    result = JSONCompiler.function_output(tree)
-    tree.node.assert_called_with('function_output.types')
-    assert result == JSONCompiler.output()
+    patch.object(Objects, 'types')
+    result = compiler.function_output(tree)
+    Objects.types.assert_called_with(tree.function_output.types)
+    assert result == [Objects.types()['types']]
 
 
 def test_compiler_imports(patch, compiler, lines, tree):

--- a/tests/unittests/compiler/json/Objects.py
+++ b/tests/unittests/compiler/json/Objects.py
@@ -229,8 +229,25 @@ def test_objects_regular_expression_flags():
     assert result['flags'] == 'flags'
 
 
+def test_objects_map_type(tree):
+    tree.data = 'types'
+    c = tree.first_child()
+    c.data = 'map_type'
+    assert Objects.types(tree) == {'$OBJECT': 'type', 'type': 'object'}
+
+
+def test_objects_list_type(tree):
+    tree.data = 'types'
+    c = tree.first_child()
+    c.data = 'list_type'
+    assert Objects.types(tree) == {'$OBJECT': 'type', 'type': 'list'}
+
+
 def test_objects_types(tree):
-    token = tree.child(0)
+    tree.data = 'types'
+    c = tree.first_child()
+    c.data = 'base_type'
+    token = c.child(0)
     assert Objects.types(tree) == {'$OBJECT': 'type', 'type': token.value}
 
 

--- a/tests/unittests/parser/Tree.py
+++ b/tests/unittests/parser/Tree.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from unittest.mock import call
+
 from lark.lexer import Token
 from lark.tree import Tree as LarkTree
 
@@ -44,6 +46,16 @@ def test_tree_node(patch):
     tree = Tree('rule', [])
     result = tree.node('inner')
     Tree.walk.assert_called_with(tree, 'inner')
+    assert result == Tree.walk()
+
+
+def test_tree_node_nested(patch):
+    patch.object(Tree, 'walk')
+    tree = Tree('rule', [])
+    result = tree.node('inner.nested')
+    assert len(Tree.walk.call_args_list) == 2
+    assert Tree.walk.call_args_list[0] == call(tree, 'inner')
+    assert Tree.walk.call_args_list[1] == call(Tree.walk(), 'nested')
     assert result == Tree.walk()
 
 


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/794

This allows the user to define nested types (already supported by the type system).
The syntax is still up for suggestions.
Currently it is:

```coffee
function foo returns {int:string[]}
	return {20: ["foo", "bar"]}
```