### PR TITLE
chore(CI): don't remove tests directory on the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,6 @@ jobs:
                   name: create packages
                   command: |
                     rm -rf dist
-                    rm -rf tests # not needed in the released package
                     . venv/bin/activate
                     python setup.py sdist
                     pip install wheel


### PR DESCRIPTION
This is no longer needed as we do a proper `exclude` in `setup.py` now.

https://github.com/storyscript/storyscript/issues/1035