### PR TITLE
feat(parser): allow argument shorthand syntax for the first service argument

### DIFF
--- a/storyscript/compiler/json/JSONCompiler.py
+++ b/storyscript/compiler/json/JSONCompiler.py
@@ -147,7 +147,6 @@ class JSONCompiler:
         assert tree.data == 'service'
         position = tree.position()
         command = tree.service_fragment.command
-        tree.expect(command is not None, 'service_without_command')
         command = command.child(0)
         arguments = self.objects.arguments(tree.service_fragment)
         service = tree.path.extract_path()

--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -203,8 +203,8 @@ class TypeResolver(ScopeSelectiveVisitor):
         listener = listener_sym.type().object()
         args = self.resolver.build_arguments(
             tree.service.service_fragment,
-            listener_name,
-            event_name
+            name=listener_name,
+            fn_type=event_name,
         )
         output_type = self.module.service_typing.resolve_service_event(
             tree,
@@ -236,10 +236,16 @@ class TypeResolver(ScopeSelectiveVisitor):
         action_node = tree.service.service_fragment.command
         tree.expect(action_node is not None, 'service_without_command')
         action_name = action_node.child(0).value
+
+        # check for malformed arguments
+        self.resolver.check_service_fragment_arguments(
+            tree.service.service_fragment
+        )
+
         args = self.resolver.build_arguments(
             tree.service.service_fragment,
-            service_name,
-            action_name
+            fn_type='Service',
+            name=service_name,
         )
 
         if name is None:

--- a/storyscript/parser/Grammar.py
+++ b/storyscript/parser/Grammar.py
@@ -203,8 +203,10 @@ class Grammar:
         self.ebnf.command = 'name'
         self.ebnf.arguments = 'name? colon expression'
         self.ebnf.output = '(as name (comma name)*)'
-        self.ebnf.service_fragment = '(command arguments*|arguments+) output?'
-        self.ebnf.inline_service_fragment = '(command arguments*|arguments+)'
+        self.ebnf.service_fragment = 'command arguments* output?'
+        self.ebnf.when_service_fragment = '(command arguments*|arguments+) ' \
+                                          'output?'
+        self.ebnf.inline_service_fragment = 'command arguments*'
         self.ebnf.service = 'path service_fragment'
         self.ebnf.service_block = 'service nl (nested_block)?'
         self.ebnf.inline_service = ('path inline_service_fragment')
@@ -266,7 +268,7 @@ class Grammar:
 
     def block(self):
         self.ebnf._WHEN = 'when'
-        self.ebnf.when_service = 'name path (service_fragment | output?)'
+        self.ebnf.when_service = 'name path (when_service_fragment | output?)'
         when = 'when (when_service | name output?)'
         self.ebnf.when_block = self.ebnf.simple_block(when)
         self.ebnf.indented_arguments = 'indent (arguments nl)+ dedent'

--- a/storyscript/parser/Transformer.py
+++ b/storyscript/parser/Transformer.py
@@ -243,7 +243,7 @@ class Transformer(LarkTransformer):
         path_token = when.path.child_token(0, 'NAME')
         nested_block = matches[1]
 
-        if not when.service_fragment:
+        if not when.when_service_fragment:
             # workaround for LARK's parser limitations (no look-ahead)
             # it parses: when <service> <path> <output>?
             # but it's actually: when <service> <command> <output>?
@@ -256,6 +256,8 @@ class Transformer(LarkTransformer):
                 output=when.output,
                 block=nested_block
             )
+
+        when.when_service_fragment.data = 'service_fragment'
 
         # workaround for LARK's parser. It parses the first service_fragment
         # argument wrongly, because arguments without names are still allowed

--- a/tests/e2e/arg_name_shorthand3_error.error
+++ b/tests/e2e/arg_name_shorthand3_error.error
@@ -1,6 +1,0 @@
-Error: syntax error in story at line 2, column 1
-
-2|    my_service command :body
-      ^^^^^^^^^^
-
-E0052: Service calls require a command.

--- a/tests/e2e/arg_name_shorthand3_error.story
+++ b/tests/e2e/arg_name_shorthand3_error.story
@@ -1,2 +1,0 @@
-body = ""
-my_service command :body

