### PR TITLE
fix(grammar): allow pokematch catch

### DIFF
--- a/storyscript/compiler/json/Lines.py
+++ b/storyscript/compiler/json/Lines.py
@@ -105,7 +105,8 @@ class Lines:
         """
         Creates the base dictionary for a given line.
         """
-        assert position.line not in self.lines, 'Line numbers must be unique'
+        assert position.line not in self.lines, \
+            f'Line {position.line} is not unique'
         col_start = self._as_none(position.column)
         col_end = self._as_none(position.end_column)
         raw_line = self.story.line(position.line)

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -253,9 +253,9 @@ class Grammar:
 
     def try_block(self):
         self.ebnf.TRY = 'try'
-        self.ebnf._CATCH = 'catch'
+        self.ebnf.CATCH = 'catch'
         self.ebnf.FINALLY = 'finally'
-        self.ebnf.catch_statement = 'catch as name'
+        self.ebnf.catch_statement = 'catch (as name)?'
         self.ebnf.catch_block = self.ebnf.simple_block('catch_statement')
         self.ebnf.finally_statement = 'finally'
         self.ebnf.finally_block = self.ebnf.simple_block('finally_statement')

--- a/tests/e2e/exit_line.json
+++ b/tests/e2e/exit_line.json
@@ -202,7 +202,7 @@
       "method": "try",
       "ln": "15",
       "col_start": "1",
-      "col_end": "11",
+      "col_end": "6",
       "enter": "16",
       "exit": "17",
       "src": "try",
@@ -229,7 +229,7 @@
     "17": {
       "method": "catch",
       "ln": "17",
-      "col_start": "10",
+      "col_start": "1",
       "col_end": "6",
       "output": [
         "e"

--- a/tests/e2e/pokemon_catch.json
+++ b/tests/e2e/pokemon_catch.json
@@ -1,0 +1,93 @@
+{
+  "tree": {
+    "1": {
+      "method": "try",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "8",
+      "enter": "2",
+      "exit": "3",
+      "src": "try",
+      "next": "2"
+    },
+    "2": {
+      "method": "throw",
+      "ln": "2",
+      "col_start": "6",
+      "col_end": "19",
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "error"
+        }
+      ],
+      "parent": "1",
+      "src": "     throw \"error\"",
+      "next": "3"
+    },
+    "3": {
+      "method": "catch",
+      "ln": "3",
+      "col_start": "1",
+      "col_end": "8",
+      "enter": "4",
+      "exit": "5",
+      "src": "catch",
+      "next": "4"
+    },
+    "4": {
+      "method": "execute",
+      "ln": "4",
+      "col_start": "5",
+      "col_end": "13",
+      "service": "log",
+      "command": "info",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "msg",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "Error Happened"
+          }
+        }
+      ],
+      "parent": "3",
+      "src": "    log info msg: \"Error Happened\"",
+      "next": "5"
+    },
+    "5": {
+      "method": "finally",
+      "ln": "5",
+      "col_start": "1",
+      "col_end": "9",
+      "enter": "6",
+      "src": "finally",
+      "next": "6"
+    },
+    "6": {
+      "method": "execute",
+      "ln": "6",
+      "col_start": "6",
+      "col_end": "14",
+      "service": "log",
+      "command": "info",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "msg",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "Finally"
+          }
+        }
+      ],
+      "parent": "5",
+      "src": "     log info msg: \"Finally\""
+    }
+  },
+  "services": [
+    "log"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/pokemon_catch.story
+++ b/tests/e2e/pokemon_catch.story
@@ -1,0 +1,6 @@
+try
+     throw "error"
+catch
+    log info msg: "Error Happened"
+finally
+     log info msg: "Finally"

--- a/tests/e2e/scope_individual_try_catch.error
+++ b/tests/e2e/scope_individual_try_catch.error
@@ -1,6 +1,0 @@
-Error: syntax error in story at line 3, column 6
-
-3|    catch
-           ^
-
-E0053: Unexpected end of line. Expected: ['_AS'].

--- a/tests/e2e/scope_individual_try_catch.json
+++ b/tests/e2e/scope_individual_try_catch.json
@@ -1,0 +1,139 @@
+{
+  "tree": {
+    "1": {
+      "method": "try",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "8",
+      "enter": "2",
+      "exit": "3",
+      "src": "try",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    c = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "catch",
+      "ln": "3",
+      "col_start": "1",
+      "col_end": "6",
+      "enter": "4",
+      "exit": "5",
+      "src": "catch",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "3",
+      "src": "    d = 1",
+      "next": "5"
+    },
+    "5": {
+      "method": "finally",
+      "ln": "5",
+      "col_start": "1",
+      "col_end": "6",
+      "enter": "6",
+      "exit": "7",
+      "src": "finally",
+      "next": "6"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "e"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "5",
+      "src": "    e = 1",
+      "next": "7"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "2"
+        }
+      ],
+      "src": "c = \"2\"",
+      "next": "8"
+    },
+    "8": {
+      "method": "expression",
+      "ln": "8",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "2"
+        }
+      ],
+      "src": "d = \"2\"",
+      "next": "9"
+    },
+    "9": {
+      "method": "expression",
+      "ln": "9",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "e"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "2"
+        }
+      ],
+      "src": "e = \"2\""
+    }
+  },
+  "entrypoint": "1"
+}

