### PR TITLE
fix(tests): migrate whitespace mutations to non-whitespace syntax and ban the whitespace syntax

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -161,8 +161,6 @@ class ErrorCodes:
         'E0117', 'Invalid mutation `{name}`')
     arg_name_required = (
         'E0118', '{fn_type} `{name}` requires arguments to be named')
-    mutation_nested = (
-        'E0119', "Mutations can't have nested blocks.")
     mutation_output = (
         'E0120', "Mutations can't have outputs.")
     mutation_overload_mismatch = (

--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -266,6 +266,10 @@ class ErrorCodes:
         'E0147',
         'Service object `{object}` only support events, no actions.'
     )
+    service_name_expected = (
+        'E0148',
+        'Service expected but {found} found.'
+    )
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -264,9 +264,13 @@ class ErrorCodes:
         'E0147',
         'Service object `{object}` only support events, no actions.'
     )
-    service_name_expected = (
+    service_name_not_var = (
         'E0148',
-        'Service expected but {found} found.'
+        'Service name expected but existing variable `{var}` found.'
+    )
+    service_name_not_inline_service = (
+        'E0149',
+        'Service name expected but inline service expression found.'
     )
 
     @staticmethod

--- a/storyscript/compiler/lowering/Lowering.py
+++ b/storyscript/compiler/lowering/Lowering.py
@@ -4,8 +4,7 @@ from enum import Enum
 from lark.lexer import Token
 
 from storyscript.compiler.lowering.Faketree import FakeTree
-from storyscript.compiler.lowering.utils import service_to_mutation, \
-        unicode_escape
+from storyscript.compiler.lowering.utils import unicode_escape
 from storyscript.parser.Transformer import Transformer
 from storyscript.parser.Tree import Tree
 
@@ -103,10 +102,9 @@ class Lowering:
             # Evaluate from leaf to the top
             fun(node, fake_tree, entity.path)
 
-            # split services into service calls and mutations
-            if entity.data == 'service':
-                entity.entity = Tree('entity', [entity.path])
-                service_to_mutation(entity)
+            entity.path.expect(entity.data != 'service',
+                               'service_name_expected',
+                               found='inline service')
 
     @staticmethod
     def is_inline_expression(n):

--- a/storyscript/compiler/lowering/Lowering.py
+++ b/storyscript/compiler/lowering/Lowering.py
@@ -103,8 +103,7 @@ class Lowering:
             fun(node, fake_tree, entity.path)
 
             entity.path.expect(entity.data != 'service',
-                               'service_name_expected',
-                               found='inline service')
+                               'service_name_not_inline_service')
 
     @staticmethod
     def is_inline_expression(n):

