### PR TITLE
feat(grammar): Improve EOL error messages

### DIFF
--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -153,7 +153,24 @@ class StoryError(SyntaxError):
         elif intention.assignment():
             return ErrorCodes.assignment_incomplete
 
-        self._format = {'allowed': str(self.error.expected)}
+        expected = self.error.expected
+        if len(expected) == 1:
+            # Try to show the literal token value
+            from storyscript.parser import Grammar as Grammar  # noqa
+
+            expected = expected[0]
+            grammar = Grammar()
+            grammar.build()
+            token_name = expected.lower()[1:]
+            expected_token = grammar.ebnf._tokens.get(token_name)
+            if expected_token:
+                allowed = '`{}`'.format(expected_token['value'].strip('"'))
+            else:
+                allowed = expected
+        else:
+            allowed = str(self.error.expected)
+
+        self._format = {'allowed': allowed}
         if token.type == '_NL':
             return ErrorCodes.unexpected_end_of_line
 

--- a/tests/e2e/e0053_unexpected_end_of_line2.error
+++ b/tests/e2e/e0053_unexpected_end_of_line2.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 1, column 6
 1|    foo .
            ^
 
-E0053: Unexpected end of line. Expected: ['NAME'].
+E0053: Unexpected end of line. Expected: NAME.

--- a/tests/e2e/invalid_return_type3.error
+++ b/tests/e2e/invalid_return_type3.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 1, column 26
 1|    function foo returns List
                                ^
 
-E0053: Unexpected end of line. Expected: ['_OSB'].
+E0053: Unexpected end of line. Expected: `[`.

--- a/tests/e2e/scope_individual_try_catch.error
+++ b/tests/e2e/scope_individual_try_catch.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 3, column 6
 3|    catch
            ^
 
-E0053: Unexpected end of line. Expected: ['_AS'].
+E0053: Unexpected end of line. Expected: `as`.


### PR DESCRIPTION
Avoid showing token names in error messages when
the token can be displayed as a single character.

Also remove list syntax when only one token type
is expected.
