### PR TITLE
feat(grammar): stop accepting type assignment cast shorthand

### DIFF
--- a/storyscript/compiler/json/JSONExpressionVisitor.py
+++ b/storyscript/compiler/json/JSONExpressionVisitor.py
@@ -35,7 +35,7 @@ class JSONExpressionVisitor(ExpressionVisitor):
             'values': values,
         }
 
-    def as_expression(self, tree, expr=None):
+    def as_expression(self, tree, expr):
         assert tree.child(1).data == 'as_operator'
         t = self.visitor.types(tree.child(1).types)
         return {'$OBJECT': 'type_cast', 'type': t, 'value': expr}

--- a/storyscript/compiler/lowering/Faketree.py
+++ b/storyscript/compiler/lowering/Faketree.py
@@ -74,8 +74,7 @@ class FakeTree:
         """
         line = self.get_line(value)
         first_token = value.find_first_token()
-        if first_token is not None:
-            first_token.line = line
+        first_token.line = line
         path = self.path(line=line)
         return self.assignment_path(path, value, line)
 

--- a/storyscript/compiler/lowering/Lowering.py
+++ b/storyscript/compiler/lowering/Lowering.py
@@ -436,24 +436,6 @@ class Lowering:
 
         if node.data == 'assignment':
             c = node.children[0]
-            if c.data == 'types':
-                line = node.line()
-                base_expr = node.assignment_fragment.base_expression
-                orig_node = Tree('base_expression', base_expr.children)
-                orig_obj = block.add_assignment(orig_node, original_line=line)
-                base_expr.children = [
-                    Tree('expression', [
-                        Tree('expression', [
-                            Tree('entity', [
-                                orig_obj
-                            ]),
-                        ]),
-                        Tree('as_operator', [c]),
-                    ])
-                ]
-                # now process the rest of the assignment
-                node.children = node.children[1:]
-                c = node.children[0]
 
             if c.data == 'path':
                 # a path assignment -> no processing required

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -59,7 +59,7 @@ class SymbolExpressionVisitor(ExpressionVisitor):
         """
         return operator in cls._arithmetic_types
 
-    def as_expression(self, tree, expr=None):
+    def as_expression(self, tree, expr):
         assert tree.child(1).data == 'as_operator'
         # check for compatibility
         t = self.visitor.types(tree.child(1).types)

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -106,7 +106,7 @@ class Grammar:
         self.ebnf.assignment_fragment = assignment_fragment
         objects = self.ebnf.collection('ocb', 'path', 'path', 'ccb')
         self.ebnf.assignment_destructoring = objects
-        self.ebnf.assignment = ('types? (path | assignment_destructoring ) '
+        self.ebnf.assignment = ('(path | assignment_destructoring) '
                                 'assignment_fragment')
 
     def expressions(self):

--- a/tests/e2e/explicit_cast_invalid.story
+++ b/tests/e2e/explicit_cast_invalid.story
@@ -1,2 +1,2 @@
-Map[time,time] t = {}
+t = {} as Map[time,time]
 c = t as Map[float,float]

--- a/tests/e2e/explicit_cast_invalid2.error
+++ b/tests/e2e/explicit_cast_invalid2.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1
+Error: syntax error in story at line 1, column 16
 
-1|    List[time] t = {}
-      ^^^^^^^^^^^^^^^^^
+1|    t = {} as List[time]
+                     ^^^^
 
 E0126: Type casting not supported from `Map[any,any]` to `List[time]`.

--- a/tests/e2e/explicit_cast_invalid2.story
+++ b/tests/e2e/explicit_cast_invalid2.story
@@ -1,2 +1,2 @@
-List[time] t = {}
+t = {} as List[time]
 c = t as List[float]

--- a/tests/e2e/type_assignment.json
+++ b/tests/e2e/type_assignment.json
@@ -1,19 +1,5 @@
 {
   "tree": {
-    "1.1": {
-      "method": "expression",
-      "ln": "1.1",
-      "name": [
-        "__p-1.1"
-      ],
-      "args": [
-        {
-          "$OBJECT": "list",
-          "items": []
-        }
-      ],
-      "next": "1"
-    },
     "1": {
       "method": "expression",
       "ln": "1",
@@ -34,14 +20,12 @@
             ]
           },
           "value": {
-            "$OBJECT": "path",
-            "paths": [
-              "__p-1.1"
-            ]
+            "$OBJECT": "list",
+            "items": []
           }
         }
       ],
-      "src": "List[int] a = []",
+      "src": "a = [] as List[int]",
       "next": "2"
     },
     "2": {
@@ -75,5 +59,5 @@
       "src": "b = 2 + a[0]"
     }
   },
-  "entrypoint": "1.1"
+  "entrypoint": "1"
 }

--- a/tests/e2e/type_assignment.story
+++ b/tests/e2e/type_assignment.story
@@ -1,2 +1,2 @@
-List[int] a = []
+a = [] as List[int]
 b = 2 + a[0]

--- a/tests/e2e/type_assignment_invalid.error
+++ b/tests/e2e/type_assignment_invalid.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1
+Error: syntax error in story at line 1, column 5
 
-1|    int a = []
-      ^^^^^^^^^^
+1|    a = [] as int
+          ^^^^^^^^^
 
 E0126: Type casting not supported from `List[any]` to `int`.

--- a/tests/e2e/type_assignment_invalid.story
+++ b/tests/e2e/type_assignment_invalid.story
@@ -1,1 +1,1 @@
-int a = []
+a = [] as int

