### PR TITLE
fix(semantics): avoid over-greedy mutation conversion

### DIFF
--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -414,16 +414,18 @@ class ExpressionResolver:
         if tree.service_fragment.output is not None:
             tree.service_fragment.output.expect(
                 0, 'service_no_inline_output')
+        t = None
         try:
             # check whether variable exists
             t = self.path(tree.path)
-            service_to_mutation(tree)
-            return self.resolve_mutation(t, tree)
-        except CompilerError as e:
-            # ignore only invalid variables (must be services)
-            if e.error == 'var_not_defined':
-                return AnyType.instance()
-            raise e
+        except CompilerError:
+            # ignore invalid variables (not existent or invalid)
+            # -> must be a service
+            return AnyType.instance()
+
+        # variable exists -> mutation
+        service_to_mutation(tree)
+        return self.resolve_mutation(t, tree)
 
     def mutation(self, tree):
         if tree.path:

--- a/tests/e2e/mutation_expression.json
+++ b/tests/e2e/mutation_expression.json
@@ -4,6 +4,21 @@
       "method": "expression",
       "ln": "1",
       "name": [
+        "req"
+      ],
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": []
+        }
+      ],
+      "src": "req = {}",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "name": [
         "a"
       ],
       "args": [
@@ -22,11 +37,11 @@
         }
       ],
       "src": "a = [\"opened\", \"labeled\"]",
-      "next": "2"
+      "next": "3"
     },
-    "2": {
+    "3": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "3",
       "args": [
         {
           "$OBJECT": "path",
@@ -42,26 +57,16 @@
               "$OBJECT": "arg",
               "name": "item",
               "arg": {
-                "$OBJECT": "expression",
-                "expression": "equal",
-                "values": [
+                "$OBJECT": "path",
+                "paths": [
+                  "req",
                   {
-                    "$OBJECT": "path",
-                    "paths": [
-                      "req",
-                      {
-                        "$OBJECT": "dot",
-                        "dot": "body"
-                      },
-                      {
-                        "$OBJECT": "string",
-                        "string": "action"
-                      }
-                    ]
+                    "$OBJECT": "dot",
+                    "dot": "body"
                   },
                   {
-                    "$OBJECT": "boolean",
-                    "boolean": false
+                    "$OBJECT": "string",
+                    "string": "action"
                   }
                 ]
               }
@@ -69,7 +74,7 @@
           ]
         }
       ],
-      "src": "a contains item: req.body[\"action\"] == false"
+      "src": "a contains item: req.body[\"action\"]"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/mutation_expression.story
+++ b/tests/e2e/mutation_expression.story
@@ -1,2 +1,3 @@
+req = {}
 a = ["opened", "labeled"]
-a contains item: req.body["action"] == false
+a contains item: req.body["action"]

--- a/tests/e2e/service_name_minus.json
+++ b/tests/e2e/service_name_minus.json
@@ -1,0 +1,28 @@
+{
+  "tree": {
+    "1": {
+      "method": "execute",
+      "ln": "1",
+      "name": [
+        "a"
+      ],
+      "service": "kennethreitz-uritool",
+      "command": "parse",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "uri",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "https://github.com/"
+          }
+        }
+      ],
+      "src": "a = kennethreitz-uritool parse uri:'https://github.com/'"
+    }
+  },
+  "services": [
+    "kennethreitz-uritool"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/service_name_minus.story
+++ b/tests/e2e/service_name_minus.story
@@ -1,0 +1,1 @@
+a = kennethreitz-uritool parse uri:'https://github.com/'

--- a/tests/e2e/service_name_slash.json
+++ b/tests/e2e/service_name_slash.json
@@ -1,0 +1,28 @@
+{
+  "tree": {
+    "1": {
+      "method": "execute",
+      "ln": "1",
+      "name": [
+        "a"
+      ],
+      "service": "kennethreitz/uritool",
+      "command": "parse",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "uri",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "https://github.com/"
+          }
+        }
+      ],
+      "src": "a = kennethreitz/uritool parse uri:'https://github.com/'"
+    }
+  },
+  "services": [
+    "kennethreitz/uritool"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/service_name_slash.story
+++ b/tests/e2e/service_name_slash.story
@@ -1,0 +1,1 @@
+a = kennethreitz/uritool parse uri:'https://github.com/'


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/878

The problem here is that the compiler doesn't know whether it's a mutation or service call from the syntax alone, but must do semantic analysis on this.