### PR TITLE
chore(README.md): use unicode characters for emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 <img src="https://user-images.githubusercontent.com/4370550/56803568-460e5800-6823-11e9-8a70-25ab4b7e32ea.png" width="275">
 </div>
 
-## :wave: Meet Storyscript
+## &#x1f44b;<!-- wave --> Meet Storyscript
 The [DSL](https://en.wikipedia.org/wiki/Domain-specific_language) for **Application Storytelling**.
 Develop rapidly, deploy natively to the cloud and focus on what matters most: business-logic.
-Designed with :heart: by [Storyscript](https://storyscript.io) on a mission to bring application development to the next level.
+Designed with &#x2764;&#xfe0f;<!-- heart --> by [Storyscript](https://storyscript.io) on a mission to bring application development to the next level.
 
 ```coffee
 # Applications are stories of data.
@@ -31,9 +31,9 @@ when http server listen path: "/" as request     # Serverless
 $ story deploy  # Zero-devop deployments into Kubernetes
 ```
 
-:100:Open Source for a delicious application development. :sparkles::cake::sparkles:
+&#x1f4af;<!-- 100 --> Open Source for a delicious application development. &#x2728;<!-- sparkles -->&#x1f370;<!-- cake -->&#x2728;<!-- sparkles -->
 
-> :rocket:Choose: hosted **Storyscript Cloud** or `helm install story` for on-premises deployments.
+> &#x1f680;<!-- rocket --> Choose: hosted **Storyscript Cloud** or `helm install story` for on-premises deployments.
 
 ## Using Storyscript
 


### PR DESCRIPTION
This is because Pypi doesn't understand Github flavour markdown
emoji's and storyscript page appears on Pypi a bit broken.

To still keep the ease of understanding what a given emoji code
represents just by reading it, I added HTML comments after each
emoji code specifying its human readable name.

Emoji codes picked up from https://emojiguide.org/

Fixes: #1033 