### PR TITLE
feat(ObjectType): ban cast to object and return an object

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -284,6 +284,14 @@ class ErrorCodes:
         'E0152',
         '`as` can not be used in assignments.'
     )
+    return_type_no_object = (
+        'E0153',
+        'Return type cannot be `object`.'
+    )
+    object_no_as = (
+        'E0154',
+        'Type cast to `object` is not allowed.'
+    )
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/semantics/ExpressionResolver.py
+++ b/storyscript/compiler/semantics/ExpressionResolver.py
@@ -78,6 +78,7 @@ class SymbolExpressionVisitor(ExpressionVisitor):
         assert tree.child(1).data == 'as_operator'
         # check for compatibility
         t = self.visitor.types(tree.child(1).types)
+        tree.expect(t.type() != ObjectType.instance(), 'object_no_as')
         tree.expect(explicit_cast(expr.type(), t.type()),
                     'type_operation_cast_incompatible',
                     left=expr.type(), right=t.type())

--- a/storyscript/compiler/semantics/FunctionResolver.py
+++ b/storyscript/compiler/semantics/FunctionResolver.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from storyscript.compiler.semantics.types.Types import NoneType
+from storyscript.compiler.semantics.types.Types import NoneType, ObjectType
 from storyscript.parser import Tree
 
 from .ExpressionResolver import ExpressionResolver
@@ -47,6 +47,8 @@ class FunctionResolver(ScopeSelectiveVisitor):
         output = tree.function_output
         if output is not None:
             return_type = self.resolver.types(output.types).type()
+            tree.expect(return_type != ObjectType.instance(),
+                        'return_type_no_object')
         self.module.function_table.insert(function_name, args, return_type)
         return scope, return_type
 

--- a/storyscript/compiler/semantics/types/Types.py
+++ b/storyscript/compiler/semantics/types/Types.py
@@ -128,13 +128,6 @@ class BaseType:
             return other
         return None
 
-    def explicit_from(self, from_type):
-        """
-        Return `self` if the type can be explicitly converted from `other`.
-        None otherwise.
-        """
-        return from_type.implicit_to(self)
-
     def hashable(self):
         """
         Returns whether the type can be hashed.

--- a/tests/e2e/function_return_app2.error
+++ b/tests/e2e/function_return_app2.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 2, column 12
+Error: syntax error in story at line 1, column 1
 
-2|        return app.secrets
-                 ^^^
+1|    function foo returns object
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-E0128: `Object` is readonly and can not be returned.
+E0153: Return type cannot be `object`.

--- a/tests/e2e/function_return_object.error
+++ b/tests/e2e/function_return_object.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 2, column 12
+Error: syntax error in story at line 1, column 1
 
-2|        return app
-                 ^^^
+1|    function foo returns object
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-E0128: `Object` is readonly and can not be returned.
+E0153: Return type cannot be `object`.

--- a/tests/e2e/object_no_type_cast.error
+++ b/tests/e2e/object_no_type_cast.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 6
+
+1|    a = (1 as any) as object
+           ^^^^^^^^^^^^^^^^^^^
+
+E0154: Type cast to `object` is not allowed.

--- a/tests/e2e/object_no_type_cast.story
+++ b/tests/e2e/object_no_type_cast.story
@@ -1,0 +1,1 @@
+a = (1 as any) as object

--- a/tests/e2e/return_no_object.error
+++ b/tests/e2e/return_no_object.error
@@ -1,6 +1,6 @@
 Error: syntax error in story at line 1, column 1
 
-1|    function foo returns object
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1|    function foobar returns object
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E0153: Return type cannot be `object`.

--- a/tests/e2e/return_no_object.story
+++ b/tests/e2e/return_no_object.story
@@ -1,0 +1,2 @@
+function foobar returns object
+    return http server

--- a/tests/e2e/return_no_object2.error
+++ b/tests/e2e/return_no_object2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 1
+
+1|    function foobar returns object
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+E0153: Return type cannot be `object`.

--- a/tests/e2e/return_no_object2.story
+++ b/tests/e2e/return_no_object2.story
@@ -1,0 +1,2 @@
+function foobar returns object
+    return {}

--- a/tests/integration/compiler/semantics/types/Types.py
+++ b/tests/integration/compiler/semantics/types/Types.py
@@ -195,8 +195,8 @@ implicit_assigns = {
                            'any', 'Map[float,string]', 'Map[string,float]',
                            'Map[string,int]'],
     'none': [],
-    'object': ['object', 'any', 'string'],
-    'any': [k for k in all_types.keys() if k != 'none'],
+    'object': ['any', 'string'],
+    'any': [k for k in all_types.keys() if k != 'none' and k != 'object'],
 }
 
 


### PR DESCRIPTION
We aren't sure about what we want ObjectType to be. There is
confusion with Maps if we start calling {} to be an object?

Hence for the moment we decided to stop allowing objects
being returned from functions or other datatypes being
casted to an object. Well only datatype that can be casted
to an object is `any` so we ban that as well.

Fixes: #1200, #858