### PR TITLE
chore(test): fix bom{8,16} tests files for newer testsuite

### DIFF
--- a/tests/e2e/bom16be_service.json
+++ b/tests/e2e/bom16be_service.json
@@ -3,6 +3,8 @@
     "1": {
       "method": "execute",
       "ln": "1",
+      "col_start": "1",
+      "col_end": "12",
       "service": "alpine",
       "command": "echo",
       "args": [

--- a/tests/e2e/bom16le_service.json
+++ b/tests/e2e/bom16le_service.json
@@ -3,6 +3,8 @@
     "1": {
       "method": "execute",
       "ln": "1",
+      "col_start": "1",
+      "col_end": "12",
       "service": "alpine",
       "command": "echo",
       "args": [

--- a/tests/e2e/bom8le_service.json
+++ b/tests/e2e/bom8le_service.json
@@ -3,6 +3,8 @@
     "1": {
       "method": "execute",
       "ln": "1",
+      "col_start": "1",
+      "col_end": "12",
       "service": "alpine",
       "command": "echo",
       "args": [

--- a/tests/e2e/update
+++ b/tests/e2e/update
@@ -10,6 +10,8 @@ import multiprocessing as mp
 from os import path
 import sys
 
+from bom_open import bom_open
+
 from click import unstyle
 
 from storyscript.Api import Api
@@ -40,7 +42,7 @@ class StoryRunner():
         self.updated = False
 
     def run(self):
-        with io.open(self.story_path, 'r') as f:
+        with bom_open(self.story_path, 'r') as f:
             source = f.read()
         s = Api.loads(source, features=parse_features(features, source))
         if s.success():


### PR DESCRIPTION
Required as https://github.com/storyscript/storyscript/pull/1040 used an old JSON output.