### PR TITLE
feat(ServiceTyping): ban event based services in expressions

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -296,6 +296,11 @@ class ErrorCodes:
         'E0155',
         'Service object expected but existing variable `{var}` found.'
     )
+    expression_no_event = (
+        'E0156',
+        'Event based action `{action}` of service `{service}` cannot be used '
+        'in expressions.'
+    )
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/semantics/ServiceTyping.py
+++ b/storyscript/compiler/semantics/ServiceTyping.py
@@ -70,6 +70,8 @@ class ServiceTyping:
         if nested_block:
             return ObjectType(obj=action)
         else:
+            tree.expect(action.events() == [], 'expression_no_event',
+                        service=service_name, action=action_name)
             return self.get_service_output(action)
 
     def get_service_output(self, action):

--- a/tests/e2e/expression_no_event.error
+++ b/tests/e2e/expression_no_event.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 5
+
+1|    a = http server
+          ^^^^^^^^^^^
+
+E0156: Event based action `server` of service `http` cannot be used in expressions.

--- a/tests/e2e/expression_no_event.story
+++ b/tests/e2e/expression_no_event.story
@@ -1,0 +1,1 @@
+a = http server

--- a/tests/e2e/expression_no_event2.error
+++ b/tests/e2e/expression_no_event2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 2
+
+1|    (http server)
+       ^^^^^^^^^^^
+
+E0156: Event based action `server` of service `http` cannot be used in expressions.

--- a/tests/e2e/expression_no_event2.story
+++ b/tests/e2e/expression_no_event2.story
@@ -1,0 +1,1 @@
+(http server)


### PR DESCRIPTION
This bans service actions which are event based from being used
as part of expressions.

eg.		`a = http server`
		`(http server)`

The above lines is no longer allowed since `server` action is
event based.

**NOTE:**
This PR does the opposite of the issue #1050 and we are allowing this PR in for the moment. This is because we have decided to go along the direction of doing things in a way that allowing service assignments for event streaming won't require the runtime to change. This means we are going to  lower the such service assignments into service blocks so that for the runtime its bussines as usual. 
This is something which is sorta more involved project and isn't the highest priority right now so we are gonna defer it for later. As a result we need to for the moment ban such assignments because otherwise runtime won't know what to do which such output from the language since runtime doesn't understand service assignments for event streaming.