### PR TITLE
fix(semantics): create a writable scope for foreach/while loops

### DIFF
--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -133,7 +133,7 @@ class TypeResolver(ScopeSelectiveVisitor):
         Create a new scope and add output variables to it
         """
         tree.scope = Scope(parent=scope)
-        with self.create_scope(tree.scope):
+        with self.create_scope(tree.scope, storage_class=StorageClass.write()):
             stmt = tree.foreach_statement
             output_expr = self.resolver.base_expression(stmt.base_expression)
             output_type = output_expr.type()
@@ -159,7 +159,7 @@ class TypeResolver(ScopeSelectiveVisitor):
     def while_block(self, tree, scope):
         self.while_statement(tree.while_statement, scope)
         tree.scope = Scope(parent=scope)
-        with self.create_scope(tree.scope):
+        with self.create_scope(tree.scope, storage_class=StorageClass.write()):
             self.visit_children(tree.nested_block, scope=tree.scope)
 
     def while_statement(self, tree, scope):

--- a/tests/e2e/semantics/readonly_foreach.json
+++ b/tests/e2e/semantics/readonly_foreach.json
@@ -1,0 +1,107 @@
+{
+  "tree": {
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "l"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 2
+            },
+            {
+              "$OBJECT": "int",
+              "int": 3
+            }
+          ]
+        }
+      ],
+      "src": "l = [1, 2, 3]",
+      "next": "3"
+    },
+    "3": {
+      "method": "for",
+      "ln": "3",
+      "col_start": "9",
+      "col_end": "6",
+      "output": [
+        "el"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "l"
+          ]
+        }
+      ],
+      "enter": "4",
+      "src": "foreach l as el",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 2
+            },
+            {
+              "$OBJECT": "int",
+              "int": 3
+            }
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "    a = [1, 2, 3]",
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "col_start": "5",
+      "col_end": "11",
+      "name": [
+        "a",
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "    a[1] = 2"
+    }
+  },
+  "entrypoint": "2"
+}

--- a/tests/e2e/semantics/readonly_foreach.story
+++ b/tests/e2e/semantics/readonly_foreach.story
@@ -1,0 +1,5 @@
+# FEAT: globals=False
+l = [1, 2, 3]
+foreach l as el
+    a = [1, 2, 3]
+    a[1] = 2

--- a/tests/e2e/semantics/readonly_if.error
+++ b/tests/e2e/semantics/readonly_if.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 4, column 5
+
+4|        a[1] = 2
+          ^^^^^^
+
+E0127: `a[]` is readonly and can not be assigned to.

--- a/tests/e2e/semantics/readonly_if.story
+++ b/tests/e2e/semantics/readonly_if.story
@@ -1,0 +1,10 @@
+# FEAT: globals=False
+if true
+    a = [1, 2, 3]
+    a[1] = 2
+else if true
+    b = [1, 2, 3]
+    b[1] = 2
+else
+    c = [1, 2, 3]
+    c[1] = 2

--- a/tests/e2e/semantics/readonly_if2.error
+++ b/tests/e2e/semantics/readonly_if2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 4, column 5
+
+4|        a[1] = 2
+          ^^^^^^
+
+E0127: `a[]` is readonly and can not be assigned to.

--- a/tests/e2e/semantics/readonly_if2.story
+++ b/tests/e2e/semantics/readonly_if2.story
@@ -1,0 +1,4 @@
+# FEAT: globals=False
+if true
+    a = [1, 2, 3]
+    a[1] = 2

--- a/tests/e2e/semantics/readonly_if3.error
+++ b/tests/e2e/semantics/readonly_if3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 6, column 5
+
+6|        b[1] = 2
+          ^^^^^^
+
+E0127: `b[]` is readonly and can not be assigned to.

--- a/tests/e2e/semantics/readonly_if3.story
+++ b/tests/e2e/semantics/readonly_if3.story
@@ -1,0 +1,6 @@
+# FEAT: globals=False
+if true
+    a = 1
+else if true
+    b = [1, 2, 3]
+    b[1] = 2

--- a/tests/e2e/semantics/readonly_if4.error
+++ b/tests/e2e/semantics/readonly_if4.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 8, column 5
+
+8|        c[1] = 2
+          ^^^^^^
+
+E0127: `c[]` is readonly and can not be assigned to.

--- a/tests/e2e/semantics/readonly_if4.story
+++ b/tests/e2e/semantics/readonly_if4.story
@@ -1,0 +1,8 @@
+# FEAT: globals=False
+if true
+    a = 1
+else if true
+    b = 1
+else
+    c = [1, 2, 3]
+    c[1] = 2

--- a/tests/e2e/semantics/readonly_while.json
+++ b/tests/e2e/semantics/readonly_while.json
@@ -1,0 +1,72 @@
+{
+  "tree": {
+    "2": {
+      "method": "while",
+      "ln": "2",
+      "col_start": "7",
+      "col_end": "6",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "3",
+      "src": "while true",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 2
+            },
+            {
+              "$OBJECT": "int",
+              "int": 3
+            }
+          ]
+        }
+      ],
+      "parent": "2",
+      "src": "    a = [1, 2, 3]",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "5",
+      "col_end": "11",
+      "name": [
+        "a",
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "2",
+      "src": "    a[1] = 2"
+    }
+  },
+  "entrypoint": "2"
+}

--- a/tests/e2e/semantics/readonly_while.story
+++ b/tests/e2e/semantics/readonly_while.story
@@ -1,0 +1,4 @@
+# FEAT: globals=False
+while true
+    a = [1, 2, 3]
+    a[1] = 2


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/1076, requires https://github.com/storyscript/storyscript/pull/1053 -> cherry-pick inhttps://github.com/storyscript/storyscript/pull/1081

if statements affect the parent scope if the symbol is defined in all statements, hence not looking at them here.