### PR TITLE
Add approxEqual variants

### DIFF
--- a/storyscript/compiler/semantics/functions/HubMutations.py
+++ b/storyscript/compiler/semantics/functions/HubMutations.py
@@ -65,6 +65,8 @@ float abs -> float
 float isNaN -> boolean
 float isInfinity -> boolean
 float approxEqual value: float -> boolean
+float approxEqual value: float maxRelDiff: float -> boolean
+float approxEqual value: float maxAbsDiff: float -> boolean
 float approxEqual value: float maxRelDiff: float maxAbsDiff: float -> boolean
 float sqrt -> float
 """


### PR DESCRIPTION
`maxRelDiff` and `maxAbsDiff` are now independently optional.