### PR TITLE
feat(parser): stop accepting old (whitespace+then) mutation syntax

### DIFF
--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -106,11 +106,6 @@ class TypeResolver(ScopeSelectiveVisitor):
     def nested_block(self, tree, scope):
         self.visit_children(tree, scope)
 
-    def mutation_block(self, tree, scope):
-        # resolve to perform checks
-        tree.scope = Scope(parent=scope)
-        self.resolver.mutation(tree.mutation)
-
     def absolute_expression(self, tree, scope):
         # resolve to perform checks
         self.resolver.expression(tree.expression)

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -84,8 +84,7 @@ class Grammar:
         self.ebnf.map = self.ebnf.collection(*map_)
         self.ebnf.regular_expression = 'regexp'
         self.ebnf.inline_expression = ('op inline_service cp, '
-                                       'call_expression, '
-                                       'op mutation cp')
+                                       'call_expression')
         values = ('number, string, boolean, void, list, map, '
                   'regular_expression, time')
         self.ebnf.values = values
@@ -165,9 +164,9 @@ class Grammar:
 
         self.ebnf.expression = 'or_expression'
         self.ebnf.absolute_expression = 'expression'
-        # service and mutation calls don't need parentheses when they are at
+        # service calls don't need parentheses when they are at
         # the base,e.g. `if my_service commmand`
-        self.ebnf.base_expression = '(expression, inline_service, mutation)'
+        self.ebnf.base_expression = '(expression, inline_service)'
 
     def throw_statement(self):
         self.ebnf.THROW = 'throw'
@@ -183,25 +182,15 @@ class Grammar:
                  'throw_statement, break_statement, block')
         self.ebnf.rules = rules
 
-    def mutation_block(self):
-        self.ebnf._THEN = 'then'
-        self.ebnf.mutation_fragment = 'name arguments*'
-        self.ebnf.chained_mutation = 'then mutation_fragment'
-        self.ebnf.mutation = ('primary_expression (mutation_fragment '
-                              '(chained_mutation)*)')
-        self.ebnf.mutation_block = 'mutation nl (nested_block)?'
-        self.ebnf.indented_chain = 'indent (chained_mutation nl)+ dedent'
-
     def service_block(self):
         self.ebnf.command = 'name'
         self.ebnf.arguments = 'name? colon expression'
         self.ebnf.output = '(as name (comma name)*)'
         self.ebnf.service_fragment = '(command arguments*|arguments+) output?'
         self.ebnf.inline_service_fragment = '(command arguments*|arguments+)'
-        self.ebnf.service = 'path service_fragment chained_mutation*'
+        self.ebnf.service = 'path service_fragment'
         self.ebnf.service_block = 'service nl (nested_block)?'
-        self.ebnf.inline_service = ('path inline_service_fragment '
-                                    'chained_mutation*')
+        self.ebnf.inline_service = ('path inline_service_fragment')
 
     def call_expression(self):
         self.ebnf.call_expression = ('path op arguments* '
@@ -265,8 +254,7 @@ class Grammar:
         self.ebnf.when_block = self.ebnf.simple_block(when)
         self.ebnf.indented_arguments = 'indent (arguments nl)+ dedent'
         block = ('rules nl, if_block, foreach_block, function_block, '
-                 'arguments, indented_chain, chained_mutation, '
-                 'mutation_block, service_block, when_block, try_block, '
+                 'arguments, service_block, when_block, try_block, '
                  'indented_arguments, while_block')
         self.ebnf.block = block
         self.ebnf.nested_block = 'indent block+ dedent'
@@ -279,7 +267,6 @@ class Grammar:
         self.assignments()
         self.expressions()
         self.rules()
-        self.mutation_block()
         self.service_block()
         self.call_expression()
         self.if_block()

--- a/tests/e2e/arg_name_shorthand2.json
+++ b/tests/e2e/arg_name_shorthand2.json
@@ -13,11 +13,14 @@
         }
       ],
       "src": "item = 0",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
+      "name": [
+        "__p-2.1"
+      ],
       "args": [
         {
           "$OBJECT": "list",
@@ -49,7 +52,20 @@
           ]
         }
       ],
-      "src": "[0, 1] contains :item"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "[0, 1].contains(:item)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/arg_name_shorthand2.story
+++ b/tests/e2e/arg_name_shorthand2.story
@@ -1,2 +1,2 @@
 item = 0
-[0, 1] contains :item
+[0, 1].contains(:item)

