### PR TITLE
refactor(API): improve interface to support multiple error messages in the future

### DIFF
--- a/storyscript/Api.py
+++ b/storyscript/Api.py
@@ -4,6 +4,70 @@ from .Story import Story
 from .exceptions import StoryError
 
 
+class StoryscriptCompilationResult:
+    """
+    Result of a Storyscript compilation.
+    Contains the compiled story or a list of compilation errors.
+    """
+
+    def __init__(self, result, errors):
+        self._result = result
+        self._errors = errors
+        self._deprecations = []
+        self._warnings = []
+
+    @classmethod
+    def from_result(cls, story):
+        """
+        Creates a CompilationResult from a result.
+        """
+        return cls(story, errors=[])
+
+    @classmethod
+    def from_error(cls, error):
+        """
+        Creates a CompilationResult from a single error.
+        """
+        return cls(None, errors=[error])
+
+    def result(self):
+        """
+        Returns the compiled story.
+        """
+        return self._result
+
+    def errors(self):
+        """
+        Returns a list of all errorsemitted by the Storyscript compiler.
+        """
+        return self._errors
+
+    def warnings(self):
+        """
+        Returns a list of all warnings emitted by the Storyscript compiler.
+        """
+        return self._warnings
+
+    def deprecations(self):
+        """
+        Returns a list of all deprecations emitted by the Storyscript compiler.
+        """
+        return self._deprecations
+
+    def success(self):
+        """
+        Returns `True` if the compilation succeeded.
+        """
+        return self._result is not None
+
+    def check_success(self):
+        """
+        Throws the first error encountered if the compilation did not succeed.
+        """
+        if len(self._errors) > 0:
+            raise self._errors[0]
+
+
 class Api:
     """
     Exposes functionalities for external use
@@ -14,14 +78,16 @@ class Api:
         Load story from a string.
         """
         try:
-            return Story(string).process()
+            s = Story(string).process()
+            return StoryscriptCompilationResult.from_result(s)
         except StoryError as e:
-            raise e
+            return StoryscriptCompilationResult.from_error(e)
         except Exception as e:
             if debug:
                 raise e
             else:
-                raise StoryError.internal_error(e)
+                e = StoryError.internal_error(e)
+                return StoryscriptCompilationResult.from_error(e)
 
     @staticmethod
     def load(stream, debug=False):
@@ -30,14 +96,16 @@ class Api:
         """
         try:
             story = Story.from_stream(stream).process()
-            return {stream.name: story, 'services': story['services']}
+            s = {stream.name: story, 'services': story['services']}
+            return StoryscriptCompilationResult.from_result(s)
         except StoryError as e:
-            raise e
+            return StoryscriptCompilationResult.from_error(e)
         except Exception as e:
             if debug:
                 raise e
             else:
-                raise StoryError.internal_error(e)
+                e = StoryError.internal_error(e)
+                return StoryscriptCompilationResult.from_error(e)
 
     @staticmethod
     def load_map(files, debug=False):
@@ -45,11 +113,13 @@ class Api:
         Load multiple stories from a file mapping
         """
         try:
-            return Bundle(story_files=files).bundle()
+            s = Bundle(story_files=files).bundle()
+            return StoryscriptCompilationResult.from_result(s)
         except StoryError as e:
-            raise e
+            return StoryscriptCompilationResult.from_error(e)
         except Exception as e:
             if debug:
                 raise e
             else:
-                raise StoryError.internal_error(e)
+                e = StoryError.internal_error(e)
+                return StoryscriptCompilationResult.from_error(e)

--- a/tests/e2e/update
+++ b/tests/e2e/update
@@ -40,13 +40,14 @@ class StoryRunner():
     def run(self):
         with io.open(self.story_path, 'r') as f:
             source = f.read()
-        try:
-            result = Api.loads(source)
-            result = _clean_dict(result)
+        s = Api.loads(source)
+        if s.success():
+            result = _clean_dict(s.result())
             del result['version']
             self.update_success(result)
             return Result(status=True, updated=self.updated)
-        except StoryError as e:
+        else:
+            e = s.errors()[0]
             self.update_error(unstyle(e.message()))
 
         return Result(status=False, updated=self.updated)

