### PR TITLE
chore(releases): upload a binary wheel to PyPi too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,7 @@ jobs:
                     rm -rf tests # not needed in the released package
                     . venv/bin/activate
                     python setup.py sdist
+                    python setup.py bdist_wheel
             - run:
                   name: upload to pypi
                   command: |


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/897