--- a/tests/e2e/arg_name_shorthand5.json
+++ b/tests/e2e/arg_name_shorthand5.json
@@ -31,12 +31,32 @@
       "next": "3"
     },
     "3": {
-      "method": "mutation",
+      "method": "expression",
       "ln": "3",
+      "name": [
+        "s"
+      ],
       "args": [
         {
           "$OBJECT": "string",
           "string": "aa"
+        }
+      ],
+      "src": "s = \"aa\"",
+      "next": "4.1"
+    },
+    "4.1": {
+      "method": "mutation",
+      "ln": "4.1",
+      "name": [
+        "__p-4.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "s"
+          ]
         },
         {
           "$OBJECT": "mutation",
@@ -65,7 +85,20 @@
           ]
         }
       ],
-      "src": "\"aa\" substring :start :end"
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-4.1"
+          ]
+        }
+      ],
+      "src": "s.substring(:start :end)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/arg_name_shorthand5.story
+++ b/tests/e2e/arg_name_shorthand5.story
@@ -1,3 +1,4 @@
 start = 0
 end = 5
-"aa" substring :start :end
+s = "aa"
+s.substring(:start :end)

--- a/tests/e2e/assignments_mutation.json
+++ b/tests/e2e/assignments_mutation.json
@@ -1,8 +1,11 @@
 {
   "tree": {
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
+      "name": [
+        "__p-2.1"
+      ],
       "args": [
         {
           "$OBJECT": "list",
@@ -28,41 +31,70 @@
           ]
         }
       ],
-      "src": "[0] append item:1",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "[0].append(item:1)",
+      "next": "3.1"
+    },
+    "3.1": {
+      "method": "mutation",
+      "ln": "3.1",
+      "name": [
+        "__p-3.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "int",
+              "int": 0
+            }
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "append",
+          "args": [
+            {
+              "$OBJECT": "arg",
+              "name": "item",
+              "arg": {
+                "$OBJECT": "int",
+                "int": 1
+              }
+            }
+          ]
+        }
+      ],
       "next": "3"
     },
     "3": {
-      "method": "mutation",
+      "method": "expression",
       "ln": "3",
       "name": [
         "mutation"
       ],
       "args": [
         {
-          "$OBJECT": "list",
-          "items": [
-            {
-              "$OBJECT": "int",
-              "int": 0
-            }
-          ]
-        },
-        {
-          "$OBJECT": "mutation",
-          "mutation": "append",
-          "args": [
-            {
-              "$OBJECT": "arg",
-              "name": "item",
-              "arg": {
-                "$OBJECT": "int",
-                "int": 1
-              }
-            }
+          "$OBJECT": "path",
+          "paths": [
+            "__p-3.1"
           ]
         }
       ],
-      "src": "mutation = [0] append item:1",
+      "src": "mutation = [0].append(item:1)",
       "next": "5"
     },
     "5": {
@@ -83,11 +115,14 @@
         }
       ],
       "src": "a = [0]",
-      "next": "6"
+      "next": "6.1"
     },
-    "6": {
+    "6.1": {
       "method": "mutation",
-      "ln": "6",
+      "ln": "6.1",
+      "name": [
+        "__p-6.1"
+      ],
       "args": [
         {
           "$OBJECT": "path",
@@ -110,11 +145,54 @@
           ]
         }
       ],
-      "src": "a append item:1",
+      "next": "6"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-6.1"
+          ]
+        }
+      ],
+      "src": "a.append(item:1)",
+      "next": "7.1"
+    },
+    "7.1": {
+      "method": "mutation",
+      "ln": "7.1",
+      "name": [
+        "__p-7.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "append",
+          "args": [
+            {
+              "$OBJECT": "arg",
+              "name": "item",
+              "arg": {
+                "$OBJECT": "int",
+                "int": 1
+              }
+            }
+          ]
+        }
+      ],
       "next": "7"
     },
     "7": {
-      "method": "mutation",
+      "method": "expression",
       "ln": "7",
       "name": [
         "mutation"
@@ -123,26 +201,12 @@
         {
           "$OBJECT": "path",
           "paths": [
-            "a"
-          ]
-        },
-        {
-          "$OBJECT": "mutation",
-          "mutation": "append",
-          "args": [
-            {
-              "$OBJECT": "arg",
-              "name": "item",
-              "arg": {
-                "$OBJECT": "int",
-                "int": 1
-              }
-            }
+            "__p-7.1"
           ]
         }
       ],
-      "src": "mutation = a append item:1"
+      "src": "mutation = a.append(item:1)"
     }
   },
