### PR TITLE
fix(ErrorCodes): change duplicate use of error code to E0133

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -39,8 +39,6 @@ class ErrorCodes:
     unnecessary_colon = (
         'E0045',
         'There is an unnecessary colon at the end of the line')
-    block_expected_after = ('E0045',
-                            'An indented block is required to follow here')
     block_expected_before = ('E0046',
                              'An indented block is required to be before here')
     file_not_found = ('E0047',
@@ -215,7 +213,9 @@ class ErrorCodes:
         'E0132',
         'Tabs are not allowed.'
     )
-    continue_outside = ('E0132', '`continue` is allowed only inside loops')
+    continue_outside = ('E0133', '`continue` is allowed only inside loops')
+    block_expected_after = ('E0134',
+                            'An indented block is required to follow here')
 
     @staticmethod
     def is_error(error_name):

--- a/tests/e2e/continue_outside.error
+++ b/tests/e2e/continue_outside.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 1, column 1
 1|    continue
       ^^^^^^^^
 
-E0132: `continue` is allowed only inside loops
+E0133: `continue` is allowed only inside loops

--- a/tests/integration/Exceptions.py
+++ b/tests/integration/Exceptions.py
@@ -112,7 +112,7 @@ def test_exceptions_block_expected_before(capsys):
     lines = e.value.message().splitlines()
     assert lines[0] == 'Error: syntax error in story at line 1, column 11'
     assert lines[2] == '1|    while true'
-    assert lines[5] == 'E0045: An indented block is required to follow here'
+    assert lines[5] == 'E0134: An indented block is required to follow here'
 
 
 def test_exceptions_block_expected_after(capsys):

--- a/tests/unittests/ErrorCodes.py
+++ b/tests/unittests/ErrorCodes.py
@@ -52,3 +52,12 @@ def test_errorcodes_is_error_string():
 def test_errorcodes_get_error():
     ErrorCodes.mock = 'value'
     assert ErrorCodes.get_error('mock') == 'value'
+
+
+def test_error_codes_unique():
+    attribs = ErrorCodes.__dict__
+    codes = set()
+    for a in attribs:
+        if isinstance(attribs[a], tuple) and isinstance(attribs[a][0], str):
+            assert attribs[a][0] not in codes, attribs[a][0]
+            codes.add(attribs[a][0])


### PR DESCRIPTION
Change duplicate ErrorCode
Before:
```
tabs = (
        'E0132',
        'Tabs are not allowed.'
    )
    continue_outside = ('E0132', '`continue` is allowed only inside loops')
```
After:
```
tabs = (
        'E0132',
        'Tabs are not allowed.'
    )
    continue_outside = ('E0133', '`continue` is allowed only inside loops')
```