--- a/tests/e2e/try_catch.json
+++ b/tests/e2e/try_catch.json
@@ -4,7 +4,7 @@
       "method": "try",
       "ln": "1",
       "col_start": "1",
-      "col_end": "15",
+      "col_end": "6",
       "enter": "2",
       "exit": "3",
       "src": "try",
@@ -31,7 +31,7 @@
     "3": {
       "method": "catch",
       "ln": "3",
-      "col_start": "10",
+      "col_start": "1",
       "col_end": "6",
       "output": [
         "error"

--- a/tests/e2e/try_nested_throw_error.json
+++ b/tests/e2e/try_nested_throw_error.json
@@ -4,7 +4,7 @@
       "method": "try",
       "ln": "1",
       "col_start": "1",
-      "col_end": "15",
+      "col_end": "6",
       "enter": "2",
       "exit": "3",
       "src": "try",
@@ -31,7 +31,7 @@
     "3": {
       "method": "catch",
       "ln": "3",
-      "col_start": "10",
+      "col_start": "1",
       "col_end": "12",
       "output": [
         "error"

--- a/tests/e2e/try_throw.json
+++ b/tests/e2e/try_throw.json
@@ -4,7 +4,7 @@
       "method": "try",
       "ln": "1",
       "col_start": "1",
-      "col_end": "15",
+      "col_end": "6",
       "enter": "2",
       "exit": "3",
       "src": "try",
@@ -31,7 +31,7 @@
     "3": {
       "method": "catch",
       "ln": "3",
-      "col_start": "10",
+      "col_start": "1",
       "col_end": "10",
       "output": [
         "error"

--- a/tests/e2e/try_throw_error.json
+++ b/tests/e2e/try_throw_error.json
@@ -4,7 +4,7 @@
       "method": "try",
       "ln": "1",
       "col_start": "1",
-      "col_end": "15",
+      "col_end": "6",
       "enter": "2",
       "exit": "3",
       "src": "try",
@@ -31,7 +31,7 @@
     "3": {
       "method": "catch",
       "ln": "3",
-      "col_start": "10",
+      "col_start": "1",
       "col_end": "10",
       "output": [
         "error"

--- a/tests/integration/parser/Parser.py
+++ b/tests/integration/parser/Parser.py
@@ -203,7 +203,7 @@ def test_parser_try():
 def test_parser_try_catch():
     result = parse('try\n    x=0\ncatch as error\n    x=1')
     catch_block = result.block.try_block.catch_block
-    assert catch_block.catch_statement.child(0) == Token('NAME', 'error')
+    assert catch_block.catch_statement.child(1) == Token('NAME', 'error')
     path = catch_block.nested_block.block.rules.assignment.path
     assert path.child(0) == Token('NAME', 'x')
 

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -75,7 +75,7 @@ function_output: _RETURNS types
 function_statement: FUNCTION_TYPE NAME typed_argument* function_output?
 indented_typed_arguments: _INDENT (typed_argument+ _NL)+ _DEDENT _DOUBLE_DEDENT
 function_block: function_statement _NL (indented_typed_arguments? block+ _DEDENT | nested_block)
-catch_statement: _CATCH _AS NAME
+catch_statement: CATCH (_AS NAME)?
 catch_block: catch_statement _NL nested_block
 finally_statement: FINALLY
 finally_block: finally_statement _NL nested_block
@@ -158,7 +158,7 @@ _WHILE: "while"
 _RETURNS: "returns"
 _DOUBLE_DEDENT: "<DOUBLE_DEDENT>"
 TRY: "try"
-_CATCH: "catch"
+CATCH: "catch"
 FINALLY: "finally"
 THROW: "throw"
 _WHEN: "when"

--- a/tests/unittests/compiler/json/Compiler.py
+++ b/tests/unittests/compiler/json/Compiler.py
@@ -741,9 +741,13 @@ def test_compiler_catch_block(patch, compiler, lines, tree):
     """
     patch.object(Objects, 'names')
     patch.object(JSONCompiler, 'subtree')
+    tree.catch_statement.children = ['catch', 'output']
     compiler.catch_block(tree, '1')
+
     lines.set_exit.assert_called_with(tree.position().line)
-    Objects.names.assert_called_with(tree.catch_statement)
+    Objects.names.assert_called_with(
+        Tree('catch_statement', tree.catch_statement.children[1:])
+    )
     lines.set_scope.assert_called_with(tree.position().line, '1',
                                        Objects.names())
     lines.finish_scope.assert_called_with(tree.position().line)


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/1096

TODO:
- [x] need to find a better way to fix the line number issue. The problem is that lark only assigns line numbers to token that are in the tree and `catch` is a ignored token.