-  "entrypoint": "2"
+  "entrypoint": "2.1"
 }

--- a/tests/e2e/assignments_mutation.story
+++ b/tests/e2e/assignments_mutation.story
@@ -1,7 +1,7 @@
 # with value
-[0] append item:1
-mutation = [0] append item:1
+[0].append(item:1)
+mutation = [0].append(item:1)
 # with var
 a = [0]
-a append item:1
-mutation = a append item:1
+a.append(item:1)
+mutation = a.append(item:1)

--- a/tests/e2e/collection_with_mutation.json
+++ b/tests/e2e/collection_with_mutation.json
@@ -1,15 +1,32 @@
 {
   "tree": {
-    "1.1": {
-      "method": "mutation",
-      "ln": "1.1",
+    "1": {
+      "method": "expression",
+      "ln": "1",
       "name": [
-        "__p-1.1"
+        "y"
       ],
       "args": [
         {
           "$OBJECT": "int",
           "int": 2
+        }
+      ],
+      "src": "y = 2",
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "mutation",
+      "ln": "2.1",
+      "name": [
+        "__p-2.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "y"
+          ]
         },
         {
           "$OBJECT": "mutation",
@@ -17,11 +34,11 @@
           "args": []
         }
       ],
-      "next": "1"
+      "next": "2"
     },
-    "1": {
+    "2": {
       "method": "expression",
-      "ln": "1",
+      "ln": "2",
       "name": [
         "a"
       ],
@@ -36,7 +53,7 @@
             {
               "$OBJECT": "path",
               "paths": [
-                "__p-1.1"
+                "__p-2.1"
               ]
             },
             {
@@ -46,8 +63,8 @@
           ]
         }
       ],
-      "src": "a = [1, 2 increment, 3]"
+      "src": "a = [1, y.increment(), 3]"
     }
   },
-  "entrypoint": "1.1"
+  "entrypoint": "1"
 }

--- a/tests/e2e/collection_with_mutation.story
+++ b/tests/e2e/collection_with_mutation.story
@@ -1,1 +1,2 @@
-a = [1, 2 increment, 3]
+y = 2
+a = [1, y.increment(), 3]

--- a/tests/e2e/entity_minus3.error
+++ b/tests/e2e/entity_minus3.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1, column 4
+Error: syntax error in story at line 1, column 2
 
 1|    0a = 0
-         ^
+       ^
 
-E0041: `=` is not allowed here
+E0007: Missing value after `=`

--- a/tests/e2e/explicit_cast5.json
+++ b/tests/e2e/explicit_cast5.json
@@ -1,10 +1,10 @@
 {
   "tree": {
-    "1": {
+    "1.1": {
       "method": "mutation",
-      "ln": "1",
+      "ln": "1.1",
       "name": [
-        "arr"
+        "__p-1.1"
       ],
       "args": [
         {
@@ -26,7 +26,23 @@
           ]
         }
       ],
-      "src": "arr = [] append item: 42",
+      "next": "1"
+    },
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "arr"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-1.1"
+          ]
+        }
+      ],
+      "src": "arr = [].append(item: 42)",
       "next": "2"
     },
     "2": {
@@ -80,5 +96,5 @@
       "src": "c = b as List[int]"
     }
   },
-  "entrypoint": "1"
+  "entrypoint": "1.1"
 }

--- a/tests/e2e/explicit_cast5.story
+++ b/tests/e2e/explicit_cast5.story
@@ -1,3 +1,3 @@
-arr = [] append item: 42
+arr = [].append(item: 42)
 b = arr[0]
 c = b as List[int]

--- a/tests/e2e/explicit_cast6.json
+++ b/tests/e2e/explicit_cast6.json
@@ -1,10 +1,10 @@
 {
   "tree": {
-    "1": {
+    "1.1": {
       "method": "mutation",
-      "ln": "1",
+      "ln": "1.1",
       "name": [
-        "arr"
+        "__p-1.1"
       ],
       "args": [
         {
@@ -26,7 +26,23 @@
           ]
         }
       ],
-      "src": "arr = [] append item: 42",
+      "next": "1"
+    },
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "arr"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-1.1"
+          ]
+        }
+      ],
+      "src": "arr = [].append(item: 42)",
       "next": "2"
     },
     "2": {
@@ -84,5 +100,5 @@
       "src": "c = b as Map[int, string]"
     }
   },