--- a/storyscript/compiler/lowering/utils.py
+++ b/storyscript/compiler/lowering/utils.py
@@ -1,15 +1,3 @@
-def service_to_mutation(tree):
-    """
-    Convert a service block into a mutation block.
-    """
-    tree.data = 'mutation'
-    tree.service_fragment.data = 'mutation_fragment'
-    # convert command into a name
-    tree.mutation_fragment.children[0] = \
-        tree.mutation_fragment.child(0).child(0)
-    return tree
-
-
 def unicode_escape(tree, text):
     """
     Evaluates unicode escape codes like \n or \x12

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 
 from lark.lexer import Token
 
-from storyscript.compiler.lowering.utils import service_to_mutation
 from storyscript.compiler.semantics.types.Types import AnyType, BaseType, \
     BooleanType, FloatType, IntType, ListType, MapType, ObjectType, \
     RegExpType, StringType, TimeType, explicit_cast
@@ -580,9 +579,12 @@ class ExpressionResolver:
             # -> must be a service
             return base_symbol(self.resolve_service(tree))
 
-        # variable exists -> mutation
-        service_to_mutation(tree)
-        return self.resolve_mutation(t, tree)
+        # variable exists -> mutation/event-based service
+        if t.type() == ObjectType.instance():
+            # In case of event-based service return Anytype for now.
+            return base_symbol(AnyType.instance())
+
+        tree.expect(0, 'service_name_expected', found='variable')
 
     def mutation(self, tree):
         assert tree.expression is not None

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -585,10 +585,8 @@ class ExpressionResolver:
         return self.resolve_mutation(t, tree)
 
     def mutation(self, tree):
-        if tree.path:
-            s = self.path(tree.path)
-        else:
-            s = self.expression(tree.expression)
+        assert tree.expression is not None
+        s = self.expression(tree.expression)
         return self.resolve_mutation(s, tree)
 
     def call_expression(self, tree):

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -584,7 +584,8 @@ class ExpressionResolver:
             # In case of event-based service return Anytype for now.
             return base_symbol(AnyType.instance())
 
-        tree.expect(0, 'service_name_expected', found='variable')
+        var_name = tree.path.child(0).value
+        tree.path.expect(0, 'service_name_not_var', var=var_name)
 
     def mutation(self, tree):
         assert tree.expression is not None

--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -229,9 +229,8 @@ class TypeResolver(ScopeSelectiveVisitor):
             tree.expect(tree.service.service_fragment.output is None,
                         'mutation_nested')
             tree.expect(tree.nested_block is None, 'mutation_nested')
-            # resolve to perform checks
-            self.resolver.service(tree.service)
-            return
+            # Whitespace syntax for mutations is not allowed anymore.
+            tree.expect(0, 'service_name_expected', found='variable')
 
         action_node = tree.service.service_fragment.command
         tree.expect(action_node is not None, 'service_without_command')

--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -225,12 +225,10 @@ class TypeResolver(ScopeSelectiveVisitor):
     def service_block(self, tree, scope):
         service_name = tree.service.path.child(0).value
         name = scope.resolve(service_name)
-        if name is not None and not isinstance(name.type(), ObjectType):
-            tree.expect(tree.service.service_fragment.output is None,
-                        'mutation_nested')
-            tree.expect(tree.nested_block is None, 'mutation_nested')
-            # Whitespace syntax for mutations is not allowed anymore.
-            tree.expect(0, 'service_name_expected', found='variable')
+
+        # Whitespace syntax for mutations is not allowed anymore.
+        tree.expect(name is None or isinstance(name.type(), ObjectType),
+                    'service_name_expected', found='variable')
 
         action_node = tree.service.service_fragment.command
         tree.expect(action_node is not None, 'service_without_command')

--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -223,12 +223,14 @@ class TypeResolver(ScopeSelectiveVisitor):
             self.in_when_block = False
 
     def service_block(self, tree, scope):
-        service_name = tree.service.path.child(0).value
+        service_path = tree.service.path
+        service_name = service_path.child(0).value
         name = scope.resolve(service_name)
 
         # Whitespace syntax for mutations is not allowed anymore.
-        tree.expect(name is None or isinstance(name.type(), ObjectType),
-                    'service_name_expected', found='variable')
+        service_path.expect(
+            name is None or isinstance(name.type(), ObjectType),
+            'service_name_not_var', var=service_name)
 
         action_node = tree.service.service_fragment.command
         tree.expect(action_node is not None, 'service_without_command')

--- a/tests/e2e/full_string_interpolation_mutation.json
+++ b/tests/e2e/full_string_interpolation_mutation.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "bar = 0",
-      "next": "2.1"
+      "next": "2.2"
     },
-    "2.1": {
+    "2.2": {
       "method": "mutation",
-      "ln": "2.1",
+      "ln": "2.2",
       "col_start": "7",
-      "col_end": "20",
+      "col_end": "10",
       "name": [
-        "__p-2.1"
+        "__p-2.2"
       ],
       "args": [
         {
@@ -36,6 +36,22 @@
           "$OBJECT": "mutation",
           "mutation": "increment",
           "args": []
+        }
+      ],
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "expression",
+      "ln": "2.1",
+      "name": [
+        "__p-2.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.2"
+          ]
         }
       ],
       "next": "2"
@@ -73,7 +89,7 @@
           ]
         }
       ],
-      "src": "a = \"foo{bar increment}\""
+      "src": "a = \"foo{bar.increment()}\""
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/full_string_interpolation_mutation.story
+++ b/tests/e2e/full_string_interpolation_mutation.story
@@ -1,2 +1,2 @@
 bar = 0
-a = "foo{bar increment}"
+a = "foo{bar.increment()}"

--- a/tests/e2e/function_return_mutation_without_type.error
+++ b/tests/e2e/function_return_mutation_without_type.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3
 
-3|        return my_int decrement
-          ^^^^^^^^^^^^^^^^^^^^^^^
+3|        return my_int.decrement()
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E0110: `return` expected. Did you miss to add `returns int`?

--- a/tests/e2e/function_return_mutation_without_type.story
+++ b/tests/e2e/function_return_mutation_without_type.story
@@ -1,3 +1,3 @@
 function random
     my_int = 5
-    return my_int decrement
+    return my_int.decrement()

--- a/tests/e2e/mutation_any_contains.json
+++ b/tests/e2e/mutation_any_contains.json
@@ -51,15 +51,15 @@
         }
       ],
       "src": "b = a[0]",
-      "next": "3"
+      "next": "3.1"
     },
-    "3": {
+    "3.1": {
       "method": "mutation",
-      "ln": "3",
+      "ln": "3.1",
       "col_start": "5",
-      "col_end": "15",
+      "col_end": "6",
       "name": [
-        "c"
+        "__p-3.1"
       ],
       "args": [
         {
@@ -83,7 +83,25 @@
           ]
         }
       ],
-      "src": "c = b contains item:0"
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-3.1"
+          ]
+        }
+      ],
+      "src": "c = b.contains(item:0)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/mutation_any_contains.story
+++ b/tests/e2e/mutation_any_contains.story
@@ -1,3 +1,3 @@
 a = [] as List[any]
 b = a[0]
-c = b contains item:0
+c = b.contains(item:0)

--- a/tests/e2e/mutation_any_contains2.json
+++ b/tests/e2e/mutation_any_contains2.json
@@ -55,15 +55,15 @@
         }
       ],
       "src": "b = a[0]",
-      "next": "3"
+      "next": "3.1"
     },
-    "3": {
+    "3.1": {
       "method": "mutation",
-      "ln": "3",
+      "ln": "3.1",
       "col_start": "5",
-      "col_end": "15",
+      "col_end": "6",
       "name": [
-        "c"
+        "__p-3.1"
       ],
       "args": [
         {
@@ -87,7 +87,25 @@
           ]
         }
       ],
-      "src": "c = b contains item:0"
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-3.1"
+          ]
+        }
+      ],
+      "src": "c = b.contains(item:0)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/mutation_any_contains2.story
+++ b/tests/e2e/mutation_any_contains2.story
@@ -1,3 +1,3 @@
 a = {} as Map[any,any]
 b = a[0]
-c = b contains item:0
+c = b.contains(item:0)

--- a/tests/e2e/mutation_any_invalid.error
+++ b/tests/e2e/mutation_any_invalid.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 7
 
-3|    c = b substring foo:2
+3|    c = b.substring(foo:2)
             ^^^^^^^^^^^^^
 
 E0121: Multiple mutation overloads for `substring` found:

--- a/tests/e2e/mutation_any_invalid.story
+++ b/tests/e2e/mutation_any_invalid.story
@@ -1,3 +1,3 @@
 a = [] as List[any]
 b = a[0]
-c = b substring foo:2
+c = b.substring(foo:2)

--- a/tests/e2e/mutation_any_invalid2.error
+++ b/tests/e2e/mutation_any_invalid2.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 5
 
-3|    c = b substring2 foo:2
+3|    c = b.substring2(foo:2)
           ^^^^^^^^^^^^
 
 E0117: Invalid mutation `substring2`

--- a/tests/e2e/mutation_any_invalid2.story
+++ b/tests/e2e/mutation_any_invalid2.story
@@ -1,3 +1,3 @@
 a = [] as List[any]
 b = a[0]
-c = b substring2 foo:2
+c = b.substring2(foo:2)

--- a/tests/e2e/mutation_any_invalid3.error
+++ b/tests/e2e/mutation_any_invalid3.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 7
 
-3|    c = b substring start:"2"
+3|    c = b.substring(start:"2")
             ^^^^^^^^^^^^^^^
 
 E0115: Mutation `substring` requires argument `start` to be of `int`, not `string`

--- a/tests/e2e/mutation_any_invalid3.story
+++ b/tests/e2e/mutation_any_invalid3.story
@@ -1,3 +1,3 @@
 a = [] as List[any]
 b = a[0]
-c = b substring start:"2"
+c = b.substring(start:"2")

--- a/tests/e2e/mutation_any_invalid4.error
+++ b/tests/e2e/mutation_any_invalid4.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 7
 
-3|    c = b append i:0
+3|    c = b.append(i:0)
             ^^^^^^^^
 
 E0114: Mutation `append` does not accept argument `i`

--- a/tests/e2e/mutation_any_invalid4.story
+++ b/tests/e2e/mutation_any_invalid4.story
@@ -1,3 +1,3 @@
 a = [] as List[any]
 b = a[0]
-c = b append i:0
+c = b.append(i:0)

--- a/tests/e2e/mutation_any_invalid5.error
+++ b/tests/e2e/mutation_any_invalid5.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 7
 
-3|    c = b contains i:0
+3|    c = b.contains(i:0)
             ^^^^^^^^^^
 
 E0121: Multiple mutation overloads for `contains` found:

--- a/tests/e2e/mutation_any_invalid5.story
+++ b/tests/e2e/mutation_any_invalid5.story
@@ -1,3 +1,3 @@
 a = {} as Map[any,any]
 b = a[0]
-c = b contains i:0
+c = b.contains(i:0)

--- a/tests/e2e/mutation_any_invalid6.error
+++ b/tests/e2e/mutation_any_invalid6.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 3, column 7
 
-3|    c = b length arg:1
+3|    c = b.length(arg:1)
             ^^^^^^^^^^
 
 E0121: Multiple mutation overloads for `length` found:

--- a/tests/e2e/mutation_any_invalid6.story
+++ b/tests/e2e/mutation_any_invalid6.story
@@ -1,3 +1,3 @@
 a = {} as Map[any,any]
 b = a[0]
-c = b length arg:1
+c = b.length(arg:1)

--- a/tests/e2e/mutation_assignment.json
+++ b/tests/e2e/mutation_assignment.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "a = \"hello world\"",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "16",
+      "col_end": "6",
       "name": [
-        "b"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -38,7 +38,25 @@
           "args": []
         }
       ],
-      "src": "b = a uppercase"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "b = a.uppercase()"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/mutation_assignment.story
+++ b/tests/e2e/mutation_assignment.story
@@ -1,2 +1,2 @@
 a = "hello world"
-b = a uppercase
+b = a.uppercase()

--- a/tests/e2e/mutation_on_object.json
+++ b/tests/e2e/mutation_on_object.json
@@ -1,0 +1,67 @@
+{
+  "tree": {
+    "1": {
+      "method": "execute",
+      "ln": "1",
+      "col_start": "5",
+      "col_end": "18",
+      "name": [
+        "a"
+      ],
+      "service": "gmaps",
+      "command": "geocode",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "address",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "foobar"
+          }
+        }
+      ],
+      "src": "a = gmaps geocode address: \"foobar\"",
+      "next": "2.1"
+    },
+    "2.1": {
+      "method": "mutation",
+      "ln": "2.1",
+      "col_start": "1",
+      "col_end": "2",
+      "name": [
+        "__p-2.1"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        },
+        {
+          "$OBJECT": "mutation",
+          "mutation": "round",
+          "args": []
+        }
+      ],
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "a.round()"
+    }
+  },
+  "services": [
+    "gmaps"
+  ],
+  "entrypoint": "1"
+}

--- a/tests/e2e/mutation_on_object.story
+++ b/tests/e2e/mutation_on_object.story
@@ -1,0 +1,2 @@
+a = gmaps geocode address: "foobar"
+a.round()

--- a/tests/e2e/mutation_whitespace.error
+++ b/tests/e2e/mutation_whitespace.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|    a = b increment
+          ^^^^^^^^^^^
+
+E0148: Service expected but variable found.

--- a/tests/e2e/mutation_whitespace.error
+++ b/tests/e2e/mutation_whitespace.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 5
 
 2|    a = b increment
-          ^^^^^^^^^^^
+          ^
 
-E0148: Service expected but variable found.
+E0148: Service name expected but existing variable `b` found.

--- a/tests/e2e/mutation_whitespace.story
+++ b/tests/e2e/mutation_whitespace.story
@@ -1,0 +1,2 @@
+b = 1
+a = b increment

--- a/tests/e2e/mutation_whitespace2.error
+++ b/tests/e2e/mutation_whitespace2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2
+
+2|    a = (http fetch url:diff_url) split by: "\n"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+E0148: Service expected but inline service found.

--- a/tests/e2e/mutation_whitespace2.error
+++ b/tests/e2e/mutation_whitespace2.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 2
 2|    a = (http fetch url:diff_url) split by: "\n"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-E0148: Service expected but inline service found.
+E0149: Service name expected but inline service expression found.

--- a/tests/e2e/mutation_whitespace2.story
+++ b/tests/e2e/mutation_whitespace2.story
@@ -1,0 +1,2 @@
+diff_url = "foobar"
+a = (http fetch url:diff_url) split by: "\n"

--- a/tests/e2e/mutation_whitespace3.error
+++ b/tests/e2e/mutation_whitespace3.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 1
 1|    (http fetch url:diff_url) split by: "\n"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-E0148: Service expected but inline service found.
+E0149: Service name expected but inline service expression found.

--- a/tests/e2e/mutation_whitespace3.error
+++ b/tests/e2e/mutation_whitespace3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1
+
+1|    (http fetch url:diff_url) split by: "\n"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+E0148: Service expected but inline service found.

--- a/tests/e2e/mutation_whitespace3.story
+++ b/tests/e2e/mutation_whitespace3.story
@@ -1,0 +1,1 @@
+(http fetch url:diff_url) split by: "\n"

--- a/tests/e2e/mutation_whitespace4.error
+++ b/tests/e2e/mutation_whitespace4.error
@@ -3,4 +3,4 @@ Error: syntax error in story at line 2, column 1
 2|    a split by: "\n"
       ^
 
-E0148: Service expected but variable found.
+E0148: Service name expected but existing variable `a` found.

--- a/tests/e2e/mutation_whitespace4.error
+++ b/tests/e2e/mutation_whitespace4.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 1
+
+2|    a split by: "\n"
+      ^
+
+E0148: Service expected but variable found.

--- a/tests/e2e/mutation_whitespace4.story
+++ b/tests/e2e/mutation_whitespace4.story
@@ -1,0 +1,2 @@
+a = "foobar"
+a split by: "\n"

--- a/tests/e2e/re_more_arguments.json
+++ b/tests/e2e/re_more_arguments.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "str = \"hello.\"",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "16",
+      "col_end": "8",
       "name": [
-        "r"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -56,7 +56,25 @@
           ]
         }
       ],
-      "src": "r = str replace pattern:/hello/i by:\"foo\""
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "r"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "r = str.replace(pattern:/hello/i by:\"foo\")"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/re_more_arguments.story
+++ b/tests/e2e/re_more_arguments.story
@@ -1,2 +1,2 @@
 str = "hello."
-r = str replace pattern:/hello/i by:"foo"
+r = str.replace(pattern:/hello/i by:"foo")

--- a/tests/e2e/return_with_mutation.json
+++ b/tests/e2e/return_with_mutation.json
@@ -35,7 +35,7 @@
       "method": "mutation",
       "ln": "3.1",
       "col_start": "12",
-      "col_end": "28",
+      "col_end": "18",
       "name": [
         "__p-3.1"
       ],
@@ -68,7 +68,7 @@
         }
       ],
       "parent": "1",
-      "src": "    return my_int decrement"
+      "src": "    return my_int.decrement()"
     }
   },
   "entrypoint": "1",

--- a/tests/e2e/return_with_mutation.story
+++ b/tests/e2e/return_with_mutation.story
@@ -1,3 +1,3 @@
 function random returns any
     my_int = 5
-    return my_int decrement
+    return my_int.decrement()

--- a/tests/e2e/semantics/foreach_mutation_invalid_name.error
+++ b/tests/e2e/semantics/foreach_mutation_invalid_name.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 9
 
-2|    foreach b my_mutation as e
+2|    foreach b.my_mutation() as e
               ^^^^^^^^^^^^^
 
 E0117: Invalid mutation `my_mutation`

--- a/tests/e2e/semantics/foreach_mutation_invalid_name.story
+++ b/tests/e2e/semantics/foreach_mutation_invalid_name.story
@@ -1,3 +1,3 @@
 b = 0
-foreach b my_mutation as e
+foreach b.my_mutation() as e
     break

--- a/tests/e2e/semantics/mutation/float_round.json
+++ b/tests/e2e/semantics/mutation/float_round.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "a = 0.5",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "12",
+      "col_end": "6",
       "name": [
-        "b"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -38,7 +38,25 @@
           "args": []
         }
       ],
-      "src": "b = a round"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "b = a.round()"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/semantics/mutation/float_round.story
+++ b/tests/e2e/semantics/mutation/float_round.story
@@ -1,2 +1,2 @@
 a = 0.5
-b = a round
+b = a.round()

--- a/tests/e2e/semantics/mutation/float_round_err.story
+++ b/tests/e2e/semantics/mutation/float_round_err.story
@@ -1,3 +1,3 @@
 a = 0.5
-b = a round
+b = a.round()
 b = "f"

--- a/tests/e2e/semantics/mutation/int_increment.story
+++ b/tests/e2e/semantics/mutation/int_increment.story
@@ -1,3 +1,3 @@
 a = 0
-b = a increment
+b = a.increment()
 b = "foo"

--- a/tests/e2e/semantics/mutation/int_round.error
+++ b/tests/e2e/semantics/mutation/int_round.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 5
 
-2|    b = a round
+2|    b = a.round()
           ^^^^^^^
 
 E0117: Invalid mutation `round`

--- a/tests/e2e/semantics/mutation/int_round.story
+++ b/tests/e2e/semantics/mutation/int_round.story
@@ -1,2 +1,2 @@
 a = 1
-b = a round
+b = a.round()

--- a/tests/e2e/semantics/mutation/invalid_arg2.error
+++ b/tests/e2e/semantics/mutation/invalid_arg2.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a increment item:1
+2|    b = a.increment(item:1)
             ^^^^^^^^^^^^^^
 
 E0114: Mutation `increment` does not accept argument `item`

--- a/tests/e2e/semantics/mutation/invalid_arg2.story
+++ b/tests/e2e/semantics/mutation/invalid_arg2.story
@@ -1,2 +1,2 @@
 a = 1
-b = a increment item:1
+b = a.increment(item:1)

--- a/tests/e2e/semantics/mutation/list_contains_err.error
+++ b/tests/e2e/semantics/mutation/list_contains_err.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains item: "foo"
+2|    b = a.contains(item: "foo")
             ^^^^^^^^^^^^^
 
 E0115: Mutation `contains` requires argument `item` to be of `int`, not `string`

--- a/tests/e2e/semantics/mutation/list_contains_err.story
+++ b/tests/e2e/semantics/mutation/list_contains_err.story
@@ -1,2 +1,2 @@
 a = [1, 2]
-b = a contains item: "foo"
+b = a.contains(item: "foo")

--- a/tests/e2e/semantics/mutation/list_contains_err2.story
+++ b/tests/e2e/semantics/mutation/list_contains_err2.story
@@ -1,3 +1,3 @@
 a = [1, 2]
-b = a contains item: 2
+b = a.contains(item: 2)
 b = "f"

--- a/tests/e2e/semantics/mutation/list_length_err.story
+++ b/tests/e2e/semantics/mutation/list_length_err.story
@@ -1,3 +1,3 @@
 a = [1, 2]
-b = a length
+b = a.length()
 b = "f"

--- a/tests/e2e/semantics/mutation/list_substring_args.error
+++ b/tests/e2e/semantics/mutation/list_substring_args.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 5
 
-2|    b = a substring start:1
+2|    b = a.substring(start:1)
           ^^^^^^^^^^^
 
 E0117: Invalid mutation `substring`

--- a/tests/e2e/semantics/mutation/list_substring_args.story
+++ b/tests/e2e/semantics/mutation/list_substring_args.story
@@ -1,2 +1,2 @@
 a = [1]
-b = a substring start:1
+b = a.substring(start:1)

--- a/tests/e2e/semantics/mutation/list_substring_no_args.error
+++ b/tests/e2e/semantics/mutation/list_substring_no_args.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 5
 
-2|    b = a substring
+2|    b = a.substring()
           ^^^^^^^^^^^
 
 E0117: Invalid mutation `substring`

--- a/tests/e2e/semantics/mutation/list_substring_no_args.story
+++ b/tests/e2e/semantics/mutation/list_substring_no_args.story
@@ -1,2 +1,2 @@
 a = [1]
-b = a substring
+b = a.substring()

--- a/tests/e2e/semantics/mutation/obj_flatten.story
+++ b/tests/e2e/semantics/mutation/obj_flatten.story
@@ -1,3 +1,3 @@
 a = {1: true}
-b = a flatten
+b = a.flatten()
 b = 1

--- a/tests/e2e/semantics/mutation/obj_keys.story
+++ b/tests/e2e/semantics/mutation/obj_keys.story
@@ -1,3 +1,3 @@
 a = {"a": 1}
-b = a keys
+b = a.keys()
 b = 0

--- a/tests/e2e/semantics/mutation/obj_values.story
+++ b/tests/e2e/semantics/mutation/obj_values.story
@@ -1,3 +1,3 @@
 a = {"a": 1}
-b = a values
+b = a.values()
 b = 0

--- a/tests/e2e/semantics/mutation/string_contains.error
+++ b/tests/e2e/semantics/mutation/string_contains.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains
+2|    b = a.contains()
             ^^^^^^^^
 
 E0121: Multiple mutation overloads for `contains` found:

--- a/tests/e2e/semantics/mutation/string_contains.story
+++ b/tests/e2e/semantics/mutation/string_contains.story
@@ -1,2 +1,2 @@
 a = ""
-b = a contains
+b = a.contains()

--- a/tests/e2e/semantics/mutation/string_contains_invalid.error
+++ b/tests/e2e/semantics/mutation/string_contains_invalid.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains start:1
+2|    b = a.contains(start:1)
             ^^^^^^^^^^^^^^
 
 E0121: Multiple mutation overloads for `contains` found:

--- a/tests/e2e/semantics/mutation/string_contains_invalid.story
+++ b/tests/e2e/semantics/mutation/string_contains_invalid.story
@@ -1,2 +1,2 @@
 a = ""
-b = a contains start:1
+b = a.contains(start:1)

--- a/tests/e2e/semantics/mutation/string_contains_item.json
+++ b/tests/e2e/semantics/mutation/string_contains_item.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "a = \"\"",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "15",
+      "col_end": "6",
       "name": [
-        "b"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -47,7 +47,25 @@
           ]
         }
       ],
-      "src": "b = a contains item: \"e\""
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "b = a.contains(item: \"e\")"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/semantics/mutation/string_contains_item.story
+++ b/tests/e2e/semantics/mutation/string_contains_item.story
@@ -1,2 +1,2 @@
 a = ""
-b = a contains item: "e"
+b = a.contains(item: "e")

--- a/tests/e2e/semantics/mutation/string_contains_item_invalid.error
+++ b/tests/e2e/semantics/mutation/string_contains_item_invalid.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains item: true
+2|    b = a.contains(item: true)
             ^^^^^^^^^^^^^
 
 E0115: Mutation `contains` requires argument `item` to be of `string`, not `boolean`

--- a/tests/e2e/semantics/mutation/string_contains_item_invalid.story
+++ b/tests/e2e/semantics/mutation/string_contains_item_invalid.story
@@ -1,2 +1,2 @@
 a = ""
-b = a contains item: true
+b = a.contains(item: true)

--- a/tests/e2e/semantics/mutation/string_contains_item_invalid2.error
+++ b/tests/e2e/semantics/mutation/string_contains_item_invalid2.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains item: "a"
+2|    b = a.contains(item: "a")
             ^^^^^^^^^^^^^
 
 E0115: Mutation `contains` requires argument `item` to be of `int`, not `string`

--- a/tests/e2e/semantics/mutation/string_contains_item_invalid2.story
+++ b/tests/e2e/semantics/mutation/string_contains_item_invalid2.story
@@ -1,2 +1,2 @@
 a = [1, 2]
-b = a contains item: "a"
+b = a.contains(item: "a")

--- a/tests/e2e/semantics/mutation/string_contains_pattern.json
+++ b/tests/e2e/semantics/mutation/string_contains_pattern.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "a = \"\"",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "15",
+      "col_end": "6",
       "name": [
-        "b"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -47,7 +47,25 @@
           ]
         }
       ],
-      "src": "b = a contains pattern: /aa/"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "b = a.contains(pattern: /aa/)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/semantics/mutation/string_contains_pattern.story
+++ b/tests/e2e/semantics/mutation/string_contains_pattern.story
@@ -1,2 +1,2 @@
 a = ""
-b = a contains pattern: /aa/
+b = a.contains(pattern: /aa/)

--- a/tests/e2e/semantics/mutation/string_contains_pattern_invalid.error
+++ b/tests/e2e/semantics/mutation/string_contains_pattern_invalid.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains pattern: 2
+2|    b = a.contains(pattern: 2)
             ^^^^^^^^^^^^^^^^
 
 E0115: Mutation `contains` requires argument `pattern` to be of `regexp`, not `int`

--- a/tests/e2e/semantics/mutation/string_contains_pattern_invalid.story
+++ b/tests/e2e/semantics/mutation/string_contains_pattern_invalid.story
@@ -1,2 +1,2 @@
 a = ""
-b = a contains pattern: 2
+b = a.contains(pattern: 2)

--- a/tests/e2e/semantics/mutation/string_contains_pattern_invalid2.error
+++ b/tests/e2e/semantics/mutation/string_contains_pattern_invalid2.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains pattern: /re/
+2|    b = a.contains(pattern: /re/)
             ^^^^^^^^^^^^^^^^
 
 E0113: Mutation `contains` requires argument `item`

--- a/tests/e2e/semantics/mutation/string_contains_pattern_invalid2.story
+++ b/tests/e2e/semantics/mutation/string_contains_pattern_invalid2.story
@@ -1,2 +1,2 @@
 a = [1, 2]
-b = a contains pattern: /re/
+b = a.contains(pattern: /re/)

--- a/tests/e2e/semantics/mutation/string_contains_pattern_item.error
+++ b/tests/e2e/semantics/mutation/string_contains_pattern_item.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains item: "a" pattern: /aa/
+2|    b = a.contains(item: "a" pattern: /aa/)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E0121: Multiple mutation overloads for `contains` found:

--- a/tests/e2e/semantics/mutation/string_contains_pattern_item.story
+++ b/tests/e2e/semantics/mutation/string_contains_pattern_item.story
@@ -1,2 +1,2 @@
 a = ""
-b = a contains item: "a" pattern: /aa/
+b = a.contains(item: "a" pattern: /aa/)

--- a/tests/e2e/semantics/mutation/string_contains_pattern_item_invalid.error
+++ b/tests/e2e/semantics/mutation/string_contains_pattern_item_invalid.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a contains item: "a" pattern: 42
+2|    b = a.contains(item: "a" pattern: 42)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E0121: Multiple mutation overloads for `contains` found:

--- a/tests/e2e/semantics/mutation/string_contains_pattern_item_invalid.story
+++ b/tests/e2e/semantics/mutation/string_contains_pattern_item_invalid.story
@@ -1,2 +1,2 @@
 a = ""
-b = a contains item: "a" pattern: 42
+b = a.contains(item: "a" pattern: 42)

--- a/tests/e2e/semantics/mutation/string_split_by_var.json
+++ b/tests/e2e/semantics/mutation/string_split_by_var.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "a = \"aa\"",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "12",
+      "col_end": "6",
       "name": [
-        "b"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -47,7 +47,25 @@
           ]
         }
       ],
-      "src": "b = a split by:\".\""
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "b = a.split(by:\".\")"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/semantics/mutation/string_split_by_var.story
+++ b/tests/e2e/semantics/mutation/string_split_by_var.story
@@ -1,2 +1,2 @@
 a = "aa"
-b = a split by:"."
+b = a.split(by:".")

--- a/tests/e2e/semantics/mutation/string_substring_end.json
+++ b/tests/e2e/semantics/mutation/string_substring_end.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "a = \"\"",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "16",
+      "col_end": "6",
       "name": [
-        "b"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -47,7 +47,25 @@
           ]
         }
       ],
-      "src": "b = a substring end: 10"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "b = a.substring(end: 10)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/semantics/mutation/string_substring_end.story
+++ b/tests/e2e/semantics/mutation/string_substring_end.story
@@ -1,2 +1,2 @@
 a = ""
-b = a substring end: 10
+b = a.substring(end: 10)

--- a/tests/e2e/semantics/mutation/string_substring_end_error.error
+++ b/tests/e2e/semantics/mutation/string_substring_end_error.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a substring end: "foo"
+2|    b = a.substring(end: "foo")
             ^^^^^^^^^^^^^
 
 E0115: Mutation `substring` requires argument `end` to be of `int`, not `string`

--- a/tests/e2e/semantics/mutation/string_substring_end_error.story
+++ b/tests/e2e/semantics/mutation/string_substring_end_error.story
@@ -1,2 +1,2 @@
 a = ""
-b = a substring end: "foo"
+b = a.substring(end: "foo")

--- a/tests/e2e/semantics/mutation/string_substring_no_args.error
+++ b/tests/e2e/semantics/mutation/string_substring_no_args.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a substring
+2|    b = a.substring()
             ^^^^^^^^^
 
 E0121: Multiple mutation overloads for `substring` found:

--- a/tests/e2e/semantics/mutation/string_substring_no_args.story
+++ b/tests/e2e/semantics/mutation/string_substring_no_args.story
@@ -1,2 +1,2 @@
 a = ""
-b = a substring
+b = a.substring()

--- a/tests/e2e/semantics/mutation/string_substring_start.json
+++ b/tests/e2e/semantics/mutation/string_substring_start.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "a = \"\"",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "16",
+      "col_end": "6",
       "name": [
-        "b"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -47,7 +47,25 @@
           ]
         }
       ],
-      "src": "b = a substring start: 1"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "b = a.substring(start: 1)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/semantics/mutation/string_substring_start.story
+++ b/tests/e2e/semantics/mutation/string_substring_start.story
@@ -1,2 +1,2 @@
 a = ""
-b = a substring start: 1
+b = a.substring(start: 1)

--- a/tests/e2e/semantics/mutation/string_substring_start_end.json
+++ b/tests/e2e/semantics/mutation/string_substring_start_end.json
@@ -15,15 +15,15 @@
         }
       ],
       "src": "a = \"\"",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "16",
+      "col_end": "6",
       "name": [
-        "b"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -55,7 +55,25 @@
           ]
         }
       ],
-      "src": "b = a substring start: 1 end: 10"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "b = a.substring(start: 1 end: 10)"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/semantics/mutation/string_substring_start_end.story
+++ b/tests/e2e/semantics/mutation/string_substring_start_end.story
@@ -1,2 +1,2 @@
 a = ""
-b = a substring start: 1 end: 10
+b = a.substring(start: 1 end: 10)

--- a/tests/e2e/semantics/mutation/string_substring_start_end_error.error
+++ b/tests/e2e/semantics/mutation/string_substring_start_end_error.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a substring start: 1 end: "foo"
+2|    b = a.substring(start: 1 end: "foo")
             ^^^^^^^^^^^^^^^^^^^^^^
 
 E0115: Mutation `substring` requires argument `end` to be of `int`, not `string`

--- a/tests/e2e/semantics/mutation/string_substring_start_end_error.story
+++ b/tests/e2e/semantics/mutation/string_substring_start_end_error.story
@@ -1,2 +1,2 @@
 a = ""
-b = a substring start: 1 end: "foo"
+b = a.substring(start: 1 end: "foo")

--- a/tests/e2e/semantics/mutation/string_substring_start_error.error
+++ b/tests/e2e/semantics/mutation/string_substring_start_error.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    b = a substring start: "1"
+2|    b = a.substring(start: "1")
             ^^^^^^^^^^^^^^^
 
 E0115: Mutation `substring` requires argument `start` to be of `int`, not `string`

--- a/tests/e2e/semantics/mutation/string_substring_start_error.story
+++ b/tests/e2e/semantics/mutation/string_substring_start_error.story
@@ -1,2 +1,2 @@
 a = ""
-b = a substring start: "1"
+b = a.substring(start: "1")

--- a/tests/e2e/semantics/nested_service_calls2.json
+++ b/tests/e2e/semantics/nested_service_calls2.json
@@ -48,66 +48,46 @@
       "next": "3.1"
     },
     "3.1": {
-      "method": "mutation",
+      "method": "execute",
       "ln": "3.1",
       "col_start": "14",
       "col_end": "27",
       "name": [
         "__p-3.1"
       ],
+      "service": "request",
+      "command": "fetch",
       "args": [
         {
-          "$OBJECT": "path",
-          "paths": [
-            "request"
-          ]
-        },
-        {
-          "$OBJECT": "mutation",
-          "mutation": "fetch",
-          "args": [
-            {
-              "$OBJECT": "arg",
-              "name": "url",
-              "arg": {
-                "$OBJECT": "string",
-                "string": "foo-url"
-              }
-            }
-          ]
+          "$OBJECT": "arg",
+          "name": "url",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "foo-url"
+          }
         }
       ],
       "parent": "2",
       "next": "3.2"
     },
     "3.2": {
-      "method": "mutation",
+      "method": "execute",
       "ln": "3.2",
       "col_start": "46",
       "col_end": "59",
       "name": [
         "__p-3.2"
       ],
+      "service": "request",
+      "command": "fetch",
       "args": [
         {
-          "$OBJECT": "path",
-          "paths": [
-            "request"
-          ]
-        },
-        {
-          "$OBJECT": "mutation",
-          "mutation": "fetch",
-          "args": [
-            {
-              "$OBJECT": "arg",
-              "name": "url",
-              "arg": {
-                "$OBJECT": "string",
-                "string": "bar-url"
-              }
-            }
-          ]
+          "$OBJECT": "arg",
+          "name": "url",
+          "arg": {
+            "$OBJECT": "string",
+            "string": "bar-url"
+          }
         }
       ],
       "parent": "2",

--- a/tests/e2e/semantics/service_mutation_block.error
+++ b/tests/e2e/semantics/service_mutation_block.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 3
 
-2|    a get key: "b"
+2|    a.get(key: "b")
         ^^^^^^^
 
 E0113: Mutation `get` requires argument `default`

--- a/tests/e2e/semantics/service_mutation_block.story
+++ b/tests/e2e/semantics/service_mutation_block.story
@@ -1,2 +1,2 @@
 a = {"a": 1}
-a get key: "b"
+a.get(key: "b")

--- a/tests/e2e/semantics/string_template_mutation_invalid_name.error
+++ b/tests/e2e/semantics/string_template_mutation_invalid_name.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 2, column 7
 
-2|    a = "foo{b my_mutation}"
+2|    a = "foo{b.my_mutation()}"
             ^^^^^^^^^^^^^
 
 E0117: Invalid mutation `my_mutation`

--- a/tests/e2e/semantics/string_template_mutation_invalid_name.story
+++ b/tests/e2e/semantics/string_template_mutation_invalid_name.story
@@ -1,2 +1,2 @@
 b = 0
-a = "foo{b my_mutation}"
+a = "foo{b.my_mutation()}"

--- a/tests/e2e/service_mutation.json
+++ b/tests/e2e/service_mutation.json
@@ -39,14 +39,13 @@
           }
         }
       ],
-      "next": "2"
+      "next": "2.2"
     },
-    "2": {
+    "2.2": {
       "method": "mutation",
-      "ln": "2",
-      "col_end": "41",
+      "ln": "2.2",
       "name": [
-        "lines"
+        "__p-2.2"
       ],
       "args": [
         {
@@ -70,7 +69,25 @@
           ]
         }
       ],
-      "src": "lines = (http fetch url: diff_url) split by: \"\\n\""
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "8",
+      "name": [
+        "lines"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.2"
+          ]
+        }
+      ],
+      "src": "lines = (http fetch url: diff_url).split(by: \"\\n\")"
     }
   },
   "services": [

--- a/tests/e2e/service_mutation.story
+++ b/tests/e2e/service_mutation.story
@@ -1,2 +1,2 @@
 diff_url = "foobar"
-lines = (http fetch url: diff_url) split by: "\n"
+lines = (http fetch url: diff_url).split(by: "\n")

--- a/tests/e2e/var_scope_mutation.json
+++ b/tests/e2e/var_scope_mutation.json
@@ -24,13 +24,16 @@
         }
       ],
       "src": "my_service = [1, 2]",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "1",
-      "col_end": "18",
+      "col_end": "11",
+      "name": [
+        "__p-2.1"
+      ],
       "args": [
         {
           "$OBJECT": "path",
@@ -44,7 +47,20 @@
           "args": []
         }
       ],
-      "src": "my_service length"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "my_service.length()"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/var_scope_mutation.story
+++ b/tests/e2e/var_scope_mutation.story
@@ -1,2 +1,2 @@
 my_service = [1, 2]
-my_service length
+my_service.length()

--- a/tests/e2e/var_scope_mutation2.json
+++ b/tests/e2e/var_scope_mutation2.json
@@ -24,15 +24,15 @@
         }
       ],
       "src": "my_service = [1, 2]",
-      "next": "2"
+      "next": "2.1"
     },
-    "2": {
+    "2.1": {
       "method": "mutation",
-      "ln": "2",
+      "ln": "2.1",
       "col_start": "5",
-      "col_end": "22",
+      "col_end": "15",
       "name": [
-        "a"
+        "__p-2.1"
       ],
       "args": [
         {
@@ -47,7 +47,25 @@
           "args": []
         }
       ],
-      "src": "a = my_service length"
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "4",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-2.1"
+          ]
+        }
+      ],
+      "src": "a = my_service.length()"
     }
   },
   "entrypoint": "1"

--- a/tests/e2e/var_scope_mutation2.story
+++ b/tests/e2e/var_scope_mutation2.story
@@ -1,2 +1,2 @@
 my_service = [1, 2]
-a = my_service length
+a = my_service.length()

--- a/tests/e2e/while_with_mutation.json
+++ b/tests/e2e/while_with_mutation.json
@@ -21,7 +21,7 @@
       "method": "mutation",
       "ln": "2.1",
       "col_start": "7",
-      "col_end": "14",
+      "col_end": "8",
       "name": [
         "__p-2.1"
       ],
@@ -53,7 +53,7 @@
         }
       ],
       "enter": "3",
-      "src": "while x isOdd",
+      "src": "while x.isOdd()",
       "next": "3"
     },
     "3": {

--- a/tests/e2e/while_with_mutation.story
+++ b/tests/e2e/while_with_mutation.story
@@ -1,3 +1,3 @@
 x = 5
-while x isOdd
+while x.isOdd()
     break

--- a/tests/unittests/compiler/lowering/Lowering.py
+++ b/tests/unittests/compiler/lowering/Lowering.py
@@ -283,38 +283,6 @@ def test_preprocessor_visit_nested_parent(patch, magic, preprocessor, entity):
     ]
 
 
-def test_preprocessor_service_mut(patch, magic, preprocessor, entity):
-    """
-    Check that services are correctly converted into mutations
-    """
-    tree = magic()
-    tree.data = 'service'
-    replace = magic()
-    cs = [magic(), magic()]
-    for c in cs:
-        c.children = [magic()]
-
-    tree.children = [cs[0]]
-    cs[0].children = [cs[1]]
-    cs[0].data = 'path'
-    tree.child(0).data = 'path'
-
-    def is_inline(n):
-        return n == cs[0]
-
-    preprocessor.visit(tree, '.block.', entity, is_inline,
-                       replace, parent=None)
-    preprocessor.fake_tree.mock_calls = [
-        mock.call(tree),
-    ]
-    replace.mock_calls = [
-        mock.call(cs[0], preprocessor.fake_tree(), tree),
-    ]
-    assert tree.data == 'mutation'
-    assert tree.entity == Tree('entity', [tree.path])
-    assert tree.service_fragment.data == 'mutation_fragment'
-
-
 def test_preprocessor_visit_base_expression(patch, magic, preprocessor,
                                             entity):
     """


### PR DESCRIPTION
This is a prepratory PR for the changes to come in the effor to achieve #1158 
This basically migrates all of the existing tests which use whitespace mutation syntax to not use it.

Moving forward, we will ban this syntax in an upcoming PR and add tests to ensure that it stays banned but this PR is just about preparring for that effort.


EDIT: Due to codecoverage failing for just migrating the tests, I decided to make this PR about the entire #1158 issue. Now this PR has commits which ban whitespace syntax for mutations by always expecting a service.

Fixes: #1158.