### PR TITLE
feat(semantics): emit type casts after doing arg type checks

### DIFF
--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from storyscript.compiler.lowering.utils import service_to_mutation
-from storyscript.compiler.semantics.types.Types import AnyType, BooleanType, \
-    FloatType, IntType, ListType, MapType, ObjectType, RegExpType, \
-    StringType, TimeType, explicit_cast
+from storyscript.compiler.semantics.types.Types import AnyType, BaseType, \
+    BooleanType, FloatType, IntType, ListType, MapType, ObjectType, \
+    RegExpType, StringType, TimeType, explicit_cast
 from storyscript.compiler.visitors.ExpressionVisitor import ExpressionVisitor
 from storyscript.exceptions import CompilerError
 from storyscript.parser import Tree
@@ -105,75 +105,77 @@ class SymbolExpressionVisitor(ExpressionVisitor):
         return Tree('base_type', [base_type])
 
     def nary_expression(self, tree, op, values):
-        values = [v.type() for v in values]
+        types = [v.type() for v in values]
         if self.op_returns_boolean(op.type):
-            assert len(values) <= 2
+            assert len(types) <= 2
             # e.g. a < b
             if self.is_cmp(op.type):
-                val = values[0].cmp(values[1])
-                tree.expect(val, 'type_operation_cmp_incompatible',
-                            left=values[0], right=values[1])
-                self.implicit_cast(tree, val, values)
+                target_type = types[0].cmp(types[1])
+                tree.expect(target_type, 'type_operation_cmp_incompatible',
+                            left=types[0], right=types[1])
+                self.nary_args_implicit_cast(tree, target_type, types)
                 return base_symbol(BooleanType.instance())
 
             # e.g. a == b
             if self.is_equal(op.type):
-                val = values[0].equal(values[1])
-                tree.expect(val,
+                target_type = types[0].equal(types[1])
+                tree.expect(target_type,
                             'type_operation_equal_incompatible',
-                            left=values[0], right=values[1])
-                self.implicit_cast(tree, val, values)
+                            left=types[0], right=types[1])
+                self.nary_args_implicit_cast(tree, target_type, types)
                 return base_symbol(BooleanType.instance())
 
             # e.g. a and b, a or b, !a
-            tree.expect(values[0].has_boolean(),
+            tree.expect(types[0].has_boolean(),
                         'type_operation_boolean_incompatible',
-                        val=values[0])
-            if len(values) == 2:
-                tree.expect(values[1].has_boolean(),
+                        val=types[0])
+            if len(types) == 2:
+                tree.expect(types[1].has_boolean(),
                             'type_operation_boolean_incompatible',
-                            val=values[1])
+                            val=types[1])
             return base_symbol(BooleanType.instance())
 
         is_arithmetic = self.is_arithmetic_operator(op.type)
         tree.expect(is_arithmetic, 'compiler_error_no_operator',
                     operator=op.type)
-        val = values[0]
-        for v in values[1:]:
-            new_val = val.binary_op(v, op)
-            tree.expect(new_val is not None, 'type_operation_incompatible',
-                        left=val, right=v, op=op.value)
-            val = new_val
+        target_type = types[0]
+        for t in types[1:]:
+            new_target_type = target_type.binary_op(t, op)
+            tree.expect(new_target_type is not None,
+                        'type_operation_incompatible',
+                        left=target_type, right=t, op=op.value)
+            target_type = new_target_type
         # add implicit casts
         if tree.kind == 'pow_expression':
-            return base_symbol(val)
+            return base_symbol(target_type)
         if tree.kind == 'mul_expression':
-            self.implicit_cast(tree, val, values)
+            self.nary_args_implicit_cast(tree, target_type, types)
         else:
             assert tree.kind == 'arith_expression'
-            self.implicit_cast(tree, val, values)
-        return base_symbol(val)
+            self.nary_args_implicit_cast(tree, target_type, types)
+        return base_symbol(target_type)
 
     @staticmethod
     def type_cast_expression(expr_node, target_type):
         """
-        Type casts the given expr_node with an entity to the target_type.
+        Type casts the given expr_node to the target_type.
         This is done by creating a new AST for the expr_node with an
         `as_operator`.
 
         Args:
-            expr_node (Tree): Tree node representing an expression. This is the
+            expr_node: Tree node representing an expression. This is the
                 expression for which this function will generate a new
                 expression node which also contains an `as_operator` to
                 represent the type cast.
-            target_type (Union[str, MapType, ListType]): The type to type cast
-                given expression (expr_node) into.
+            target_type: The type to type cast given expression (expr_node)
+                into. Must be a `types` node.
 
         Note: This does not perform any checks around feasibility of performing
         the type cast operation and depends upon the caller to have had
         performed these checks before making the call.
         """
         assert expr_node.data == 'expression'
