### PR TITLE
Require Python 3.5 or newer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(name=name,
       extras_require={
           'docs': extras
       },
+      python_requires='>=3.5',
       entry_points={
           'console_scripts': ['storyscript=storyscript.Cli:Cli.main']
       },


### PR DESCRIPTION
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires