### PR TITLE
feat(parser): multi-line call expressions (partially)

### DIFF
--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -201,7 +201,8 @@ class Grammar:
                                     'chained_mutation*')
 
     def call_expression(self):
-        self.ebnf.call_expression = 'path op arguments* cp'
+        self.ebnf.call_expression = ('path op arguments* '
+                                     '(nl indent (arguments nl?)* dedent)? cp')
 
     def if_block(self):
         self.ebnf._IF = 'if'

--- a/tests/e2e/function_call_indented.json
+++ b/tests/e2e/function_call_indented.json
@@ -1,0 +1,91 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "output": [
+        "string"
+      ],
+      "function": "fun",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "string"
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "b",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "string"
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4.1",
+      "src": "function fun a: string b:string returns string",
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "foo"
+        }
+      ],
+      "parent": "1",
+      "src": "\treturn \"foo\"",
+      "next": "4.1"
+    },
+    "4.1": {
+      "method": "call",
+      "ln": "4.1",
+      "name": [
+        "__p-4.1"
+      ],
+      "function": "fun",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "string",
+            "string": ""
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "b",
+          "arg": {
+            "$OBJECT": "string",
+            "string": ""
+          }
+        }
+      ],
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-4.1"
+          ]
+        }
+      ],
+      "src": "fun(a: \"\""
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "fun": "1"
+  }
+}

--- a/tests/e2e/function_call_indented.story
+++ b/tests/e2e/function_call_indented.story
@@ -1,0 +1,6 @@
+function fun a: string b:string returns string
+	return "foo"
+
+fun(a: ""
+    b: ""
+)

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -58,7 +58,7 @@ inline_service_fragment: (command arguments*|arguments+)
 service: path service_fragment chained_mutation*
 service_block: service _NL (nested_block)?
 inline_service: path inline_service_fragment chained_mutation*
-call_expression: path _OP arguments* _CP
+call_expression: path _OP arguments* (_NL _INDENT (arguments _NL?)* _DEDENT)? _CP
 if_statement: _IF base_expression
 elseif_statement: _ELSE _IF base_expression
 elseif_block: elseif_statement _NL nested_block


### PR DESCRIPTION
This fixes parts of https://github.com/storyscript/storyscript/issues/891, in particular:

```coffee
function fun a: string b:string returns string
	return "foo"

fun(a: ""
    b: ""
)
```

yields:

<details>

```json
{
  "tree": {
    "1": {
      "method": "function",
      "ln": "1",
      "output": [
        "string"
      ],
      "function": "fun",
      "args": [
        {
          "$OBJECT": "arg",
          "name": "a",
          "arg": {
            "$OBJECT": "type",
            "type": "string"
          }
        },
        {
          "$OBJECT": "arg",
          "name": "b",
          "arg": {
            "$OBJECT": "type",
            "type": "string"
          }
        }
      ],
      "enter": "2",
      "exit": "4.1",
      "src": "function fun a: string b:string returns string",
      "next": "2"
    },
    "2": {
      "method": "return",
      "ln": "2",
      "args": [
        {
          "$OBJECT": "string",
          "string": "foo"
        }
      ],
      "parent": "1",
      "src": "\treturn \"foo\"",
      "next": "4.1"
    },
    "4.1": {
      "method": "call",
      "ln": "4.1",
      "name": [
        "__p-4.1"
      ],
      "function": "fun",
      "args": [
        {
          "$OBJECT": "arg",
          "name": "a",
          "arg": {
            "$OBJECT": "string",
            "string": ""
          }
        },
        {
          "$OBJECT": "arg",
          "name": "b",
          "arg": {
            "$OBJECT": "string",
            "string": ""
          }
        }
      ],
      "next": "4"
    },
    "4": {
      "method": "expression",
      "ln": "4",
      "args": [
        {
          "$OBJECT": "path",
          "paths": [
            "__p-4.1"
          ]
        }
      ],
      "src": "fun(a: \"\""
    }
  },
  "entrypoint": "1",
  "functions": {
    "fun": "1"
  },
  "version": "0.19.1-1-gefb108bb"
}
```

</details>

However, it doesn't fix this case:

```coffee
fun(a: ""
    b: "")
```

as the lexer emits the following here:

```
16 NAME fun
17 _OP (
18 NAME a
19 _COLON :
20 DOUBLE_QUOTED ""
21 _NL 
    
22 _INDENT     
23 NAME b
24 _COLON :
25 DOUBLE_QUOTED ""
26 _CP )
27 _NL 

28 _DEDENT 
```

and `call_expression` is a statement which at the end expects a NL , not DEDENT.
Now we could hack around this with add a special case:

```py
        self.ebnf.call_expression = 'path op arguments* (cp | nl indent (arguments nl?)* (dedent cp | cp nl dedent))'
```

But that would "eat" the NL from the token stream and the lexer thus would fail with:

```
E0043: `)` is not allowed here. Allowed: ['NAME', '_DEDENT', '_COLON', '_NL']
```

There's also another case where we have sth. like e.g.:

```coffee
fun(a: ""
    b: ""
	)
```

But this doesn't work for the same reasons :/