--- a/tests/integration/Api.py
+++ b/tests/integration/Api.py
@@ -15,7 +15,7 @@ def test_api_load_map_compiling_try_block():
     """
     files = {'asd': 'foo ='}
     with raises(StoryError) as e:
-        Api.load_map(files)
+        Api.load_map(files).check_success()
     assert e.value.short_message() == 'E0007: Missing value after `=`'
 
 
@@ -23,11 +23,13 @@ def test_api_load_map_compiling_try_block_loads():
     """
     Ensures Api.load functions return errors
     """
-    with raises(StoryError) as e:
-        Api.loads('foo =')
-    assert e.value.short_message() == 'E0007: Missing value after `=`'
-    e.value.with_color = False
-    assert e.value.message() == \
+    s = Api.loads('foo =')
+    assert len(s.deprecations()) == 0
+    assert len(s.warnings()) == 0
+    e = s.errors()[0]
+    assert e.short_message() == 'E0007: Missing value after `=`'
+    e.with_color = False
+    assert e.message() == \
         """Error: syntax error in story at line 1, column 6
 
 1|    foo =
@@ -41,11 +43,11 @@ def test_api_load_map_syntax_error():
     Ensures Api.load functions return errors
     """
     files = {'asd': 'foo ='}
-    with raises(StoryError) as e:
-        Api.load_map(files)
-    assert e.value.short_message() == 'E0007: Missing value after `=`'
-    e.value.with_color = False
-    assert e.value.message() == \
+    s = Api.load_map(files)
+    e = s.errors()[0]
+    assert e.short_message() == 'E0007: Missing value after `=`'
+    e.with_color = False
+    assert e.message() == \
         """Error: syntax error in story at line 1, column 6
 
 1|    foo =
@@ -60,9 +62,9 @@ def test_api_load_map_ice():
     """
     with patch.object(Bundle, 'bundle') as p:
         p.side_effect = Exception('ICE')
-        with raises(StoryError) as e:
-            Api.load_map({})
-        assert e.value.message() == \
+        s = Api.load_map({})
+        e = s.errors()[0]
+        assert e.message() == \
             """Internal error occured: ICE
 Please report at https://github.com/storyscript/storyscript/issues"""
 
@@ -74,7 +76,7 @@ def test_api_loads_ice():
     with patch.object(Story, 'process') as p:
         p.side_effect = Exception('ICE')
         with raises(StoryError) as e:
-            Api.loads('foo')
+            Api.loads('foo').check_success()
         assert e.value.message() == \
             """Internal error occured: ICE
 Please report at https://github.com/storyscript/storyscript/issues"""
@@ -86,15 +88,15 @@ def test_api_load_ice():
     """
     with patch.object(Story, 'from_stream') as p:
         p.side_effect = Exception('ICE')
-        with raises(StoryError) as e:
-            Api.load('foo')
-        assert e.value.message() == \
+        s = Api.load('foo')
+        e = s.errors()[0]
+        assert e.message() == \
             """Internal error occured: ICE
 Please report at https://github.com/storyscript/storyscript/issues"""
 
 
 def test_compiler_only_comments():
-    api_result = Api.load_map({'a.story': '# foo\n'})
+    api_result = Api.load_map({'a.story': '# foo\n'}).result()
     result = api_result['stories']['a.story']
     assert result['tree'] == {}
     assert result['entrypoint'] is None

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -12,7 +12,7 @@ def test_compiler_mutation_chained(source):
     """
     Ensures that chained mutations are compiled correctly
     """
