### PR TITLE
chore(CI): remove code coverage workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,15 +38,6 @@ jobs:
                 #paths:
                     #- ./venv
                 #key: v1-dependencies-{{ checksum "setup.py" }}
-            - run:
-                name: Apply CodeCov workaround for excluding lines
-                command: |
-                  # Workaround for https://github.com/codecov/codecov-python/issues/107
-                  sed 's/internal_assert(0)/# ignored for CodeCov/' \
-                  -i $(find storyscript -type f -name '*.py')
-                  #sed 's/from.*internal_assert/# ignored for CodeCov/' \
-                  #-i $(find storyscript -type f -name '*.py' \
-                  #  -not -name '*__init__.py')
 
             - run:
                 name: run pep8 linter


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/967 as the code coverage workaround is no longer needed.