+        assert isinstance(target_type, BaseType)
         cast_type = SymbolExpressionVisitor.type_to_tree(
             expr_node,
             target_type
@@ -189,24 +191,20 @@ class SymbolExpressionVisitor(ExpressionVisitor):
         element.kind = 'as_expression'
         return element
 
-    def implicit_cast(self, tree, val, values):
+    def nary_args_implicit_cast(self, tree, target_type, source_types):
         """
-        Creates an AST with the cast.
-        This boils down to
-        - finding the right level to insert the new pow_expression with
-          its respective as_operator
-        - building a correct tree cascade in pow_expression to the old value
+        Cast nary_expression arguments implicitly.
         """
-        if val == AnyType.instance():
+        if target_type == AnyType.instance():
             return
-        for i, v in enumerate(values):
+        for i, t in enumerate(source_types):
             if i > 0:
                 # ignore the arith_operator tree child
                 i += 1
             # check whether a tree child needs casting
-            if v != val:
+            if t != target_type:
                 tree.children[i] = self.type_cast_expression(
-                    tree.children[i], val)
+                    tree.children[i], target_type)
 
 
 class ExpressionResolver:

--- a/tests/e2e/function_call_implicit_cast.json
+++ b/tests/e2e/function_call_implicit_cast.json
@@ -1,0 +1,148 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "9",
+      "output": [
+        "float"
+      ],
+      "function": "boomrang",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "k1",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "Map",
+            "values": [
+              {
+                "$OBJECT": "type",
+                "type": "string"
+              },
+              {
+                "$OBJECT": "type",
+                "type": "float"
+              }
+            ]
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "k2",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "float"
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4.1",
+      "src": "function boomrang k1: Map[string, float] k2: float returns float",
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "col_start": "3",
+      "col_end": "12",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "k1",
+            {
+              "$OBJECT": "string",
+              "string": "foo"
+            }
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "  return k1[\"foo\"]",
+      "next": "4.1"
+    },
+    "4.1": {
+      "method": "call",
+      "ln": "4.1",
+      "col_start": "1",
+      "col_end": "27",
+      "name": [
+        "__p-4.1"
+      ],
+      "function": "boomrang",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "k1",
+          "arg": {
+            "$OBJECT": "type_cast",
+            "type": {
+              "$OBJECT": "type",
+              "type": "Map",
+              "values": [
+                {
+                  "$OBJECT": "type",
+                  "type": "string"
+                },
+                {
+                  "$OBJECT": "type",
+                  "type": "float"
+                }
+              ]
+            },
+            "value": {
+              "$OBJECT": "dict",
+              "items": [
+                [
+                  {
+                    "$OBJECT": "string",
+                    "string": "foo"
+                  },
+                  {
+                    "$OBJECT": "int",
+                    "int": 2
+                  }
+                ]
+              ]
+            }
+          }
+        },
+        {
+          "$OBJECT": "arg",
+          "name": "k2",
+          "arg": {
+            "$OBJECT": "type_cast",
+            "type": {
+              "$OBJECT": "type",
+              "type": "float"
+            },
+            "value": {
+              "$OBJECT": "int",
+              "int": 1
+            }
+          }
+        }
+      ],
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-4.1"
+          ]
+        }
+      ],
+      "src": "boomrang(k1: {\"foo\": 2} k2: 1)"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "boomrang": "1"
+  }
+}

--- a/tests/e2e/function_call_implicit_cast.story
+++ b/tests/e2e/function_call_implicit_cast.story
@@ -1,0 +1,4 @@
+function boomrang k1: Map[string, float] k2: float returns float
+  return k1["foo"]
+
+boomrang(k1: {"foo": 2} k2: 1)

