### PR TITLE
chore(tests/update): fix update tool post removal of StoryscriptHubFixture

### DIFF
--- a/tests/e2e/update
+++ b/tests/e2e/update
@@ -18,15 +18,20 @@ import storyscript.hub.Hub as StoryHub
 from storyscript.Api import Api
 from storyscript.App import _clean_dict
 
+from storyhub.sdk.ServiceWrapper import ServiceWrapper
+
 from utils.Features import parse_features
-from utils.StoryscriptHubFixture import StoryscriptHubFixture
+
 
 test_dir = path.dirname(path.realpath(__file__))
 Result = namedtuple('Result', ['status', 'updated'])
 
 features = {'globals': True}
 
-StoryHub.StoryscriptHub = StoryscriptHubFixture
+hub_fixtures_file = path.join(path.dirname(test_dir),
+                              'fixtures', 'hub_fixture.json.fixed')
+StoryHub.StoryscriptHub = lambda: \
+    ServiceWrapper.from_json_file(hub_fixtures_file)
 
 
 def parse_args():


### PR DESCRIPTION
This should have been fixed along with #1206 but wasn't so fixing
it now.
This doesn't require us to do any release immediately since its languages internal tooling but very easily it could have been the case. Sorry for the churn on this one.