### PR TITLE
fix(ExpressionResolver): make type_to_tree() handle `any` type

### DIFF
--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -98,9 +98,11 @@ class SymbolExpressionVisitor(ExpressionVisitor):
             base_type = tree.create_token('STRING_TYPE', 'string')
         elif t == TimeType.instance():
             base_type = tree.create_token('TIME_TYPE', 'time')
-        else:
-            assert t == RegExpType.instance()
+        elif t == RegExpType.instance():
             base_type = tree.create_token('REGEXP_TYPE', 'regex')
+        else:
+            assert t == AnyType.instance()
+            base_type = tree.create_token('ANY_TYPE', 'any')
 
         return Tree('base_type', [base_type])
 

--- a/tests/e2e/function_call_implicit_cast2.json
+++ b/tests/e2e/function_call_implicit_cast2.json
@@ -1,0 +1,149 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "9",
+      "output": [
+        "int"
+      ],
+      "function": "foobar",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "stuff",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "Map",
+            "values": [
+              {
+                "$OBJECT": "type",
+                "type": "string"
+              },
+              {
+                "$OBJECT": "type",
+                "type": "any"
+              }
+            ]
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4.1",
+      "src": "function foobar stuff : Map[string, any] returns int",
+      "next": "2"
+    },
+    "2": {
+      "method": "return",
+      "ln": "2",
+      "col_start": "3",
+      "col_end": "15",
+      "args": [
+        {
+          "$OBJECT": "type_cast",
+          "type": {
+            "$OBJECT": "type",
+            "type": "int"
+          },
+          "value": {
+            "$OBJECT": "path",
+            "paths": [
+              "stuff",
+              {
+                "$OBJECT": "string",
+                "string": "a"
+              }
+            ]
+          }
+        }
+      ],
+      "parent": "1",
+      "src": "  return stuff[\"a\"] as int",
+      "next": "4.1"
+    },
+    "4.1": {
+      "method": "call",
+      "ln": "4.1",
+      "col_start": "1",
+      "col_end": "13",
+      "name": [
+        "__p-4.1"
+      ],
+      "function": "foobar",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "stuff",
+          "arg": {
+            "$OBJECT": "type_cast",
+            "type": {
+              "$OBJECT": "type",
+              "type": "Map",
+              "values": [
+                {
+                  "$OBJECT": "type",
+                  "type": "string"
+                },
+                {
+                  "$OBJECT": "type",
+                  "type": "any"
+                }
+              ]
+            },
+            "value": {
+              "$OBJECT": "type_cast",
+              "type": {
+                "$OBJECT": "type",
+                "type": "any"
+              },
+              "value": {
+                "$OBJECT": "dict",
+                "items": [
+                  [
+                    {
+                      "$OBJECT": "string",
+                      "string": "a"
+                    },
+                    {
+                      "$OBJECT": "int",
+                      "int": 1
+                    }
+                  ],
+                  [
+                    {
+                      "$OBJECT": "string",
+                      "string": "b"
+                    },
+                    {
+                      "$OBJECT": "string",
+                      "string": "a"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-4.1"
+          ]
+        }
+      ],
+      "src": "foobar(stuff: {\"a\":1, \"b\": \"a\"} as any)"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foobar": "1"
+  }
+}

--- a/tests/e2e/function_call_implicit_cast2.story
+++ b/tests/e2e/function_call_implicit_cast2.story
@@ -1,0 +1,4 @@
+function foobar stuff : Map[string, any] returns int
+  return stuff["a"] as int
+
+foobar(stuff: {"a":1, "b": "a"} as any)


### PR DESCRIPTION
**- What I did**

In this commit we fix the issue which arose due to the fact that
type_to_tree() didn't handle `any` type. This results in assertion
errors since give a type Map[string, any] this function can call
itself with type `any` and end up with errors.

**- How I did it**
In general as well, this function should have been able to handle
`any` type which we now add to it.

**- How to verify it**
test case included.

Fixes: #1072.