### PR TITLE
fix(setup.py): change how we handle install command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
                     . venv/bin/activate
                     python3 setup.py install
                     pip install tox
+                    storyscript --version
 
             #- save_cache:
                 #paths:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import inspect
 import io
 import sys
 from os import getenv, path
@@ -78,7 +79,15 @@ def prepare_release(cwd, use_release):
 
 class Install(_install):
     def run(self):
-        _install.run(self)
+        if not _install._called_from_setup(inspect.currentframe()):
+            # The run function from setuptools.command.install doesn't detect
+            # install cmd properly in the current setting of sub classing
+            # Install and therefore we detect it here and do the right thing
+            # for install command otherwise fall back to super class run for
+            # the other cases.
+            _install.run(self)
+        else:
+            _install.do_egg_install(self)
         self.execute(prepare_release, (self.install_lib, False),
                      msg='Preparing the installation')
 


### PR DESCRIPTION
Due to the way setuptools.command.install.run handles detects
install command, sub classing Install breaks that login and thus
calling the `run` from super class results in a broken setup
process.
The setup process would finish without any errors but it won't
install the requirements specified in the setup.py which is not
expected. CI doesn't notice it because it uses `tox` to run tests
which installs dependacies itself.
In this change we try to reiterate the logic used in the super
class's defination of run and do the right thing for install
command and fallback to super class implmentation for the other
cases.

Fixes: #997

**- How to verify it**
Try setting up a fresh virtual environment and setup new development environment. Before this PR dependencies won't be installed.

After this PR, you can see running `python setup.py install` does install dependencies and other commands like `python setup.py bdist_wheel` continue to work fine.