--- a/tests/e2e/arg_name_shorthand7.json
+++ b/tests/e2e/arg_name_shorthand7.json
@@ -1,0 +1,46 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "name": [
+        "msg"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": ""
+        }
+      ],
+      "src": "msg = \"\"",
+      "next": "2"
+    },
+    "2": {
+      "method": "execute",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "9",
+      "service": "log",
+      "command": "info",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "msg",
+          "arg": {
+            "$OBJECT": "path",
+            "paths": [
+              "msg"
+            ]
+          }
+        }
+      ],
+      "src": "log info :msg"
+    }
+  },
+  "services": [
+    "log"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/arg_name_shorthand7.story
+++ b/tests/e2e/arg_name_shorthand7.story
@@ -1,0 +1,2 @@
+msg = ""
+log info :msg

--- a/tests/e2e/arg_name_shorthand8.json
+++ b/tests/e2e/arg_name_shorthand8.json
@@ -1,0 +1,46 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "name": [
+        "msg"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": ""
+        }
+      ],
+      "src": "msg = \"\"",
+      "next": "2"
+    },
+    "2": {
+      "method": "execute",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "9",
+      "service": "log",
+      "command": "info",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "msg",
+          "arg": {
+            "$OBJECT": "path",
+            "paths": [
+              "msg"
+            ]
+          }
+        }
+      ],
+      "src": "log info :msg"
+    }
+  },
+  "services": [
+    "log"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/arg_name_shorthand8.story
+++ b/tests/e2e/arg_name_shorthand8.story
@@ -1,0 +1,2 @@
+msg = ""
+log info :msg

--- a/tests/e2e/service_call_require_command.error
+++ b/tests/e2e/service_call_require_command.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 1, column 1
+Error: syntax error in story at line 1, column 6
 
 1|    echo message:"hello"
-      ^^^^
+           ^^^^^^^^^^^^^^^
 
 E0052: Service calls require a command.

--- a/tests/e2e/service_call_require_command2.error
+++ b/tests/e2e/service_call_require_command2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 10
+
+1|    a = echo message:"hello"
+               ^^^^^^^^^^^^^^^
+
+E0052: Service calls require a command.

--- a/tests/e2e/service_call_require_command2.story
+++ b/tests/e2e/service_call_require_command2.story
@@ -1,0 +1,1 @@
+a = echo message:"hello"

--- a/tests/e2e/service_when_shorthand_arg.json
+++ b/tests/e2e/service_when_shorthand_arg.json
@@ -1,0 +1,83 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "7",
+      "name": [
+        "path"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "a"
+        }
+      ],
+      "src": "path = \"a\"",
+      "next": "2"
+    },
+    "2": {
+      "method": "execute",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "12",
+      "output": [
+        "server"
+      ],
+      "service": "http",
+      "command": "server",
+      "enter": "3",
+      "src": "http server",
+      "next": "3"
+    },
+    "3": {
+      "method": "when",
+      "ln": "3",
+      "col_start": "10",
+      "col_end": "23",
+      "output": [
+        "listen"
+      ],
+      "service": "server",
+      "command": "listen",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "path",
+          "arg": {
+            "$OBJECT": "path",
+            "paths": [
+              "path"
+            ]
+          }
+        }
+      ],
+      "enter": "4",
+      "parent": "2",
+      "src": "    when server listen :path",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "3",
+      "src": "        a = 1"
+    }
+  },
+  "services": [
+    "http"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/service_when_shorthand_arg.story
+++ b/tests/e2e/service_when_shorthand_arg.story
@@ -1,0 +1,4 @@
+path = "a"
+http server
+    when server listen :path
+        a = 1

--- a/tests/e2e/service_when_shorthand_arg_error.error
+++ b/tests/e2e/service_when_shorthand_arg_error.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 10
+
+2|        when server listen :"path"
+               
+
+E0142: Event action `server` has no event `server`.

--- a/tests/e2e/service_when_shorthand_arg_error.story
+++ b/tests/e2e/service_when_shorthand_arg_error.story
@@ -1,0 +1,3 @@
+http server
+    when server listen :"path"
+        a = 1

--- a/tests/e2e/service_when_shorthand_arg_error2.error
+++ b/tests/e2e/service_when_shorthand_arg_error2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 10
+
+2|        when listen listen :"path"
+               
+
+E0143: server `listen` requires argument `path`.

--- a/tests/e2e/service_when_shorthand_arg_error2.story
+++ b/tests/e2e/service_when_shorthand_arg_error2.story
@@ -1,0 +1,3 @@
+http server as listen
+    when listen listen :"path"
+        a = 1

--- a/tests/integration/parser/grammar.lark
+++ b/tests/integration/parser/grammar.lark
@@ -54,8 +54,9 @@ rules: absolute_expression| assignment| return_statement| throw_statement| break
 command: NAME
 arguments: NAME? _COLON expression
 output: (_AS NAME (_COMMA NAME)*)
-service_fragment: (command arguments*|arguments+) output?
-inline_service_fragment: (command arguments*|arguments+)
+service_fragment: command arguments* output?
+when_service_fragment: (command arguments*|arguments+) output?
+inline_service_fragment: command arguments*
 service: path service_fragment
 service_block: service _NL (nested_block)?
 inline_service: path inline_service_fragment
@@ -82,7 +83,7 @@ finally_block: finally_statement _NL nested_block
 try_statement: TRY
 try_block: try_statement _NL nested_block catch_block? finally_block?
 throw_statement: THROW entity?
-when_service: NAME path (service_fragment | output?)
+when_service: NAME path (when_service_fragment | output?)
 when_block: _WHEN (when_service | NAME output?) _NL nested_block
 indented_arguments: _INDENT (arguments _NL)+ _DEDENT
 block: rules _NL| if_block| foreach_block| function_block| arguments| service_block| when_block| try_block| indented_arguments| while_block


### PR DESCRIPTION
Fixes https://github.com/storyscript/storyscript/issues/1114

TODO:
- [x] best place to check for invalid arguments (i.e. avoid duplicated check)
- [x] check `when_fragment`s