### PR TITLE
fix(semantics): make service output variable rebindable

### DIFF
--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -57,14 +57,15 @@ class TypeResolver(ScopeSelectiveVisitor):
         self.in_service_block = False
         self.in_when_block = False
         if self.features.globals:
-            self.storage_class_scope = StorageClass.write
+            self.storage_class_scope = StorageClass.write()
         else:
-            self.storage_class_scope = StorageClass.read
+            self.storage_class_scope = StorageClass.read()
 
     def assignment(self, tree, scope):
         target_symbol = self.path_resolver.path(tree.path)
 
-        tree.expect(target_symbol.can_write(), 'readonly_type_assignment',
+        # allow rebindable assignments here
+        tree.expect(target_symbol.can_assign(), 'readonly_type_assignment',
                     left=target_symbol.name())
 
         frag = tree.assignment_fragment
@@ -81,6 +82,7 @@ class TypeResolver(ScopeSelectiveVisitor):
                     'variables_dash', token=token)
 
         if target_symbol.type() == NoneType.instance():
+            storage_class = storage_class.declaration_from_symbol()
             if not target_symbol.is_internal():
                 frag.base_expression.expect(expr_type != NoneType.instance(),
                                             'assignment_type_none')
@@ -177,12 +179,12 @@ class TypeResolver(ScopeSelectiveVisitor):
         output.expect(resolved is None, 'output_unique',
                       name=resolved.name() if resolved else None)
         sym = Symbol.from_path(name, ObjectType.instance(),
-                               storage_class=StorageClass.read)
+                               storage_class=StorageClass.rebindable())
         tree.scope.insert(sym)
 
     def when_block(self, tree, scope):
         tree.scope = Scope(parent=scope)
-        with self.create_scope(tree.scope, storage_class=StorageClass.write):
+        with self.create_scope(tree.scope, storage_class=StorageClass.write()):
             self.implicit_output(tree)
 
             output = tree.service.service_fragment.output
@@ -287,7 +289,7 @@ class TypeResolver(ScopeSelectiveVisitor):
         tree.scope, return_type = self.function_statement(
             tree.function_statement, scope
         )
-        with self.create_scope(tree.scope, storage_class=StorageClass.write):
+        with self.create_scope(tree.scope, storage_class=StorageClass.write()):
             self.visit_children(tree.nested_block, scope=tree.scope)
             ReturnVisitor.check(tree, tree.scope, return_type,
                                 self.function_table, self.mutation_table)

--- a/storyscript/compiler/semantics/symbols/Scope.py
+++ b/storyscript/compiler/semantics/symbols/Scope.py
@@ -56,7 +56,7 @@ class Scope:
         scope = cls(parent=None)
         # insert global symbols
         app = Symbol(name='app', type_=ObjectType.instance(),
-                     storage_class=StorageClass.read)
+                     storage_class=StorageClass.read())
         scope.insert(app)
         return scope
 

--- a/storyscript/compiler/semantics/symbols/Symbols.py
+++ b/storyscript/compiler/semantics/symbols/Symbols.py
@@ -4,8 +4,75 @@ from storyscript.compiler.semantics.types.Types import BaseType
 
 
 class StorageClass:
-    write = 0
-    read = 1
+    """
+    A storage class of a variable defines the capabilities of a variable.
+    """
+
+    def __init__(self, write=True, rebindable=True):
+        """
+        Args:
+            write: whether any value of this variable  can be written to.
+               Akin to transitive `const`.
+            rebindable: whether the variable can be assigned with new values.
+        """
+        self._write = write
+        self._rebindable = rebindable
+
+    def can_write(self):
+        """
+        If any value of this variable  can be written to.
+        Akin to transitive `const`.
+        """
+        return self._write
+
+    def can_assign(self):
+        """
+        If the variable can be assigned with new values.
+        """
+        return self._rebindable
+
+    @classmethod
+    def write(cls):
+        """
+        Create a writable, rebindable storage class.
+        """
+        return cls(write=True, rebindable=True)
+
+    @classmethod
+    def read(cls):
+        """
+        Create a readonly and non-rebindable storage class.
+        """
+        return cls(write=False, rebindable=False)
+
+    @classmethod
+    def rebindable(cls):
+        """
+        Create a readonly, but rebindable storage class.
+        """
+        return cls(write=False, rebindable=True)
+
+    def index(self):
+        """
+        Perform an index operation on a variable (e.g. a['b']).
+        Read-permissions are transitively forwarded.
+        """
+        write = self._write
+        rebindable = self._rebindable
+        if not self.can_write():
+            rebindable = False
+        sc = StorageClass(write=write, rebindable=rebindable)
+        return sc
+
+    def declaration_from_symbol(self):
+        """
+        Create a new storage class from an existing one.
+        Copy over the existing read permission.
+        """
+        write = self._write
+        rebindable = True
+        sc = StorageClass(write=write, rebindable=rebindable)
+        return sc
 
 
 def base_symbol(type_):