-  "entrypoint": "1"
+  "entrypoint": "1.1"
 }

--- a/tests/e2e/explicit_cast6.story
+++ b/tests/e2e/explicit_cast6.story
@@ -1,3 +1,3 @@
-arr = [] append item: 42
+arr = [].append(item: 42)
 b = arr[0]
 c = b as Map[int, string]

--- a/tests/e2e/expression_mutation_nested.error
+++ b/tests/e2e/expression_mutation_nested.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 1, column 5
 
-1|    b = 1 and (["opened", "labeled"] contains item: "a")
+1|    b = 1 and (["opened", "labeled"].contains(item: "a"))
           ^
 
 E0122: `int` can't be converted to `boolean`

--- a/tests/e2e/expression_mutation_nested.story
+++ b/tests/e2e/expression_mutation_nested.story
@@ -1,1 +1,1 @@
-b = 1 and (["opened", "labeled"] contains item: "a")
+b = 1 and (["opened", "labeled"].contains(item: "a"))

--- a/tests/e2e/expression_mutation_nesteda.json
+++ b/tests/e2e/expression_mutation_nesteda.json
@@ -61,7 +61,7 @@
           ]
         }
       ],
-      "src": "b = true and ([\"opened\", \"labeled\"] contains item: \"a\")"
+      "src": "b = true and ([\"opened\", \"labeled\"].contains(item: \"a\"))"
     }
   },
   "entrypoint": "1.1"

--- a/tests/e2e/expression_mutation_nesteda.story
+++ b/tests/e2e/expression_mutation_nesteda.story
@@ -1,1 +1,1 @@
-b = true and (["opened", "labeled"] contains item: "a")
+b = true and (["opened", "labeled"].contains(item: "a"))

--- a/tests/e2e/expression_mutation_while.json
+++ b/tests/e2e/expression_mutation_while.json
@@ -53,7 +53,7 @@
         }
       ],
       "enter": "2",
