### PR TITLE
refactor(rename): objects to map

### DIFF
--- a/storyscript/compiler/json/Objects.py
+++ b/storyscript/compiler/json/Objects.py
@@ -154,7 +154,7 @@ class Objects:
                 items.append(self.base_expression(value))
         return {'$OBJECT': 'list', 'items': items}
 
-    def objects(self, tree):
+    def map(self, tree):
         items = []
         for item in tree.children:
             child = item.child(0)
@@ -186,7 +186,7 @@ class Objects:
         assert tree.data == 'types'
         c = tree.first_child()
         if c.data == 'map_type':
-            t = 'object'
+            t = 'map'
         elif c.data == 'list_type':
             t = 'list'
         else:
@@ -213,8 +213,8 @@ class Objects:
                 return self.number(subtree)
             elif subtree.data == 'time':
                 return self.time(subtree)
-            elif subtree.data == 'objects':
-                return self.objects(subtree)
+            elif subtree.data == 'map':
+                return self.map(subtree)
             elif subtree.data == 'regular_expression':
                 return self.regular_expression(subtree)
             elif subtree.data == 'types':

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -164,8 +164,8 @@ class ExpressionResolver:
             value = AnyType.instance()
         return ListType(value)
 
-    def objects(self, tree):
-        assert tree.data == 'objects'
+    def map(self, tree):
+        assert tree.data == 'map'
         keys = []
         values = []
         for i, item in enumerate(tree.children):
@@ -288,8 +288,8 @@ class ExpressionResolver:
                 return self.number(subtree)
             elif subtree.data == 'time':
                 return self.time(subtree)
-            elif subtree.data == 'objects':
-                return self.objects(subtree)
+            elif subtree.data == 'map':
+                return self.map(subtree)
             elif subtree.data == 'regular_expression':
                 return self.regular_expression(subtree)
             else:

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -80,13 +80,13 @@ class Grammar:
         self.ebnf.set_rule('!list', list)
         self.ebnf.key_value = ('(string, path, number, boolean) '
                                'colon base_expression')
-        objects = ('ocb', 'key_value', 'key_value', 'ccb')
-        self.ebnf.objects = self.ebnf.collection(*objects)
+        map_ = ('ocb', 'key_value', 'key_value', 'ccb')
+        self.ebnf.map = self.ebnf.collection(*map_)
         self.ebnf.regular_expression = 'regexp name?'
         self.ebnf.inline_expression = ('op inline_service cp, '
                                        'call_expression, '
                                        'op mutation cp')
-        values = ('number, string, boolean, void, list, objects, '
+        values = ('number, string, boolean, void, list, map, '
                   'regular_expression, time')
         self.ebnf.values = values
 

--- a/tests/e2e/semantics/nested_types.json
+++ b/tests/e2e/semantics/nested_types.json
@@ -4,7 +4,7 @@
       "method": "function",
       "ln": "1",
       "output": [
-        "object"
+        "map"
       ],
       "function": "foo",
       "enter": "2",

--- a/tests/integration/parser/Values.py
+++ b/tests/integration/parser/Values.py
@@ -123,7 +123,7 @@ def test_values_object():
     expression = result.block.rules.absolute_expression.expression
     entity = get_entity(expression)
     values = entity.values
-    key_value = values.objects.key_value
+    key_value = values.map.key_value
     assert key_value.string.child(0) == Token('SINGLE_QUOTED', "'color'")
     entity = get_entity(key_value.child(1).expression)
     assert entity.values.string.child(0) == Token('SINGLE_QUOTED', "'red'")

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -9,10 +9,10 @@ time: RAW_TIME
 string: SINGLE_QUOTED| DOUBLE_QUOTED| SINGLE_QUOTED_HEREDOC| DOUBLE_QUOTED_HEREDOC
 !list: _OSB (_NL _INDENT)? (base_expression (_COMMA _NL? base_expression)*)? (_NL _DEDENT)? _CSB
 key_value: (string| path| number| boolean) _COLON base_expression
-objects: _OCB (_NL _INDENT)? (key_value (_COMMA _NL? key_value)*)? (_NL _DEDENT)? _CCB
+map: _OCB (_NL _INDENT)? (key_value (_COMMA _NL? key_value)*)? (_NL _DEDENT)? _CCB
 regular_expression: REGEXP NAME?
 inline_expression: _OP inline_service _CP| call_expression| _OP mutation _CP
-values: number| string| boolean| void| list| objects| regular_expression| time
+values: number| string| boolean| void| list| map| regular_expression| time
 path_fragment: _DOT NAME| _OSB INT _CSB| _OSB string _CSB| _OSB path _CSB| _OSB boolean _CSB
 path: NAME (path_fragment)* | inline_expression (path_fragment)*
 assignment_fragment: EQUALS base_expression

--- a/tests/unittests/compiler/json/Objects.py
+++ b/tests/unittests/compiler/json/Objects.py
@@ -191,11 +191,11 @@ def test_objects_list(patch, tree):
     assert result == {'$OBJECT': 'list', 'items': items}
 
 
-def test_objects_objects(patch, tree):
+def test_objects_map(patch, tree):
     patch.many(Objects, ['string', 'base_expression'])
     subtree = Tree('key_value', [Tree('string', ['key']), 'value'])
     tree.children = [subtree]
-    result = Objects().objects(tree)
+    result = Objects().map(tree)
     Objects.string.assert_called_with(subtree.string)
     Objects.base_expression.assert_called_with('value')
     items = [[Objects.string(), Objects.base_expression()]]
@@ -213,7 +213,7 @@ def test_objects_objects_key_string(patch, tree):
         Tree('path', ['value.path']),
     ])
     tree.children = [subtree]
-    result = Objects().objects(tree)
+    result = Objects().map(tree)
     assert result['items'] == [[
         Objects.string(), Objects.base_expression()
     ]]
@@ -229,7 +229,7 @@ def test_objects_objects_key_path(patch, tree):
         Tree('path', ['value.path']),
     ])
     tree.children = [subtree]
-    result = Objects().objects(tree)
+    result = Objects().map(tree)
     assert result['items'] == [[
         Objects.path(), Objects.base_expression()
     ]]
@@ -257,7 +257,7 @@ def test_objects_map_type(tree):
     tree.data = 'types'
     c = tree.first_child()
     c.data = 'map_type'
-    assert Objects.types(tree) == {'$OBJECT': 'type', 'type': 'object'}
+    assert Objects.types(tree) == {'$OBJECT': 'type', 'type': 'map'}
 
 
 def test_objects_list_type(tree):
@@ -284,7 +284,7 @@ def test_objects_entity(patch, tree):
 
 
 @mark.parametrize('value_type', [
-    'string', 'boolean', 'list', 'number', 'objects', 'regular_expression',
+    'string', 'boolean', 'list', 'number', 'map', 'regular_expression',
     'types'
 ])
 def test_objects_values(patch, magic, value_type):


### PR DESCRIPTION
It's a `map` and soon we're introducing the actual `object` type.