### PR TITLE
Lock story-hub for 0.23 to 0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ requirements = [
     'click==7.0',
     'lark-parser==0.7.2',
     'click-alias==0.1.1a2',
-    'story-hub~=0.1.0'
+    'story-hub==0.1.2'
 ]
 
 extras = [


### PR DESCRIPTION
To prevent e.g. https://circleci.com/gh/storyscript/runtime/1478

CC @judepereira 