@@ -19,9 +86,11 @@ class Symbol:
     """
     Representation of an individual symbol.
     """
-    def __init__(self, name, type_, storage_class=StorageClass.write):
+    def __init__(self, name, type_, storage_class=None):
         self._name = name
         self._type = type_
+        if storage_class is None:
+            storage_class = StorageClass.write()
         self._storage_class = storage_class
 
     def name(self):
@@ -40,7 +109,7 @@ class Symbol:
         return f'Symbol({base})'
 
     @classmethod
-    def from_path(cls, node, type_, storage_class=StorageClass.write):
+    def from_path(cls, node, type_, storage_class=None):
         assert node.type == 'NAME'
         name = node.value
         return cls(name, type_, storage_class=storage_class)
@@ -70,11 +139,15 @@ class Symbol:
                         left=symbol.type(),
                         name=name,
                         right=type_)
+        sc = self._storage_class.index()
         return Symbol(name=symbol.name() + '[]', type_=new_type,
-                      storage_class=self._storage_class)
+                      storage_class=sc)
 
     def can_write(self):
-        return self._storage_class == StorageClass.write
+        return self._storage_class.can_write()
+
+    def can_assign(self):
+        return self._storage_class.can_assign()
 
 
 class Symbols:

--- a/tests/e2e/semantics/head_const_output.json
+++ b/tests/e2e/semantics/head_const_output.json
@@ -1,0 +1,83 @@
+{
+  "tree": {
+    "1": {
+      "method": "when",
+      "ln": "1",
+      "output": [
+        "res"
+      ],
+      "service": "client",
+      "command": "listen",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "method",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "post"
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "path",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "/foo"
+          }
+        }
+      ],
+      "enter": "2",
+      "src": "when client listen method:\"post\" path:\"/foo\" as res",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "name": [
+        "comment"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "res",
+            {
+              "$OBJECT": "dot",
+              "dot": "body"
+            },
+            {
+              "$OBJECT": "string",
+              "string": "comment"
+            },
+            {
+              "$OBJECT": "string",
+              "string": "body"
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "       comment = res.body[\"comment\"][\"body\"]",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "name": [
+        "comment"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "test"
+        }
+      ],
+      "parent": "1",
+      "src": "       comment = \"test\""
+    }
+  },
+  "services": [
+    "client"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/semantics/head_const_output.story
+++ b/tests/e2e/semantics/head_const_output.story
@@ -1,0 +1,3 @@
+when client listen method:"post" path:"/foo" as res
+       comment = res.body["comment"]["body"]
+       comment = "test"

--- a/tests/e2e/semantics/head_const_output2.json
+++ b/tests/e2e/semantics/head_const_output2.json
@@ -1,0 +1,75 @@
+{
+  "tree": {
+    "1": {
+      "method": "when",
+      "ln": "1",
+      "output": [
+        "res"
+      ],
+      "service": "client",
+      "command": "listen",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "method",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "post"
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "path",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "/foo"
+          }
+        }
+      ],
+      "enter": "2",
+      "src": "when client listen method:\"post\" path:\"/foo\" as res",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "name": [
+        "comment"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "res",
+            {
+              "$OBJECT": "dot",
+              "dot": "body"
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "       comment = res.body",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "name": [
+        "comment"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "test"
+        }
+      ],
+      "parent": "1",
+      "src": "       comment = \"test\""
+    }
+  },
+  "services": [
+    "client"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/semantics/head_const_output2.story
+++ b/tests/e2e/semantics/head_const_output2.story
@@ -1,0 +1,3 @@
+when client listen method:"post" path:"/foo" as res
+       comment = res.body
+       comment = "test"

--- a/tests/e2e/semantics/head_const_output3.json
+++ b/tests/e2e/semantics/head_const_output3.json
@@ -1,0 +1,75 @@
+{
+  "tree": {
+    "1": {
+      "method": "when",
+      "ln": "1",
+      "output": [
+        "res"
+      ],
+      "service": "client",
+      "command": "listen",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "method",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "post"
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "path",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "/foo"
+          }
+        }
+      ],
+      "enter": "2",
+      "src": "when client listen method:\"post\" path:\"/foo\" as res",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "name": [
+        "comment"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "res",
+            {
+              "$OBJECT": "string",
+              "string": "body"
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "       comment = res[\"body\"]",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "name": [
+        "comment"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "test"
+        }
+      ],
+      "parent": "1",
+      "src": "       comment = \"test\""
+    }
+  },
+  "services": [
+    "client"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/semantics/head_const_output3.story
+++ b/tests/e2e/semantics/head_const_output3.story
@@ -1,0 +1,3 @@
+when client listen method:"post" path:"/foo" as res
+       comment = res["body"]
+       comment = "test"

--- a/tests/e2e/semantics/head_const_output4.error
+++ b/tests/e2e/semantics/head_const_output4.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 8
+
+2|           res["body"] = "foo"
+             ^^^^^^^^^^^^^
+
+E0127: `res[]` is readonly and can not be assigned to.

--- a/tests/e2e/semantics/head_const_output4.story
+++ b/tests/e2e/semantics/head_const_output4.story
@@ -1,0 +1,2 @@
+when client listen method:"post" path:"/foo" as res
+       res["body"] = "foo"

--- a/tests/e2e/semantics/head_const_output5.json
+++ b/tests/e2e/semantics/head_const_output5.json
@@ -1,0 +1,79 @@
+{
+  "tree": {
+    "1": {
+      "method": "when",
+      "ln": "1",
+      "output": [
+        "res"
+      ],
+      "service": "client",
+      "command": "listen",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "method",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "post"
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "path",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "/foo"
+          }
+        }
+      ],
+      "enter": "2",
+      "src": "when client listen method:\"post\" path:\"/foo\" as res",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "name": [
+        "foo"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "res",
+            {
+              "$OBJECT": "dot",
+              "dot": "body"
+            },
+            {
+              "$OBJECT": "string",
+              "string": "foo"
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "       foo = res.body[\"foo\"]",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "name": [
+        "foo"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "1",
+      "src": "       foo = 2"
+    }
+  },
+  "services": [
+    "client"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/semantics/head_const_output5.story
+++ b/tests/e2e/semantics/head_const_output5.story
@@ -1,0 +1,3 @@
+when client listen method:"post" path:"/foo" as res
+       foo = res.body["foo"]
+       foo = 2

--- a/tests/e2e/semantics/head_const_output6.json
+++ b/tests/e2e/semantics/head_const_output6.json
@@ -1,0 +1,75 @@
+{
+  "tree": {
+    "1": {
+      "method": "when",
+      "ln": "1",
+      "output": [
+        "res"
+      ],
+      "service": "client",
+      "command": "listen",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "method",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "post"
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "path",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "/foo"
+          }
+        }
+      ],
+      "enter": "2",
+      "src": "when client listen method:\"post\" path:\"/foo\" as res",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "name": [
+        "foo"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "res",
+            {
+              "$OBJECT": "string",
+              "string": "foo"
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "       foo = res[\"foo\"]",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "name": [
+        "foo"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "1",
+      "src": "       foo = 2"
+    }
+  },
+  "services": [
+    "client"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/semantics/head_const_output6.story
+++ b/tests/e2e/semantics/head_const_output6.story
@@ -1,0 +1,3 @@
+when client listen method:"post" path:"/foo" as res
+       foo = res["foo"]
+       foo = 2

--- a/tests/e2e/semantics/head_const_output7.error
+++ b/tests/e2e/semantics/head_const_output7.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 8
+
+2|           res["foo"] = 2
+             ^^^^^^^^^^^^
+
+E0127: `res[]` is readonly and can not be assigned to.

--- a/tests/e2e/semantics/head_const_output7.story
+++ b/tests/e2e/semantics/head_const_output7.story
@@ -1,0 +1,2 @@
+when client listen method:"post" path:"/foo" as res
+       res["foo"] = 2

--- a/tests/e2e/semantics/head_const_output8.error
+++ b/tests/e2e/semantics/head_const_output8.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 3, column 5
+
+3|        v["foo"] = 2
+          ^^^^^^^^^^
+
+E0127: `v[]` is readonly and can not be assigned to.

--- a/tests/e2e/semantics/head_const_output8.story
+++ b/tests/e2e/semantics/head_const_output8.story
@@ -1,0 +1,3 @@
+when client listen method:"post" path:"/foo" as res
+    v = res
+    v["foo"] = 2

--- a/tests/e2e/semantics/head_const_output9.json
+++ b/tests/e2e/semantics/head_const_output9.json
@@ -1,0 +1,146 @@
+{
+  "tree": {
+    "1": {
+      "method": "execute",
+      "ln": "1",
+      "output": [
+        "server"
+      ],
+      "service": "http",
+      "command": "server",
+      "enter": "2",
+      "src": "http server as server",
+      "next": "2"
+    },
+    "2": {
+      "method": "when",
+      "ln": "2",
+      "output": [
+        "req"
+      ],
+      "service": "server",
+      "command": "listen",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "path",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "/"
+          }
+        }
+      ],
+      "enter": "3",
+      "parent": "1",
+      "src": "    when server listen path: \"/\" as req",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "name": [
+        "text"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "req",
+            {
+              "$OBJECT": "dot",
+              "dot": "body"
+            },
+            {
+              "$OBJECT": "string",
+              "string": "a"
+            },
+            {
+              "$OBJECT": "string",
+              "string": "b"
+            }
+          ]
+        }
+      ],
+      "parent": "2",
+      "src": "        text = req.body[\"a\"][\"b\"]",
+      "next": "4"
+    },
+    "4": {
+      "method": "if",
+      "ln": "4",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "equal",
+          "values": [
+            {
+              "$OBJECT": "type_cast",
+              "type": {
+                "$OBJECT": "type",
+                "type": "string"
+              },
+              "value": {
+                "$OBJECT": "path",
+                "paths": [
+                  "text"
+                ]
+              }
+            },
+            {
+              "$OBJECT": "string",
+              "string": "a"
+            }
+          ]
+        }
+      ],
+      "enter": "5",
+      "exit": "6",
+      "parent": "2",
+      "src": "        if text == \"a\"",
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "name": [
+        "text"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "b"
+        }
+      ],
+      "parent": "4",
+      "src": "            text = \"b\"",
+      "next": "6"
+    },
+    "6": {
+      "method": "else",
+      "ln": "6",
+      "enter": "7",
+      "parent": "2",
+      "src": "        else",
+      "next": "7"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "name": [
+        "text"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "c"
+        }
+      ],
+      "parent": "6",
+      "src": "            text = \"c\""
+    }
+  },
+  "services": [
+    "http"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/semantics/head_const_output9.story
+++ b/tests/e2e/semantics/head_const_output9.story
@@ -1,0 +1,7 @@
+http server as server
+    when server listen path: "/" as req
+        text = req.body["a"]["b"]
+        if text == "a"
+            text = "b"
+        else
+            text = "c"

--- a/tests/e2e/service_event_output_readonly.error
+++ b/tests/e2e/service_event_output_readonly.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 3, column 3
 3|        req = 2
           ^^^^^
 
-E0127: `req` is readonly and can not be assigned to.
+E0100: Can't assign `int` to `Object`

--- a/tests/e2e/service_output_readonly.error
+++ b/tests/e2e/service_output_readonly.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 2, column 2
 2|      event = 2
         ^^^^^^^
 
-E0127: `event` is readonly and can not be assigned to.
+E0100: Can't assign `int` to `Object`

--- a/tests/e2e/service_output_readonly2.error
+++ b/tests/e2e/service_output_readonly2.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 3, column 3
 3|        server = 2
           ^^^^^^^^
 
-E0127: `server` is readonly and can not be assigned to.
+E0100: Can't assign `int` to `Object`

--- a/tests/integration/compiler/semantics/types/Types.py
+++ b/tests/integration/compiler/semantics/types/Types.py
@@ -150,8 +150,7 @@ implicit_assigns = {
     'Map[string,int]': ['Map[string,int]'],
     'Map[string,string]': ['Map[string,string]'],
     'none': [],
-    # at the moment SS only has app as object which is const
-    'object': [],
+    'object': ['object'],
     'any': [k for k in all_types.keys() if k != 'none'],
 }
 

--- a/tests/unittests/compiler/semantics/symbols/Symbols.py
+++ b/tests/unittests/compiler/semantics/symbols/Symbols.py
@@ -27,7 +27,7 @@ def test_symbol_pretty_string():
 
 def test_symbol_str_ro_string():
     sym = Symbol('foo', StringType.instance(),
-                 storage_class=StorageClass.read)
+                 storage_class=StorageClass.read())
     assert str(sym) == "Symbol('foo', string, ro)"
 
 


### PR DESCRIPTION
Alternative fix for https://github.com/storyscript/storyscript/issues/926

See also: https://github.com/storyscript/storyscript/pull/927/files

```coffeescript
when client listen method:'post' path:'/foo' as res
    v = res["foo"]
    v["bar"] = ERROR
    v = 2 # OK
```

