### PR TITLE
Add filename to StoryError Related to #606

### DIFF
--- a/storyscript/Bundle.py
+++ b/storyscript/Bundle.py
@@ -94,7 +94,7 @@ class Bundle:
         """
         if path not in self.story_files:
             self.story_files[path] = Story.read(path)
-        return Story(self.story_files[path], features=self.features)
+        return Story(self.story_files[path], features=self.features, path=path)
 
     def find_stories(self):
         """

--- a/storyscript/exceptions/StoryError.py
+++ b/storyscript/exceptions/StoryError.py
@@ -2,6 +2,7 @@
 import os
 
 import click
+import ntpath
 
 from lark.exceptions import UnexpectedCharacters, UnexpectedToken
 
@@ -53,6 +54,15 @@ class StoryError(SyntaxError):
         line = self.int_line()
         return self.story.line(line)
 
+    def get_filename(self):
+        """
+        Gets the filename where error occured
+        """
+        if self.path:
+            head, tail = ntpath.split(self.path)
+            return tail or ntpath.basename(head)
+        return self.name()
+
     def header(self):
         """
         Creates the header of the message
@@ -75,6 +85,9 @@ class StoryError(SyntaxError):
                     self.error.end_column != 'None':
                 end_column = int(self.error.end_column)
             start_column = int(self.error.column)
+            filename_length = int(len(self.get_filename()))
+            start_column += filename_length + 1
+            end_column += filename_length + 1
         else:
             # if the column is not known, start at the first non-whitespace
             # token
@@ -98,12 +111,13 @@ class StoryError(SyntaxError):
         """
         Creates the error highlight of the message
         """
+        filename = self.get_filename()
         line = self.int_line()
         # replace tabs for consistent error messages
         raw_line = self.get_line()
         untabbed_line = raw_line.replace('\t', ' ' * self.tabwidth)
         highlight = self.symbols(raw_line)
-        return '{}|    {}\n{}'.format(line, untabbed_line, highlight)
+        return '{}:{}|    {}\n{}'.format(filename, line, untabbed_line, highlight)
 
     def error_code(self):
         """


### PR DESCRIPTION
Added a method to get filename on StoryError class to print better error on parse.

closes #606

Currently, tests are failing but I will fix them if the implementation is good enough for this ticket.

Example output on parse:

```shell
$ storyscript parse ~/repos/storyscri
ptstart/first_app/
Error: syntax error in ../../../storyscriptstart/first_app/http.story at line 2, column 31

http.story:2|        when client listen method:'get' path:"/" as r

                                               ^^^^^

E0129: Single quotes are not allowed.
```