--- a/tests/e2e/function_call_with_service_nested.json
+++ b/tests/e2e/function_call_with_service_nested.json
@@ -125,10 +125,17 @@
           "$OBJECT": "arg",
           "name": "k1",
           "arg": {
-            "$OBJECT": "path",
-            "paths": [
-              "__p-7.2"
-            ]
+            "$OBJECT": "type_cast",
+            "type": {
+              "$OBJECT": "type",
+              "type": "int"
+            },
+            "value": {
+              "$OBJECT": "path",
+              "paths": [
+                "__p-7.2"
+              ]
+            }
           }
         },
         {

--- a/tests/e2e/mutation_expression.json
+++ b/tests/e2e/mutation_expression.json
@@ -59,18 +59,25 @@
               "$OBJECT": "arg",
               "name": "item",
               "arg": {
-                "$OBJECT": "path",
-                "paths": [
-                  "req",
-                  {
-                    "$OBJECT": "dot",
-                    "dot": "body"
-                  },
-                  {
-                    "$OBJECT": "string",
-                    "string": "action"
-                  }
-                ]
+                "$OBJECT": "type_cast",
+                "type": {
+                  "$OBJECT": "type",
+                  "type": "string"
+                },
+                "value": {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "req",
+                    {
+                      "$OBJECT": "dot",
+                      "dot": "body"
+                    },
+                    {
+                      "$OBJECT": "string",
+                      "string": "action"
+                    }
+                  ]
+                }
               }
             }
           ]

--- a/tests/e2e/mutation_implicit_cast.json
+++ b/tests/e2e/mutation_implicit_cast.json
@@ -10,18 +10,27 @@
       ],
       "args": [
         {
-          "$OBJECT": "float",
-          "float": 1.1
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "float",
+              "float": 2.3
+            },
+            {
+              "$OBJECT": "float",
+              "float": 5.8
+            }
+          ]
         }
       ],
-      "src": "a = 1.1",
+      "src": "a = [2.3, 5.8]",
       "next": "2.1"
     },
     "2.1": {
       "method": "mutation",
       "ln": "2.1",
-      "col_start": "5",
-      "col_end": "6",
+      "col_start": "1",
+      "col_end": "2",
       "name": [
         "__p-2.1"
       ],
@@ -34,27 +43,11 @@
         },
         {
           "$OBJECT": "mutation",
-          "mutation": "approxEqual",
+          "mutation": "contains",
           "args": [
             {
               "$OBJECT": "arg",
-              "name": "value",
-              "arg": {
-                "$OBJECT": "float",
-                "float": 1.2
-              }
-            },
-            {
-              "$OBJECT": "arg",
-              "name": "maxRelDiff",
-              "arg": {
-                "$OBJECT": "float",
-                "float": 0.1
-              }
-            },
-            {
-              "$OBJECT": "arg",
-              "name": "maxAbsDiff",
+              "name": "item",
               "arg": {
                 "$OBJECT": "type_cast",
                 "type": {
@@ -63,7 +56,7 @@
                 },
                 "value": {
                   "$OBJECT": "int",
-                  "int": 0
+                  "int": 1
                 }
               }
             }
@@ -75,11 +68,6 @@
     "2": {
       "method": "expression",
       "ln": "2",
-      "col_start": "1",
-      "col_end": "4",
-      "name": [
-        "b"
-      ],
       "args": [
         {
           "$OBJECT": "path",
@@ -88,7 +76,7 @@
           ]
         }
       ],
-      "src": "b = a.approxEqual(value: 1.2 maxRelDiff: 0.1 maxAbsDiff: 0)"
+      "src": "a.contains(item: 1)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/mutation_implicit_cast.story
+++ b/tests/e2e/mutation_implicit_cast.story
@@ -1,0 +1,2 @@
+a = [2.3, 5.8]
+a.contains(item: 1)


### PR DESCRIPTION
**- What I did**
In this commit we start emitting type casts for the arguments in
function calls, mutations or services.

**- How I did it**
We were already doing the checks for arg compatibility and had
implicit cast method ready as well. In this commit we just refactor
the implicit_cast method a bit to extract out a type_cast_entity
function which works on single entity and add type casts to its AST
by adding as operator to its tree.

**- How to verify it**
As a result, now calling a function which accpets a float parameter
with an int parameter will specifically emit a type cast
(as operator) in the AST.

Closes: #993.