### PR TITLE
feat(ServiceTyping): check nested service blocks for events 

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -301,6 +301,11 @@ class ErrorCodes:
         'Event based action `{action}` of service `{service}` cannot be used '
         'in expressions.'
     )
+    service_event_expected = (
+        'E0157',
+        'Event based action expected but action `{action}` of service '
+        '`{service}` found.'
+    )
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/semantics/ServiceTyping.py
+++ b/storyscript/compiler/semantics/ServiceTyping.py
@@ -68,6 +68,8 @@ class ServiceTyping:
         self.check_action_args(tree, action, args, service_name, action_name)
 
         if nested_block:
+            tree.expect(action.events() != [], 'service_event_expected',
+                        service=service_name, action=action_name)
             return ObjectType(obj=action)
         else:
             tree.expect(action.events() == [], 'expression_no_event',

--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -270,7 +270,7 @@ class TypeResolver(ScopeSelectiveVisitor):
                 service_name,
                 action_name,
                 args,
-                nested_block=True
+                nested_block=tree.nested_block is not None
             )
         else:
             output_type = self.module.service_typing. \

--- a/tests/e2e/expression_no_event3.error
+++ b/tests/e2e/expression_no_event3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 1
+
+1|    http server
+      ^^^^^^^^^^^
+
+E0156: Event based action `server` of service `http` cannot be used in expressions.

--- a/tests/e2e/expression_no_event3.story
+++ b/tests/e2e/expression_no_event3.story
@@ -1,0 +1,1 @@
+http server

--- a/tests/e2e/service_event_expected.error
+++ b/tests/e2e/service_event_expected.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 1, column 1
+
+1|    gmaps geocode address: "foo" as g
+      ^^^^^^^^^^^^^
+
+E0157: Event based action expected but action `geocode` of service `gmaps` found.

--- a/tests/e2e/service_event_expected.story
+++ b/tests/e2e/service_event_expected.story
@@ -1,0 +1,2 @@
+gmaps geocode address: "foo" as g
+    foo = 1


### PR DESCRIPTION
We add checks for services which are nested in nature and should
have event listeners to make sure they really do are using
event based actions

Fixes: #1212 