--- a/tests/e2e/type_assignment_list_any.json
+++ b/tests/e2e/type_assignment_list_any.json
@@ -1,19 +1,5 @@
 {
   "tree": {
-    "1.1": {
-      "method": "expression",
-      "ln": "1.1",
-      "name": [
-        "__p-1.1"
-      ],
-      "args": [
-        {
-          "$OBJECT": "list",
-          "items": []
-        }
-      ],
-      "next": "1"
-    },
     "1": {
       "method": "expression",
       "ln": "1",
@@ -34,15 +20,13 @@
             ]
           },
           "value": {
-            "$OBJECT": "path",
-            "paths": [
-              "__p-1.1"
-            ]
+            "$OBJECT": "list",
+            "items": []
           }
         }
       ],
-      "src": "List[any] a = []"
+      "src": "a = [] as List[any]"
     }
   },
-  "entrypoint": "1.1"
+  "entrypoint": "1"
 }

--- a/tests/e2e/type_assignment_list_any.story
+++ b/tests/e2e/type_assignment_list_any.story
@@ -1,1 +1,1 @@
-List[any] a = []
+a = [] as List[any]

--- a/tests/e2e/type_assignment_list_any2.json
+++ b/tests/e2e/type_assignment_list_any2.json
@@ -1,19 +1,5 @@
 {
   "tree": {
-    "1.1": {
-      "method": "expression",
-      "ln": "1.1",
-      "name": [
-        "__p-1.1"
-      ],
-      "args": [
-        {
-          "$OBJECT": "list",
-          "items": []
-        }
-      ],
-      "next": "1"
-    },
     "1": {
       "method": "expression",
       "ln": "1",
@@ -40,15 +26,13 @@
             ]
           },
           "value": {
-            "$OBJECT": "path",
-            "paths": [
-              "__p-1.1"
-            ]
+            "$OBJECT": "list",
+            "items": []
           }
         }
       ],
-      "src": "List[List[string]] a = []"
+      "src": "a = [] as List[List[string]]"
     }
   },
-  "entrypoint": "1.1"
+  "entrypoint": "1"
 }

--- a/tests/e2e/type_assignment_list_any2.story
+++ b/tests/e2e/type_assignment_list_any2.story
@@ -1,1 +1,1 @@
-List[List[string]] a = []
+a = [] as List[List[string]]

--- a/tests/e2e/type_assignment_map_list.error
+++ b/tests/e2e/type_assignment_map_list.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1
+Error: syntax error in story at line 1, column 21
 
-1|    List[List[string]] a = {}
-      ^^^^^^^^^^^^^^^^^^^^^^^^^
+1|    a = {} as List[List[string]]
+                          ^^^^^^
 
 E0126: Type casting not supported from `Map[any,any]` to `List[List[string]]`.

--- a/tests/e2e/type_assignment_map_list.story
+++ b/tests/e2e/type_assignment_map_list.story
@@ -1,1 +1,1 @@
-List[List[string]] a = {}
+a = {} as List[List[string]]

--- a/tests/e2e/type_reassignment.json
+++ b/tests/e2e/type_reassignment.json
@@ -1,19 +1,5 @@
 {
   "tree": {
-    "1.1": {
-      "method": "expression",
-      "ln": "1.1",
-      "name": [
-        "__p-1.1"
-      ],
-      "args": [
-        {
-          "$OBJECT": "list",
-          "items": []
-        }
-      ],
-      "next": "1"
-    },
     "1": {
       "method": "expression",
       "ln": "1",
@@ -34,30 +20,12 @@
             ]
           },
           "value": {
-            "$OBJECT": "path",
-            "paths": [
-              "__p-1.1"
-            ]
+            "$OBJECT": "list",
+            "items": []
           }
         }
       ],
-      "src": "List[any] a = []",
-      "next": "2.1"
-    },
-    "2.1": {
-      "method": "expression",
-      "ln": "2.1",
-      "name": [
-        "__p-2.1"
-      ],
-      "args": [
-        {
-          "$OBJECT": "path",
-          "paths": [
-            "a"
-          ]
-        }
-      ],
+      "src": "a = [] as List[any]",
       "next": "2"
     },
     "2": {
@@ -82,13 +50,13 @@
           "value": {
             "$OBJECT": "path",
             "paths": [
-              "__p-2.1"
+              "a"
             ]
           }
         }
       ],
-      "src": "List[string] a = a"
+      "src": "a = a as List[string]"
     }
   },
-  "entrypoint": "1.1"
+  "entrypoint": "1"
 }

--- a/tests/e2e/type_reassignment.story
+++ b/tests/e2e/type_reassignment.story
@@ -1,2 +1,2 @@
-List[any] a = []
-List[string] a = a
+a = [] as List[any]
+a = a as List[string]

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -21,7 +21,7 @@ path_fragment: _DOT NAME| _OSB (number | string | path | boolean | range) _CSB
 path: NAME (path_fragment)* | inline_expression (path_fragment)*
 assignment_fragment: EQUALS base_expression
 assignment_destructoring: _OCB (_NL _INDENT)? (path (_COMMA _NL? path)*)? (_NL _DEDENT)? _CCB
-assignment: types? (path | assignment_destructoring ) assignment_fragment
+assignment: (path | assignment_destructoring) assignment_fragment
 cmp_operator: GREATER| GREATER_EQUAL| LESSER| LESSER_EQUAL| NOT_EQUAL| EQUAL
 arith_operator: PLUS| DASH
 unary_operator: NOT


### PR DESCRIPTION
This is done in order to make grammar coherant with the
storyscript theory of providing only one way of doing things.

int foo = "2" # Not accepted anymore.
foo = "2" as int # Acceptable.

Closes: #888.

**- What I did**
Removed one of the two ways to type cast
**- How I did it**
Changed the grammar and removed possibility to lead assignment expression with a type.
**- How to verify it**
Try running a story script with `int foo = "2"` type expressions.
It shouldn't be accepted.
