### PR TITLE
feat(dependencies): Switch to click-aliases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ requirements = [
     'bom-open==0.4.0',
     'click==7.0',
     'lark-parser==0.7.2',
-    'click-alias==0.1.1a2',
+    'click-aliases==1.0.1',
     'story-hub==0.1.4'
 ]
 

--- a/storyscript/Cli.py
+++ b/storyscript/Cli.py
@@ -3,7 +3,7 @@ import io
 
 import click
 
-from click_alias import ClickAliasedGroup
+from click_aliases import ClickAliasedGroup
 
 from .App import App
 from .Features import Features


### PR DESCRIPTION
click-alias is an unmaintained fork of click-aliases;
the latter is maintained by the click team, and
recently updated to support Click 7.

