### PR TITLE
fix(Objects): don't emit / for regexp objects

### DIFF
--- a/storyscript/compiler/json/Objects.py
+++ b/storyscript/compiler/json/Objects.py
@@ -171,9 +171,10 @@ class Objects:
         """
         Compiles a regexp object from a regular_expression tree
         """
-        dictionary = {'$OBJECT': 'regexp', 'regexp': tree.child(0)}
+        regexp = tree.child(0).value[1:-1]
+        dictionary = {'$OBJECT': 'regexp', 'regexp': regexp}
         if len(tree.children) > 1:
-            dictionary['flags'] = tree.child(1)
+            dictionary['flags'] = tree.child(1).value
         return dictionary
 
     @staticmethod

--- a/tests/e2e/assignments_basic.json
+++ b/tests/e2e/assignments_basic.json
@@ -261,7 +261,7 @@
       "args": [
         {
           "$OBJECT": "regexp",
-          "regexp": "/^foo/"
+          "regexp": "^foo"
         }
       ],
       "src": "regexp = /^foo/",
@@ -276,7 +276,7 @@
       "args": [
         {
           "$OBJECT": "regexp",
-          "regexp": "/^foo/",
+          "regexp": "^foo",
           "flags": "g"
         }
       ],

--- a/tests/e2e/regex_after_name5.json
+++ b/tests/e2e/regex_after_name5.json
@@ -11,7 +11,7 @@
           "name": "item",
           "arg": {
             "$OBJECT": "regexp",
-            "regexp": "/regexp/"
+            "regexp": "regexp"
           }
         }
       ],

--- a/tests/e2e/regex_after_name6.json
+++ b/tests/e2e/regex_after_name6.json
@@ -6,7 +6,7 @@
       "args": [
         {
           "$OBJECT": "regexp",
-          "regexp": "/regexp/"
+          "regexp": "regexp"
         }
       ],
       "enter": "2",
@@ -35,7 +35,7 @@
             },
             {
               "$OBJECT": "regexp",
-              "regexp": "/regexp/"
+              "regexp": "regexp"
             }
           ]
         }
@@ -66,7 +66,7 @@
             },
             {
               "$OBJECT": "regexp",
-              "regexp": "/regexp/"
+              "regexp": "regexp"
             }
           ]
         }
@@ -106,7 +106,7 @@
             },
             {
               "$OBJECT": "regexp",
-              "regexp": "/regexp/"
+              "regexp": "regexp"
             }
           ]
         }

--- a/tests/e2e/semantics/mutation/string_contains_pattern.json
+++ b/tests/e2e/semantics/mutation/string_contains_pattern.json
@@ -37,7 +37,7 @@
               "name": "pattern",
               "arg": {
                 "$OBJECT": "regexp",
-                "regexp": "/aa/"
+                "regexp": "aa"
               }
             }
           ]

--- a/tests/e2e/semantics/return_types.json
+++ b/tests/e2e/semantics/return_types.json
@@ -43,7 +43,7 @@
       "args": [
         {
           "$OBJECT": "regexp",
-          "regexp": "/foo/"
+          "regexp": "foo"
         }
       ],
       "parent": "3",

--- a/tests/unittests/compiler/json/Objects.py
+++ b/tests/unittests/compiler/json/Objects.py
@@ -239,13 +239,16 @@ def test_objects_regular_expression():
     """
     Ensures regular expressions are compiled correctly
     """
-    tree = Tree('regular_expression', ['regexp'])
+    tok = Token('regexp', '/regexp/')
+    tree = Tree('regular_expression', [tok])
     result = Objects().regular_expression(tree)
-    assert result == {'$OBJECT': 'regexp', 'regexp': tree.child(0)}
+    assert result == {'$OBJECT': 'regexp', 'regexp': 'regexp'}
 
 
 def test_objects_regular_expression_flags():
-    tree = Tree('regular_expression', ['regexp', 'flags'])
+    tok = Token('regexp', '/regexp/')
+    flags = Token('FLAGS', 'flags')
+    tree = Tree('regular_expression', [tok, flags])
     result = Objects().regular_expression(tree)
     assert result['flags'] == 'flags'
 


### PR DESCRIPTION
Example:

```coffee
r = str contains pattern: /llo/g
```

yields:

<details>

```json
{
  "tree": {
    "1": {
      "method": "execute",
      "ln": "1",
      "name": [
        "r"
      ],
      "service": "str",
      "command": "contains",
      "args": [
        {
          "$OBJECT": "arg",
          "name": "pattern",
          "arg": {
            "$OBJECT": "regexp",
            "regexp": "llo",
            "flags": "g"
          }
        }
      ],
      "src": "r = str contains pattern: /llo/g"
    }
  },
  "services": [
    "str"
  ],
  "entrypoint": "1",
  "version": "0.17.0-3-gde20ad9"
}
```

</details>