-    result = Api.loads(source)
+    result = Api.loads(source).result()
     args = [{'$OBJECT': 'int', 'int': 1},
             {'$OBJECT': 'mutation', 'mutation': 'increment', 'args': []},
             {'$OBJECT': 'mutation', 'mutation': 'format', 'args': [
@@ -22,7 +22,7 @@ def test_compiler_mutation_chained(source):
 
 
 def test_compiler_empty_files():
-    result = Api.loads('\n\n')
+    result = Api.loads('\n\n').result()
     assert result['tree'] == {}
     assert result['entrypoint'] is None
 
@@ -89,7 +89,7 @@ def test_compiler_expression_whitespace(source_pair):
     if source.startswith('b'):
         full_source = 'b=0\nc=0\n' + full_source
         index = '3'
-    result = Api.loads(full_source)
+    result = Api.loads(full_source).result()
     assert result['tree'][index]['method'] == 'expression'
     assert result['tree'][index]['name'] == ['a']
     assert len(result['tree'][index]['args']) == 1

--- a/tests/integration/compiler/Functions.py
+++ b/tests/integration/compiler/Functions.py
@@ -6,7 +6,7 @@ def test_functions_function():
     """
     Ensures that functions are compiled correctly.
     """
-    result = Api.loads('function f\n\tx = 0')
+    result = Api.loads('function f\n\tx = 0').result()
     assert result['tree']['1']['method'] == 'function'
     assert result['tree']['1']['function'] == 'f'
     assert result['tree']['1']['next'] == '2'
@@ -19,7 +19,7 @@ def test_functions_function_argument():
     """
     Ensures that functions with an argument are compiled correctly
     """
-    result = Api.loads('function echo a:string\n\tx = a')
+    result = Api.loads('function echo a:string\n\tx = a').result()
     args = [{
         '$OBJECT': 'arg',
         'arg': {'$OBJECT': 'type', 'type': 'string'}, 'name': 'a'
@@ -33,7 +33,7 @@ def test_functions_function_returns():
     """
     Ensures that functions with a return type are compiled correctly
     """
-    result = Api.loads('function f returns int\n\treturn 0')
+    result = Api.loads('function f returns int\n\treturn 0').result()
     assert result['tree']['1']['method'] == 'function'
     assert result['tree']['1']['function'] == 'f'
     assert result['tree']['1']['output'] == ['int']
@@ -43,7 +43,7 @@ def test_functions_function_return():
     """
     Ensures that return statements are compiled correctly
     """
-    result = Api.loads('function f returns int\n\treturn 0')
+    result = Api.loads('function f returns int\n\treturn 0').result()
     assert result['tree']['2']['method'] == 'return'
     assert result['tree']['2']['args'] == [{'$OBJECT': 'int', 'int': 0}]
     assert result['tree']['2']['parent'] == '1'

--- a/tests/integration/compiler/semantics/types/Types.py
+++ b/tests/integration/compiler/semantics/types/Types.py
@@ -1,23 +1,24 @@
-from pytest import mark, raises
+from pytest import mark
 
 from storyscript.Api import Api
-from storyscript.exceptions import CompilerError, StoryError
+from storyscript.exceptions import CompilerError
 
 
 def succeed(source):
     """
     Expect the source code to pass.
     """
-    Api.loads(source)
+    Api.loads(source).check_success()
 
 
 def fail(source):
     """
     Expect the source code to error.
     """
-    with raises(StoryError) as e:
-        Api.loads(source)
-    assert isinstance(e.value.error, CompilerError)
+    s = Api.loads(source)
+    assert not s.success()
+    e = s.errors()[0]
+    assert isinstance(e.error, CompilerError)
 
 
 def run(source, should_fail):

--- a/tests/integration/compiler/semantics/types/TypesOperations.py
+++ b/tests/integration/compiler/semantics/types/TypesOperations.py
@@ -1,7 +1,7 @@
-from pytest import mark, raises
+from pytest import mark
 
 from storyscript.Api import Api
-from storyscript.exceptions import CompilerError, StoryError
+from storyscript.exceptions import CompilerError
 
 
 def is_boolean(op):
@@ -76,12 +76,12 @@ def runner(source, op=None, allowed=None, pre=''):
     if not isinstance(allowed, list):
         allowed = [allowed]
 
+    s = Api.loads(in_source)
     if any(allowed_fn(op) for allowed_fn in allowed):
-        Api.loads(in_source)
+        s.check_success()
     else:
-        with raises(StoryError) as e:
-            Api.loads(in_source)
-        assert isinstance(e.value.error, CompilerError)
+        e = s.errors()[0]
+        assert isinstance(e.error, CompilerError)
 
 
 ###############################################################################


### PR DESCRIPTION
This changes the public Storyscript API to return a `StoryscriptCompilationResult` instead of the story result.
This means that the API no longer will throw an exception, but return an object will a list of `errors` and the `result`. In the future, this object will contain a list of warnings and deprecations, too.