### PR TITLE
fix(semantics): make all mutations immutable

### DIFF
--- a/storyscript/compiler/semantics/functions/HubMutations.py
+++ b/storyscript/compiler/semantics/functions/HubMutations.py
@@ -13,14 +13,14 @@ List[A] max -> A
 List[A] sum -> A
 List[A] contains item:A -> A
 List[A] unique -> List[A]
-List[A] remove item:A -> A
-List[A] index of:A -> A
+List[A] remove item:A -> List[A]
+List[A] index of:A -> int
 List[A] replace item:A by:A -> List[A]
 
 Map[K,V] length -> int
 Map[K,V] keys -> List[K]
 Map[K,V] values -> List[V]
-Map[K,V] pop key:K -> V
+Map[K,V] pop key:K -> Map[K,V]
 Map[K,V] flatten -> List[List[any]]
 Map[K,V] contains key:K -> boolean
 Map[K,V] contains value:V -> boolean

--- a/tests/e2e/semantics/mutation/obj_pop_key.error
+++ b/tests/e2e/semantics/mutation/obj_pop_key.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 3, column 1
 3|    b = 1
       ^^^
 
-E0100: Can't assign `int` to `boolean`
+E0100: Can't assign `int` to `Map[int,boolean]`


### PR DESCRIPTION
This makes all mutations immutable as the general idea is that they should be very similar to services (which must be immutable).
Having immutable mutations allows makes `const` a lot more powerful and can prevent more silly errors because the user forgot that he silently mutated his collection.
The trend of many programming languages is to move to `const` / `immutable` as people are now willing to pay the bit of extra overhead for the safety and type features gained. Storyscript should follow in line and be able to offer rich `const` types in the future.