### PR TITLE
check for existance of event based action output in when block

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -292,6 +292,10 @@ class ErrorCodes:
         'E0154',
         'Type cast to `object` is not allowed.'
     )
+    object_expect_action = (
+        'E0155',
+        'Service object expected but existing variable `{var}` found.'
+    )
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from storyhub.sdk.service.Action import Action as ServiceAction
+
 from storyscript.compiler.semantics.types.Types import BooleanType, \
     NoneType, ObjectType, StringType
 from storyscript.exceptions import expect
@@ -212,7 +214,10 @@ class TypeResolver(ScopeSelectiveVisitor):
             listener_sym.type().object() is not None,
             'event_not_defined',
             event=event_name, output=listener_name)
+
         listener = listener_sym.type().object()
+        tree.expect(isinstance(listener, ServiceAction),
+                    'object_expect_action', var=listener_name)
         args = self.resolver.build_arguments(
             tree.service.service_fragment,
             fname=event_name,

--- a/tests/e2e/when_invalid_action.error
+++ b/tests/e2e/when_invalid_action.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 6
+
+2|    when a listen path: "/" as r
+           
+
+E0144: No event listener with output `a` for event `listen`.

--- a/tests/e2e/when_invalid_action.story
+++ b/tests/e2e/when_invalid_action.story
@@ -1,0 +1,3 @@
+a = 1
+when a listen path: "/" as r
+    r write content: "foobar"

--- a/tests/e2e/when_invalid_action1.error
+++ b/tests/e2e/when_invalid_action1.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 3, column 10
+
+3|        when a listen path: "/" as r
+               
+
+E0144: No event listener with output `a` for event `listen`.

--- a/tests/e2e/when_invalid_action1.story
+++ b/tests/e2e/when_invalid_action1.story
@@ -1,0 +1,4 @@
+a = 1
+http server
+    when a listen path: "/" as r
+        r write content: "foobar"

--- a/tests/e2e/when_invalid_action2.error
+++ b/tests/e2e/when_invalid_action2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 10
+
+2|        when client listen method:"post" path:"/foo" as res
+               
+
+E0144: No event listener with output `client` for event `listen`.

--- a/tests/e2e/when_invalid_action2.story
+++ b/tests/e2e/when_invalid_action2.story
@@ -1,0 +1,4 @@
+http server
+    when client listen method:"post" path:"/foo" as res
+        v = res
+        v["foo"] = 2

--- a/tests/e2e/when_invalid_action3.error
+++ b/tests/e2e/when_invalid_action3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 6
+
+1|    when app listen path: "/" as r
+           
+
+E0155: Service object expected but existing variable `app` found.

--- a/tests/e2e/when_invalid_action3.story
+++ b/tests/e2e/when_invalid_action3.story
@@ -1,0 +1,2 @@
+when app listen path: "/" as r
+    r write content: "foobar"

--- a/tests/e2e/when_invalid_action4.error
+++ b/tests/e2e/when_invalid_action4.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 6
+
+2|    when a listen path: "/" as r
+           
+
+E0155: Service object expected but existing variable `a` found.

--- a/tests/e2e/when_invalid_action4.story
+++ b/tests/e2e/when_invalid_action4.story
@@ -1,0 +1,3 @@
+a = gmaps geocode address: "Venice"
+when a listen path: "/" as r
+    r write content: "foobar"


### PR DESCRIPTION
We make sure that:

* The event based action output in when block exists and
is the output of parent service block only in case when block is
nested inside a service block.
Eg.
```
a = 1
http server
    when a listen path: "/" as r
        r write content: "foobar"
```
Above errors out because `a` in when block isn't output of parent
service block.

```
http server
    when client listen path: "/" as r
        r write content: "foobar"
```
Above errors out because `client` in when block does not exist.

* For syntax like below:
```
a = http server
when a listen path: "/" as r
    r write content: "foobar"
```

we make sure that `a` exists and is of type `object` and is wrapping
the output of the `Service`.

Fixes: #716 