-      "src": "while [1, 2, 3] contains item:1",
+      "src": "while [1, 2, 3].contains(item:1)",
       "next": "2"
     },
     "2": {

--- a/tests/e2e/expression_mutation_while.story
+++ b/tests/e2e/expression_mutation_while.story
@@ -1,2 +1,2 @@
-while [1, 2, 3] contains item:1
+while [1, 2, 3].contains(item:1)
 	return

--- a/tests/e2e/multi_line_heredoc_invalid_double.error
+++ b/tests/e2e/multi_line_heredoc_invalid_double.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1, column 17
+Error: syntax error in story at line 1, column 14
 
 1|    a = """aaa"""bbb"""
-                      ^
+                   ^
 
 E0007: Missing value after `=`

--- a/tests/e2e/mutation_chain.json
+++ b/tests/e2e/mutation_chain.json
@@ -1,0 +1,93 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "foo bar"
+        }
+      ],
+      "src": "a = \"foo bar\"",
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "mutation",
+      "ln": "2.1",
+      "name": [
+        "__p-2.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "split",
+          "args": [
+            {
+              "$OBJECT": "arg",
+              "name": "by",
+              "arg": {
+                "$OBJECT": "string",
+                "string": " "
+              }
+            }
+          ]
+        }
+      ],
+      "next": "2.2"
+    },
+    "2.2": {
+      "method": "mutation",
+      "ln": "2.2",
+      "name": [
+        "__p-2.2"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "contains",
+          "args": [
+            {
+              "$OBJECT": "arg",
+              "name": "item",
+              "arg": {
+                "$OBJECT": "string",
+                "string": "foo"
+              }
+            }
+          ]
+        }
+      ],
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.2"
+          ]
+        }
+      ],
+      "src": "a.split(by: \" \").contains(item: \"foo\")"
+    }
+  },
+  "entrypoint": "1"
+}

--- a/tests/e2e/mutation_chain.story
+++ b/tests/e2e/mutation_chain.story
@@ -1,0 +1,2 @@
+a = "foo bar"
+a.split(by: " ").contains(item: "foo")

--- a/tests/e2e/mutation_expr.json
+++ b/tests/e2e/mutation_expr.json
@@ -1,10 +1,10 @@
 {
   "tree": {
-    "1": {
+    "1.1": {
       "method": "mutation",
-      "ln": "1",
+      "ln": "1.1",
       "name": [
-        "a"
+        "__p-1.1"
       ],
       "args": [
         {
@@ -36,8 +36,24 @@
           ]
         }
       ],
-      "src": "a = (\"a\" + \"b\") contains item: \"c\""
+      "next": "1"
+    },
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-1.1"
+          ]
+        }
+      ],
+      "src": "a = (\"a\" + \"b\").contains(item: \"c\")"
     }
   },
-  "entrypoint": "1"
+  "entrypoint": "1.1"
 }

--- a/tests/e2e/mutation_expr.story
+++ b/tests/e2e/mutation_expr.story
@@ -1,1 +1,1 @@
-a = ("a" + "b") contains item: "c"
+a = ("a" + "b").contains(item: "c")

--- a/tests/e2e/mutation_expr2.json
+++ b/tests/e2e/mutation_expr2.json
@@ -59,7 +59,7 @@
           ]
         }
       ],
-      "src": "a = \"a\" + (\"b\" contains item: \"c\")"
+      "src": "a = \"a\" + (\"b\".contains(item: \"c\"))"
     }
   },
   "entrypoint": "1.1"

--- a/tests/e2e/mutation_expr2.story
+++ b/tests/e2e/mutation_expr2.story
@@ -1,1 +1,1 @@
-a = "a" + ("b" contains item: "c")
+a = "a" + ("b".contains(item: "c"))

--- a/tests/e2e/mutation_expression_list.json
+++ b/tests/e2e/mutation_expression_list.json
@@ -1,8 +1,11 @@
 {
   "tree": {
-    "1": {
+    "1.1": {
       "method": "mutation",
-      "ln": "1",
+      "ln": "1.1",
+      "name": [
+        "__p-1.1"
+      ],
       "args": [
         {
           "$OBJECT": "list",
@@ -32,8 +35,21 @@
           ]
         }
       ],
-      "src": "[\"opened\", \"labeled\"] contains item: \"opened\""
+      "next": "1"
+    },
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-1.1"
+          ]
+        }
+      ],
+      "src": "[\"opened\", \"labeled\"].contains(item: \"opened\")"
     }
   },
-  "entrypoint": "1"
+  "entrypoint": "1.1"
 }

--- a/tests/e2e/mutation_expression_list.story
+++ b/tests/e2e/mutation_expression_list.story
@@ -1,1 +1,1 @@
-["opened", "labeled"] contains item: "opened"
+["opened", "labeled"].contains(item: "opened")

--- a/tests/e2e/mutation_expression_object.json
+++ b/tests/e2e/mutation_expression_object.json
@@ -1,8 +1,11 @@
 {
   "tree": {
-    "1": {
+    "1.1": {
       "method": "mutation",
-      "ln": "1",
+      "ln": "1.1",
+      "name": [
+        "__p-1.1"
+      ],
       "args": [
         {
           "$OBJECT": "dict",
@@ -44,8 +47,21 @@
           ]
         }
       ],
-      "src": "{\"opened\":1, \"labeled\":1} contains key: \"opened\""
+      "next": "1"
+    },
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-1.1"
+          ]
+        }
+      ],
+      "src": "{\"opened\":1, \"labeled\":1}.contains(key: \"opened\")"
     }
   },
-  "entrypoint": "1"
+  "entrypoint": "1.1"
 }

--- a/tests/e2e/mutation_expression_object.story
+++ b/tests/e2e/mutation_expression_object.story
@@ -1,1 +1,1 @@
-{"opened":1, "labeled":1} contains key: "opened"
+{"opened":1, "labeled":1}.contains(key: "opened")

--- a/tests/e2e/mutation_value.json
+++ b/tests/e2e/mutation_value.json
@@ -1,12 +1,32 @@
 {
   "tree": {
     "1": {
-      "method": "mutation",
+      "method": "expression",
       "ln": "1",
+      "name": [
+        "s"
+      ],
       "args": [
         {
           "$OBJECT": "string",
           "string": "hello"
+        }
+      ],
+      "src": "s = \"hello\"",
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "mutation",
+      "ln": "2.1",
+      "name": [
+        "__p-2.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "s"
+          ]
         },
         {
           "$OBJECT": "mutation",
@@ -14,7 +34,20 @@
           "args": []
         }
       ],
-      "src": "\"hello\" length"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "s.length()"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/mutation_value.story
+++ b/tests/e2e/mutation_value.story
@@ -1,1 +1,2 @@
-"hello" length
+s = "hello"
+s.length()

--- a/tests/e2e/obj_with_mutation.json
+++ b/tests/e2e/obj_with_mutation.json
@@ -1,15 +1,32 @@
 {
   "tree": {
-    "1.1": {
-      "method": "mutation",
-      "ln": "1.1",
+    "1": {
+      "method": "expression",
+      "ln": "1",
       "name": [
-        "__p-1.1"
+        "num"
       ],
       "args": [
         {
           "$OBJECT": "int",
           "int": 1
+        }
+      ],
+      "src": "num = 1",
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "mutation",
+      "ln": "2.1",
+      "name": [
+        "__p-2.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "num"
+          ]
         },
         {
           "$OBJECT": "mutation",
@@ -17,11 +34,11 @@
           "args": []
         }
       ],
-      "next": "1"
+      "next": "2"
     },
-    "1": {
+    "2": {
       "method": "expression",
-      "ln": "1",
+      "ln": "2",
       "name": [
         "a"
       ],
@@ -37,15 +54,15 @@
               {
                 "$OBJECT": "path",
                 "paths": [
-                  "__p-1.1"
+                  "__p-2.1"
                 ]
               }
             ]
           ]
         }
       ],
-      "src": "a = {\"my_key\": 1 increment}"
+      "src": "a = {\"my_key\": num.increment()}"
     }
   },
-  "entrypoint": "1.1"
+  "entrypoint": "1"
 }

--- a/tests/e2e/obj_with_mutation.story
+++ b/tests/e2e/obj_with_mutation.story
@@ -1,1 +1,2 @@
-a = {"my_key": 1 increment}
+num = 1
+a = {"my_key": num.increment()}

--- a/tests/e2e/semantics/mutation/arg_required.error
+++ b/tests/e2e/semantics/mutation/arg_required.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1, column 12
+Error: syntax error in story at line 1, column 21
 
-1|    a = [1, 2] contains
-                 ^^^^^^^^
+1|    a = [1, 2].contains()
+                          ^
 
-E0113: Mutation `contains` requires argument `item`
+E0041: `)` is not allowed here

--- a/tests/e2e/semantics/mutation/arg_required.story
+++ b/tests/e2e/semantics/mutation/arg_required.story
@@ -1,2 +1,2 @@
-a = [1, 2] contains
+a = [1, 2].contains()
 a = "foo"

--- a/tests/e2e/semantics/mutation/invalid_arg.error
+++ b/tests/e2e/semantics/mutation/invalid_arg.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1, column 12
+Error: syntax error in story at line 1, column 28
 
-1|    a = [1, 2] contains item:1 bar:2
-                 ^^^^^^^^^^^^^^^^^^^
+1|    a = [1, 2].contains(item:1 bar:2)
+                                 ^
 
-E0114: Mutation `contains` does not accept argument `bar`
+E0075: Expected closing parenthesis: )

--- a/tests/e2e/semantics/mutation/invalid_arg.story
+++ b/tests/e2e/semantics/mutation/invalid_arg.story
@@ -1,2 +1,2 @@
-a = [1, 2] contains item:1 bar:2
+a = [1, 2].contains(item:1 bar:2)
 a = "foo"

--- a/tests/e2e/semantics/mutation/invalid_arg_type.story
+++ b/tests/e2e/semantics/mutation/invalid_arg_type.story
@@ -1,2 +1,2 @@
-a = [1, 2] contains item:1
+a = [1, 2].contains(item:1)
 a = "foo"

--- a/tests/e2e/semantics/mutation/invalid_name.error
+++ b/tests/e2e/semantics/mutation/invalid_name.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1, column 5
+Error: syntax error in story at line 1, column 34
 
-1|    a = [1, 2] invalid_mutation_name
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1|    a = [1, 2].invalid_mutation_name()
+                                       ^
 
-E0117: Invalid mutation `invalid_mutation_name`
+E0041: `)` is not allowed here

--- a/tests/e2e/semantics/mutation/invalid_name.story
+++ b/tests/e2e/semantics/mutation/invalid_name.story
@@ -1,2 +1,2 @@
-a = [1, 2] invalid_mutation_name
+a = [1, 2].invalid_mutation_name()
 a = "foo"

--- a/tests/e2e/semantics/mutation/string_split_by.json
+++ b/tests/e2e/semantics/mutation/string_split_by.json
@@ -1,10 +1,10 @@
 {
   "tree": {
-    "1": {
+    "1.1": {
       "method": "mutation",
-      "ln": "1",
+      "ln": "1.1",
       "name": [
-        "a"
+        "__p-1.1"
       ],
       "args": [
         {
@@ -26,8 +26,24 @@
           ]
         }
       ],
-      "src": "a = \"aa\" split by:\".\""
+      "next": "1"
+    },
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-1.1"
+          ]
+        }
+      ],
+      "src": "a = \"aa\".split(by:\".\")"
     }
   },
-  "entrypoint": "1"
+  "entrypoint": "1.1"
 }

--- a/tests/e2e/semantics/mutation/string_split_by.story
+++ b/tests/e2e/semantics/mutation/string_split_by.story
@@ -1,1 +1,1 @@
-a = "aa" split by:"."
+a = "aa".split(by:".")

--- a/tests/e2e/semantics/mutation/unnamed_arg.error
+++ b/tests/e2e/semantics/mutation/unnamed_arg.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 1, column 9
 
-1|    b = [0] contains :1
+1|    b = [0].contains(:1)
               ^^^^^^^^^^^
 
 E0118: Mutation `contains` requires arguments to be named

--- a/tests/e2e/semantics/mutation/unnamed_arg.story
+++ b/tests/e2e/semantics/mutation/unnamed_arg.story
@@ -1,1 +1,1 @@
-b = [0] contains :1
+b = [0].contains(:1)

--- a/tests/e2e/semantics/mutation_block.error
+++ b/tests/e2e/semantics/mutation_block.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 1, column 10
 
-1|    {"a": 1} get key: "b"
+1|    {"a": 1}.get(key: "b")
                ^^^^^^^
 
 E0113: Mutation `get` requires argument `default`

--- a/tests/e2e/semantics/mutation_block.story
+++ b/tests/e2e/semantics/mutation_block.story
@@ -1,1 +1,1 @@
-{"a": 1} get key: "b"
+{"a": 1}.get(key: "b")

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -4,31 +4,6 @@ from pytest import mark
 from storyscript.Api import Api
 
 
-@mark.parametrize('source', [
-    'a = "foo bar"\na.split(by: " ").contains(item: "foo")'
-])
-def test_compiler_mutation_chained(source):
-    """
-    Ensures that chained mutations are compiled correctly
-    """
-    result = Api.loads(source).result()
-    args1 = [{'$OBJECT': 'string', 'string': 'foo bar'}]
-    args2_1 = [{'$OBJECT': 'path', 'paths': ['a']},
-               {'$OBJECT': 'mutation', 'mutation': 'split', 'args': [
-                   {'$OBJECT': 'arg', 'name': 'by',
-                    'arg': {'$OBJECT': 'string', 'string': ' '}}]}]
-    args2_2 = [{'$OBJECT': 'path', 'paths': ['__p-2.1']},
-               {'$OBJECT': 'mutation', 'mutation': 'contains', 'args': [
-                   {'$OBJECT': 'arg', 'name': 'item',
-                    'arg': {'$OBJECT': 'string', 'string': 'foo'}}]}]
-    args2 = [{'$OBJECT': 'path', 'paths': ['__p-2.2']}]
-
-    assert result['tree']['1']['args'] == args1
-    assert result['tree']['2.1']['args'] == args2_1
-    assert result['tree']['2.2']['args'] == args2_2
-    assert result['tree']['2']['args'] == args2
-
-
 def test_compiler_empty_files():
     result = Api.loads('\n\n').result()
     assert result['tree'] == {}

--- a/tests/integration/compiler/Compiler.py
+++ b/tests/integration/compiler/Compiler.py
@@ -5,20 +5,28 @@ from storyscript.Api import Api
 
 
 @mark.parametrize('source', [
-    '1 increment then format to:"string"',
-    '1 increment\n\tthen format to:"string"'
+    'a = "foo bar"\na.split(by: " ").contains(item: "foo")'
 ])
 def test_compiler_mutation_chained(source):
     """
     Ensures that chained mutations are compiled correctly
     """
     result = Api.loads(source).result()
-    args = [{'$OBJECT': 'int', 'int': 1},
-            {'$OBJECT': 'mutation', 'mutation': 'increment', 'args': []},
-            {'$OBJECT': 'mutation', 'mutation': 'format', 'args': [
-                {'$OBJECT': 'arg', 'name': 'to',
-                 'arg': {'$OBJECT': 'string', 'string': 'string'}}]}]
-    assert result['tree']['1']['args'] == args
+    args1 = [{'$OBJECT': 'string', 'string': 'foo bar'}]
+    args2_1 = [{'$OBJECT': 'path', 'paths': ['a']},
+               {'$OBJECT': 'mutation', 'mutation': 'split', 'args': [
+                   {'$OBJECT': 'arg', 'name': 'by',
+                    'arg': {'$OBJECT': 'string', 'string': ' '}}]}]
+    args2_2 = [{'$OBJECT': 'path', 'paths': ['__p-2.1']},
+               {'$OBJECT': 'mutation', 'mutation': 'contains', 'args': [
+                   {'$OBJECT': 'arg', 'name': 'item',
+                    'arg': {'$OBJECT': 'string', 'string': 'foo'}}]}]
+    args2 = [{'$OBJECT': 'path', 'paths': ['__p-2.2']}]
+
+    assert result['tree']['1']['args'] == args1
+    assert result['tree']['2.1']['args'] == args2_1
+    assert result['tree']['2.2']['args'] == args2_2
+    assert result['tree']['2']['args'] == args2
 
 
 def test_compiler_empty_files():

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -11,7 +11,7 @@ string: SINGLE_QUOTED| DOUBLE_QUOTED| DOUBLE_QUOTED_HEREDOC
 key_value: (string| path| number| boolean) _COLON base_expression
 map: _OCB (_NL _INDENT)? (key_value (_COMMA _NL? key_value)*)? (_NL _DEDENT)? _CCB
 regular_expression: REGEXP
-inline_expression: _OP inline_service _CP| call_expression| _OP mutation _CP
+inline_expression: _OP inline_service _CP| call_expression
 values: number| string| boolean| void| list| map| regular_expression| time
 range_start: (number | path) _COLON
 range_start_end: (number | path) _COLON (number | path)
@@ -43,24 +43,19 @@ or_operator: OR
 or_expression: (or_expression or_operator)? and_expression
 expression: or_expression
 absolute_expression: expression
-base_expression: (expression| inline_service| mutation)
+base_expression: (expression| inline_service)
 return_statement: RETURN base_expression?
 break_statement: BREAK
 entity: values| path
 rules: absolute_expression| assignment| return_statement| throw_statement| break_statement| block
-mutation_fragment: NAME arguments*
-chained_mutation: _THEN mutation_fragment
-mutation: primary_expression (mutation_fragment (chained_mutation)*)
-mutation_block: mutation _NL (nested_block)?
-indented_chain: _INDENT (chained_mutation _NL)+ _DEDENT
 command: NAME
 arguments: NAME? _COLON expression
 output: (_AS NAME (_COMMA NAME)*)
 service_fragment: (command arguments*|arguments+) output?
 inline_service_fragment: (command arguments*|arguments+)
-service: path service_fragment chained_mutation*
+service: path service_fragment
 service_block: service _NL (nested_block)?
-inline_service: path inline_service_fragment chained_mutation*
+inline_service: path inline_service_fragment
 call_expression: path _OP arguments* (_NL _INDENT (arguments _NL?)* _DEDENT)? _CP
 if_statement: _IF base_expression
 elseif_statement: _ELSE _IF base_expression
@@ -87,7 +82,7 @@ throw_statement: THROW entity?
 when_service: NAME path (service_fragment | output?)
 when_block: _WHEN (when_service | NAME output?) _NL nested_block
 indented_arguments: _INDENT (arguments _NL)+ _DEDENT
-block: rules _NL| if_block| foreach_block| function_block| arguments| indented_chain| chained_mutation| mutation_block| service_block| when_block| try_block| indented_arguments| while_block
+block: rules _NL| if_block| foreach_block| function_block| arguments| service_block| when_block| try_block| indented_arguments| while_block
 nested_block: _INDENT block+ _DEDENT
 start: _NL? block*
 
@@ -146,7 +141,6 @@ PLUS.5: "+"
 DASH.5: "-"
 RETURN: "return"
 BREAK: "break"
-_THEN: "then"
 _IF: "if"
 _ELSE: "else"
 _FOREACH: "foreach"


### PR DESCRIPTION
**- What I did**

We modify grammar to stop accepting mutation syntax which used
whitespaces and `then` keyword.

Example:
		"a b c" split by: " " then contains item: "a"

**- How I did it**
Essentially with this commit, we remove grammar's own capability to
parse mutations and leave the job to the lowering phase to
appropriately modify the AST to represent mutations from the new
syntax.

**- How to verify it**
Example:
		s = "a b c"
		s.split(by: " ").contains(item: "a")

Closes: #965.