### PR TITLE
chore(Parser): make allow_single_quotes optional

### DIFF
--- a/storyscript/parser/Parser.py
+++ b/storyscript/parser/Parser.py
@@ -45,7 +45,7 @@ class Parser:
         """
         return Lark(self.grammar(), parser=self.algo, postlex=self.indenter())
 
-    def parse(self, source, allow_single_quotes):
+    def parse(self, source, allow_single_quotes=False):
         """
         Parses the source string.
         """


### PR DESCRIPTION
`Parser.parse` is used by external APIs which shouldn't need to worry about this flag.