### PR TITLE
Fix exact version of Hub SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ requirements = [
     'click==7.0',
     'lark-parser==0.7.2',
     'click-alias==0.1.1a2',
-    'story-hub~=0.1.0'
+    'story-hub==0.1.1'
 ]
 
 extras = [


### PR DESCRIPTION
Releasing a new version of Storyscript got very easy, reducing the advantage of being able to release a patch of the Hub SDK.
As the Hub SDK contains the Hub builtins, imho for now it's a good idea to couple a Storyscript release with a specific version of the Hub SDK, s.t. it's easy to know which version of the Hub SDK was used by the user (only SS version required).