### PR TITLE
chore(python): fix conflicts with the built-in format function

### DIFF
--- a/storyscript/exceptions/CompilerError.py
+++ b/storyscript/exceptions/CompilerError.py
@@ -7,5 +7,6 @@ class CompilerError(ProcessingError):
     A compiler error that occurs despite the syntax being correct, for example
     a return outside of a function.
     """
-    def __init__(self, error, token=None, tree=None, format=None):
-        super().__init__(error, token=token, tree=tree, format=format)
+    def __init__(self, error, token=None, tree=None, format_args=None):
+        super().__init__(error, token=token, tree=tree,
+                         format_args=format_args)

--- a/storyscript/exceptions/ProcessingError.py
+++ b/storyscript/exceptions/ProcessingError.py
@@ -25,15 +25,15 @@ class ProcessingError(Exception):
     A generic error that occurs while processing a story
     """
 
-    def __init__(self, error, token=None, tree=None, format=None):
+    def __init__(self, error, token=None, tree=None, format_args=None):
         self.error = error
         self.token_position(token)
         self.tree_position(tree)
-        if format is None:
-            self.format = {}
+        if format_args is None:
+            self.format_args = {}
         else:
-            self.format = format
-        self.format = ConstDict(self.format)
+            self.format_args = format_args
+        self.format_args = ConstDict(self.format_args)
 
     def token_position(self, token):
         """
@@ -56,7 +56,7 @@ class ProcessingError(Exception):
     def message(self):
         if ErrorCodes.is_error(self.error):
             return ErrorCodes.get_error(self.error)[1].format(
-                **self.format)
+                **self.format_args)
         else:
             return 'Unknown compiler error'
 

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -241,7 +241,7 @@ class StoryError(SyntaxError):
         Builds a compiler error with 'error_code' and all other arguments
         as its format parameters.
         """
-        return StoryError(CompilerError(error_code, format=kwargs), None)
+        return StoryError(CompilerError(error_code, format_args=kwargs), None)
 
     @staticmethod
     def internal_error(error):

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -32,10 +32,12 @@ class Transformer(LarkTransformer):
             return
         if keyword in cls.reserved_keywords:
             raise StorySyntaxError('reserved_keyword',
-                                   token=token, format={'keyword': keyword})
+                                   token=token,
+                                   format_args={'keyword': keyword})
         if keyword in cls.future_reserved_keywords:
             raise StorySyntaxError('future_reserved_keyword',
-                                   token=token, format={'keyword': keyword})
+                                   token=token,
+                                   format_args={'keyword': keyword})
         if keyword.startswith('__'):
             raise StorySyntaxError('path_name_internal', token=token)
 

--- a/storyscript/parser/Tree.py
+++ b/storyscript/parser/Tree.py
@@ -146,7 +146,7 @@ class Tree(LarkTree):
         Throws a compiler error with message if the condition is falsy.
         """
         if not cond:
-            raise CompilerError(error, tree=self, format=kwargs)
+            raise CompilerError(error, tree=self, format_args=kwargs)
 
     def follow_node_chain(self, expected_nodes):
         """

--- a/tests/unittests/exceptions/CompilerError.py
+++ b/tests/unittests/exceptions/CompilerError.py
@@ -20,5 +20,5 @@ def test_error_message(patch):
 
 
 def test_compiler_error_extra_parameters():
-    e2 = CompilerError('my_custom_error', format={'a': 2})
-    assert e2.format.a == 2
+    e2 = CompilerError('my_custom_error', format_args={'a': 2})
+    assert e2.format_args.a == 2

--- a/tests/unittests/exceptions/StoryError.py
+++ b/tests/unittests/exceptions/StoryError.py
@@ -202,7 +202,7 @@ def test_storyerror_hint_invalid_character(patch, storyerror):
 def test_storyerror_hint_redeclared(patch, storyerror, magic):
     storyerror.error = CompilerError(
         'reserved_keyword',
-        format={'keyword': 'foo'})
+        format_args={'keyword': 'foo'})
     storyerror.error_tuple = ErrorCodes.reserved_keyword
     assert storyerror.hint() == '`foo` is a reserved keyword'
 
@@ -400,7 +400,7 @@ def test_storyerror_create_error(patch):
     patch.init(CompilerError)
     error = StoryError.create_error('error_code')
     assert isinstance(error, StoryError)
-    CompilerError.__init__.assert_called_with('error_code', format={})
+    CompilerError.__init__.assert_called_with('error_code', format_args={})
     assert isinstance(StoryError.__init__.call_args[0][0], CompilerError)
     assert StoryError.__init__.call_args[0][1] is None
 
@@ -413,7 +413,8 @@ def test_storyerror_create_error_kwargs(patch):
     patch.init(CompilerError)
     error = StoryError.create_error('error_code', a=0)
     assert isinstance(error, StoryError)
-    CompilerError.__init__.assert_called_with('error_code', format={'a': 0})
+    CompilerError.__init__.assert_called_with('error_code',
+                                              format_args={'a': 0})
     assert isinstance(StoryError.__init__.call_args[0][0], CompilerError)
     assert StoryError.__init__.call_args[0][1] is None
 

--- a/tests/unittests/parser/Transformer.py
+++ b/tests/unittests/parser/Transformer.py
@@ -41,7 +41,7 @@ def test_transformer_is_keyword(syntax_error, keyword):
         Transformer.is_keyword(token)
     name = 'reserved_keyword'
     format = {'keyword': keyword}
-    syntax_error.assert_called_with(name, token=token, format=format)
+    syntax_error.assert_called_with(name, token=token, format_args=format)
 
 
 @mark.parametrize('keyword', [
@@ -53,7 +53,7 @@ def test_transformer_is_keyword_future(syntax_error, keyword):
         Transformer.is_keyword(token)
     name = 'future_reserved_keyword'
     format = {'keyword': keyword}
-    syntax_error.assert_called_with(name, token=token, format=format)
+    syntax_error.assert_called_with(name, token=token, format_args=format)
 
 
 def test_transformer_assignment(magic):

--- a/tests/unittests/parser/Tree.py
+++ b/tests/unittests/parser/Tree.py
@@ -238,9 +238,9 @@ def test_tree_expect_kwargs(tree):
     with raises(CompilerError) as e:
         tree.expect(0, 'error', a=0, b=1, c=2)
 
-    assert e.value.format.a == 0
-    assert e.value.format.b == 1
-    assert e.value.format.c == 2
+    assert e.value.format_args.a == 0
+    assert e.value.format_args.b == 1
+    assert e.value.format_args.c == 2
 
 
 def test_follow_node_chain_no_children(tree):


### PR DESCRIPTION
This fixes problems in SLS that only manifest in some versions of Python.
See e.g. https://circleci.com/gh/storyscript/sls/29?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

tl;dr: it's best to not use named arguments that conflict with built-in Python functions.