### PR TITLE
fix(ReturnVisitor): support returning local variables from a scope

### DIFF
--- a/storyscript/compiler/semantics/ReturnVisitor.py
+++ b/storyscript/compiler/semantics/ReturnVisitor.py
@@ -5,7 +5,6 @@ from storyscript.compiler.semantics.types.Types import NoneType
 from storyscript.exceptions import CompilerError
 
 from .ExpressionResolver import ExpressionResolver
-from .SymbolResolver import SymbolResolver
 
 
 class ReturnVisitor:
@@ -14,7 +13,7 @@ class ReturnVisitor:
     """
     def __init__(self, return_type, module):
         self.return_type = return_type
-        self.symbol_resolver = SymbolResolver(scope=None)
+        self.module = module
         self.resolver = ExpressionResolver(module=module)
 
     def has_return(self, tree):
@@ -43,7 +42,7 @@ class ReturnVisitor:
 
     def return_statement(self, tree, scope):
         assert tree.data == 'return_statement'
-        self.symbol_resolver.update_scope(scope)
+        self.module.symbol_resolver.update_scope(tree.scope)
         obj = tree.base_expression
         if obj is None:
             return base_symbol(NoneType.instance()), tree
@@ -79,5 +78,7 @@ class ReturnVisitor:
 
     @classmethod
     def check(cls, tree, scope, return_type, module):
+        # NOTE: ReturnVisitor updates the module.symbol_resolver scope
+        # and depends upon the caller to restore old scope when this returns.
         rv = ReturnVisitor(return_type, module)
         rv.function_block(tree, scope)

--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -388,6 +388,9 @@ class TypeResolver(ScopeSelectiveVisitor):
         tree.entity.expect(sym.type() == StringType.instance(),
                            'throw_only_string')
 
+    def return_statement(self, tree, scope):
+        tree.scope = scope
+
     def function_block(self, tree, scope):
         tree.scope, return_type = self.function_statement(
             tree.function_statement, scope

--- a/storyscript/compiler/semantics/symbols/Scope.py
+++ b/storyscript/compiler/semantics/symbols/Scope.py
@@ -73,6 +73,15 @@ class Scope:
         scope.insert(app_keyword)
         return scope
 
+    def copy(self):
+        """
+        Creates and returns a new scope by copying over from current scope.
+        """
+        new_scope = Scope(parent=self._parent)
+        for sym in self._symbols._symbols.values():
+            new_scope.insert(sym)
+        return new_scope
+
 
 class ScopeJoiner:
     """
@@ -89,8 +98,8 @@ class ScopeJoiner:
         Performs the join operation on one or more scopes.
         """
         if self.scope is None:
-            self.scope = scope
-            self.symbols = scope._symbols._symbols
+            self.scope = scope.copy()
+            self.symbols = self.scope._symbols._symbols
         else:
             # join symbols
             new_symbols = scope._symbols._symbols

--- a/tests/e2e/return_local_var.json
+++ b/tests/e2e/return_local_var.json
@@ -1,0 +1,85 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "12",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "if",
+      "ln": "2",
+      "col_start": "8",
+      "col_end": "10",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "3",
+      "exit": "5",
+      "parent": "1",
+      "src": "    if true",
+      "next": "5"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "2",
+      "src": "        a = 1",
+      "next": "4"
+    },
+    "4": {
+      "method": "return",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "2",
+      "src": "        return a"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    return 1"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var.story
+++ b/tests/e2e/return_local_var.story
@@ -1,0 +1,5 @@
+function foo returns int
+    if true
+        a = 1
+        return a
+    return 1

--- a/tests/e2e/return_local_var10.json
+++ b/tests/e2e/return_local_var10.json
@@ -1,0 +1,225 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "try",
+      "ln": "3",
+      "col_start": "5",
+      "col_end": "12",
+      "enter": "4",
+      "exit": "6",
+      "parent": "1",
+      "src": "    try",
+      "next": "6"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "b"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return b + a"
+    },
+    "6": {
+      "method": "catch",
+      "ln": "6",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "7",
+      "exit": "9",
+      "parent": "1",
+      "src": "    catch",
+      "next": "9"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "6",
+      "src": "        c = 3",
+      "next": "8"
+    },
+    "8": {
+      "method": "return",
+      "ln": "8",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "c"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "6",
+      "src": "        return c + a"
+    },
+    "9": {
+      "method": "finally",
+      "ln": "9",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "10",
+      "exit": "12",
+      "parent": "1",
+      "src": "    finally",
+      "next": "12"
+    },
+    "10": {
+      "method": "expression",
+      "ln": "10",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 4
+        }
+      ],
+      "parent": "9",
+      "src": "        d = 4",
+      "next": "11"
+    },
+    "11": {
+      "method": "return",
+      "ln": "11",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "d"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "9",
+      "src": "        return d + a"
+    },
+    "12": {
+      "method": "return",
+      "ln": "12",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var10.story
+++ b/tests/e2e/return_local_var10.story
@@ -1,0 +1,12 @@
+function foo returns int
+    a = 1
+    try
+        b = 2
+        return b + a
+    catch
+        c = 3
+        return c + a
+    finally
+        d = 4
+        return d + a
+    return a

--- a/tests/e2e/return_local_var11.json
+++ b/tests/e2e/return_local_var11.json
@@ -1,0 +1,289 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "try",
+      "ln": "3",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "4",
+      "exit": "14",
+      "parent": "1",
+      "src": "    try",
+      "next": "14"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "try",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "16",
+      "enter": "6",
+      "exit": "8",
+      "parent": "3",
+      "src": "        try",
+      "next": "8"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "5",
+      "src": "            c = 3",
+      "next": "7"
+    },
+    "7": {
+      "method": "return",
+      "ln": "7",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "c"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "5",
+      "src": "            return c + b + a"
+    },
+    "8": {
+      "method": "catch",
+      "ln": "8",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "9",
+      "exit": "11",
+      "parent": "3",
+      "src": "        catch",
+      "next": "11"
+    },
+    "9": {
+      "method": "expression",
+      "ln": "9",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 4
+        }
+      ],
+      "parent": "8",
+      "src": "            d = 4",
+      "next": "10"
+    },
+    "10": {
+      "method": "return",
+      "ln": "10",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "d"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "8",
+      "src": "            return d + b + a"
+    },
+    "11": {
+      "method": "finally",
+      "ln": "11",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "12",
+      "exit": "14",
+      "parent": "3",
+      "src": "        finally"
+    },
+    "12": {
+      "method": "expression",
+      "ln": "12",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "e"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 5
+        }
+      ],
+      "parent": "11",
+      "src": "            e = 5",
+      "next": "13"
+    },
+    "13": {
+      "method": "return",
+      "ln": "13",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "e"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "11",
+      "src": "            return e + b + a"
+    },
+    "14": {
+      "method": "return",
+      "ln": "14",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var11.story
+++ b/tests/e2e/return_local_var11.story
@@ -1,0 +1,14 @@
+function foo returns int
+    a = 1
+    try
+        b = 2
+        try
+            c = 3
+            return c + b + a
+        catch
+            d = 4
+            return d + b + a
+        finally
+            e = 5
+            return e + b + a
+    return a

--- a/tests/e2e/return_local_var12.json
+++ b/tests/e2e/return_local_var12.json
@@ -1,0 +1,316 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "try",
+      "ln": "3",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "4",
+      "exit": "5",
+      "parent": "1",
+      "src": "    try",
+      "next": "5"
+    },
+    "4": {
+      "method": "return",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return a"
+    },
+    "5": {
+      "method": "catch",
+      "ln": "5",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "6",
+      "exit": "16",
+      "parent": "1",
+      "src": "    catch",
+      "next": "16"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "5",
+      "src": "        b = 2",
+      "next": "7"
+    },
+    "7": {
+      "method": "try",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "16",
+      "enter": "8",
+      "exit": "10",
+      "parent": "5",
+      "src": "        try",
+      "next": "10"
+    },
+    "8": {
+      "method": "expression",
+      "ln": "8",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "7",
+      "src": "            c = 3",
+      "next": "9"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "c"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "7",
+      "src": "            return c + b + a"
+    },
+    "10": {
+      "method": "catch",
+      "ln": "10",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "11",
+      "exit": "13",
+      "parent": "5",
+      "src": "        catch",
+      "next": "13"
+    },
+    "11": {
+      "method": "expression",
+      "ln": "11",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 4
+        }
+      ],
+      "parent": "10",
+      "src": "            d = 4",
+      "next": "12"
+    },
+    "12": {
+      "method": "return",
+      "ln": "12",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "d"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "10",
+      "src": "            return d + b + a"
+    },
+    "13": {
+      "method": "finally",
+      "ln": "13",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "14",
+      "exit": "16",
+      "parent": "5",
+      "src": "        finally"
+    },
+    "14": {
+      "method": "expression",
+      "ln": "14",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "e"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 5
+        }
+      ],
+      "parent": "13",
+      "src": "            e = 5",
+      "next": "15"
+    },
+    "15": {
+      "method": "return",
+      "ln": "15",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "e"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "13",
+      "src": "            return e + b + a"
+    },
+    "16": {
+      "method": "return",
+      "ln": "16",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var12.story
+++ b/tests/e2e/return_local_var12.story
@@ -1,0 +1,16 @@
+function foo returns int
+    a = 1
+    try
+        return a
+    catch
+        b = 2
+        try
+            c = 3
+            return c + b + a
+        catch
+            d = 4
+            return d + b + a
+        finally
+            e = 5
+            return e + b + a
+    return a

--- a/tests/e2e/return_local_var13.json
+++ b/tests/e2e/return_local_var13.json
@@ -1,0 +1,316 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "try",
+      "ln": "3",
+      "col_start": "5",
+      "col_end": "12",
+      "enter": "4",
+      "exit": "5",
+      "parent": "1",
+      "src": "    try",
+      "next": "5"
+    },
+    "4": {
+      "method": "return",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return a"
+    },
+    "5": {
+      "method": "finally",
+      "ln": "5",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "6",
+      "exit": "16",
+      "parent": "1",
+      "src": "    finally",
+      "next": "16"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "5",
+      "src": "        b = 2",
+      "next": "7"
+    },
+    "7": {
+      "method": "try",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "16",
+      "enter": "8",
+      "exit": "10",
+      "parent": "5",
+      "src": "        try",
+      "next": "10"
+    },
+    "8": {
+      "method": "expression",
+      "ln": "8",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "7",
+      "src": "            c = 3",
+      "next": "9"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "c"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "7",
+      "src": "            return c + b + a"
+    },
+    "10": {
+      "method": "catch",
+      "ln": "10",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "11",
+      "exit": "13",
+      "parent": "5",
+      "src": "        catch",
+      "next": "13"
+    },
+    "11": {
+      "method": "expression",
+      "ln": "11",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 4
+        }
+      ],
+      "parent": "10",
+      "src": "            d = 4",
+      "next": "12"
+    },
+    "12": {
+      "method": "return",
+      "ln": "12",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "d"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "10",
+      "src": "            return d + b + a"
+    },
+    "13": {
+      "method": "finally",
+      "ln": "13",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "14",
+      "exit": "16",
+      "parent": "5",
+      "src": "        finally"
+    },
+    "14": {
+      "method": "expression",
+      "ln": "14",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "e"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 5
+        }
+      ],
+      "parent": "13",
+      "src": "            e = 5",
+      "next": "15"
+    },
+    "15": {
+      "method": "return",
+      "ln": "15",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "e"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "13",
+      "src": "            return e + b + a"
+    },
+    "16": {
+      "method": "return",
+      "ln": "16",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var13.story
+++ b/tests/e2e/return_local_var13.story
@@ -1,0 +1,16 @@
+function foo returns int
+    a = 1
+    try
+        return a
+    finally
+        b = 2
+        try
+            c = 3
+            return c + b + a
+        catch
+            d = 4
+            return d + b + a
+        finally
+            e = 5
+            return e + b + a
+    return a

--- a/tests/e2e/return_local_var14.json
+++ b/tests/e2e/return_local_var14.json
@@ -1,0 +1,340 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "if",
+      "ln": "3",
+      "col_start": "8",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "4",
+      "exit": "5",
+      "parent": "1",
+      "src": "    if true",
+      "next": "5"
+    },
+    "4": {
+      "method": "return",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return a"
+    },
+    "5": {
+      "method": "elif",
+      "ln": "5",
+      "col_start": "13",
+      "col_end": "10",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "6",
+      "exit": "16",
+      "parent": "1",
+      "src": "    else if true",
+      "next": "16"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "5",
+      "src": "        b = 2",
+      "next": "7"
+    },
+    "7": {
+      "method": "if",
+      "ln": "7",
+      "col_start": "12",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "8",
+      "exit": "10",
+      "parent": "5",
+      "src": "        if true",
+      "next": "10"
+    },
+    "8": {
+      "method": "expression",
+      "ln": "8",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "7",
+      "src": "            c = 3",
+      "next": "9"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "c"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "7",
+      "src": "            return c + b + a"
+    },
+    "10": {
+      "method": "elif",
+      "ln": "10",
+      "col_start": "17",
+      "col_end": "14",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "11",
+      "exit": "13",
+      "parent": "5",
+      "src": "        else if true",
+      "next": "13"
+    },
+    "11": {
+      "method": "expression",
+      "ln": "11",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 4
+        }
+      ],
+      "parent": "10",
+      "src": "            d = 4",
+      "next": "12"
+    },
+    "12": {
+      "method": "return",
+      "ln": "12",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "d"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "10",
+      "src": "            return d + b + a"
+    },
+    "13": {
+      "method": "else",
+      "ln": "13",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "14",
+      "exit": "16",
+      "parent": "5",
+      "src": "        else"
+    },
+    "14": {
+      "method": "expression",
+      "ln": "14",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "e"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 5
+        }
+      ],
+      "parent": "13",
+      "src": "            e = 5",
+      "next": "15"
+    },
+    "15": {
+      "method": "return",
+      "ln": "15",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "e"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "13",
+      "src": "            return e + b + a"
+    },
+    "16": {
+      "method": "return",
+      "ln": "16",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var14.story
+++ b/tests/e2e/return_local_var14.story
@@ -1,0 +1,16 @@
+function foo returns int
+    a = 1
+    if true
+        return a
+    else if true
+        b = 2
+        if true
+            c = 3
+            return c + b + a
+        else if true
+            d = 4
+            return d + b + a
+        else
+            e = 5
+            return e + b + a
+    return a

--- a/tests/e2e/return_local_var15.json
+++ b/tests/e2e/return_local_var15.json
@@ -1,0 +1,334 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "if",
+      "ln": "3",
+      "col_start": "8",
+      "col_end": "9",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "4",
+      "exit": "5",
+      "parent": "1",
+      "src": "    if true",
+      "next": "5"
+    },
+    "4": {
+      "method": "return",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return a"
+    },
+    "5": {
+      "method": "else",
+      "ln": "5",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "6",
+      "exit": "16",
+      "parent": "1",
+      "src": "    else",
+      "next": "16"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "5",
+      "src": "        b = 2",
+      "next": "7"
+    },
+    "7": {
+      "method": "if",
+      "ln": "7",
+      "col_start": "12",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "8",
+      "exit": "10",
+      "parent": "5",
+      "src": "        if true",
+      "next": "10"
+    },
+    "8": {
+      "method": "expression",
+      "ln": "8",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "7",
+      "src": "            c = 3",
+      "next": "9"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "c"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "7",
+      "src": "            return c + b + a"
+    },
+    "10": {
+      "method": "elif",
+      "ln": "10",
+      "col_start": "17",
+      "col_end": "14",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "11",
+      "exit": "13",
+      "parent": "5",
+      "src": "        else if true",
+      "next": "13"
+    },
+    "11": {
+      "method": "expression",
+      "ln": "11",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 4
+        }
+      ],
+      "parent": "10",
+      "src": "            d = 4",
+      "next": "12"
+    },
+    "12": {
+      "method": "return",
+      "ln": "12",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "d"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "10",
+      "src": "            return d + b + a"
+    },
+    "13": {
+      "method": "else",
+      "ln": "13",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "14",
+      "exit": "16",
+      "parent": "5",
+      "src": "        else"
+    },
+    "14": {
+      "method": "expression",
+      "ln": "14",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "e"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 5
+        }
+      ],
+      "parent": "13",
+      "src": "            e = 5",
+      "next": "15"
+    },
+    "15": {
+      "method": "return",
+      "ln": "15",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "e"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "13",
+      "src": "            return e + b + a"
+    },
+    "16": {
+      "method": "return",
+      "ln": "16",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var15.story
+++ b/tests/e2e/return_local_var15.story
@@ -1,0 +1,16 @@
+function foo returns int
+    a = 1
+    if true
+        return a
+    else
+        b = 2
+        if true
+            c = 3
+            return c + b + a
+        else if true
+            d = 4
+            return d + b + a
+        else
+            e = 5
+            return e + b + a
+    return a

--- a/tests/e2e/return_local_var16.json
+++ b/tests/e2e/return_local_var16.json
@@ -1,0 +1,143 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "9",
+      "output": [
+        "int"
+      ],
+      "function": "factorial",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "n",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "int"
+          }
+        }
+      ],
+      "enter": "2",
+      "src": "function factorial n: int returns int"
+    },
+    "2": {
+      "method": "if",
+      "ln": "2",
+      "col_start": "8",
+      "col_end": "9",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "equal",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "n"
+              ]
+            },
+            {
+              "$OBJECT": "int",
+              "int": 1
+            }
+          ]
+        }
+      ],
+      "enter": "3",
+      "exit": "4",
+      "parent": "1",
+      "src": "    if n == 1",
+      "next": "4"
+    },
+    "3": {
+      "method": "return",
+      "ln": "3",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "2",
+      "src": "        return 1"
+    },
+    "4": {
+      "method": "else",
+      "ln": "4",
+      "col_start": "5",
+      "enter": "5.1",
+      "parent": "1",
+      "src": "    else"
+    },
+    "5.1": {
+      "method": "call",
+      "ln": "5.1",
+      "col_start": "20",
+      "col_end": "31",
+      "name": [
+        "__p-5.1"
+      ],
+      "function": "factorial",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "n",
+          "arg": {
+            "$OBJECT": "expression",
+            "expression": "subtraction",
+            "values": [
+              {
+                "$OBJECT": "path",
+                "paths": [
+                  "n"
+                ]
+              },
+              {
+                "$OBJECT": "int",
+                "int": 1
+              }
+            ]
+          }
+        }
+      ],
+      "parent": "4",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "multiplication",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "n"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "__p-5.1"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "4",
+      "src": "        return n * factorial(n: n - 1)"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "factorial": "1"
+  }
+}

--- a/tests/e2e/return_local_var16.story
+++ b/tests/e2e/return_local_var16.story
@@ -1,0 +1,5 @@
+function factorial n: int returns int
+    if n == 1
+        return 1
+    else
+        return n * factorial(n: n - 1)

--- a/tests/e2e/return_local_var2.json
+++ b/tests/e2e/return_local_var2.json
@@ -1,0 +1,193 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "if",
+      "ln": "3",
+      "col_start": "8",
+      "col_end": "9",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "4",
+      "exit": "6",
+      "parent": "1",
+      "src": "    if true",
+      "next": "6"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 1",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return b"
+    },
+    "6": {
+      "method": "elif",
+      "ln": "6",
+      "col_start": "13",
+      "col_end": "15",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "equal",
+          "values": [
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 2
+            }
+          ]
+        }
+      ],
+      "enter": "7",
+      "exit": "8",
+      "parent": "1",
+      "src": "    else if 1 == 2",
+      "next": "8"
+    },
+    "7": {
+      "method": "return",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "6",
+      "src": "        return a"
+    },
+    "8": {
+      "method": "else",
+      "ln": "8",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "9",
+      "exit": "11",
+      "parent": "1",
+      "src": "    else",
+      "next": "11"
+    },
+    "9": {
+      "method": "expression",
+      "ln": "9",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "8",
+      "src": "        c = 3",
+      "next": "10"
+    },
+    "10": {
+      "method": "return",
+      "ln": "10",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "c"
+          ]
+        }
+      ],
+      "parent": "8",
+      "src": "        return c"
+    },
+    "11": {
+      "method": "return",
+      "ln": "11",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var2.story
+++ b/tests/e2e/return_local_var2.story
@@ -1,0 +1,11 @@
+function foo returns int
+    a = 1
+    if true
+        b = 1
+        return b
+    else if 1 == 2
+        return a
+    else
+        c = 3
+        return c
+    return a

--- a/tests/e2e/return_local_var3.json
+++ b/tests/e2e/return_local_var3.json
@@ -1,0 +1,166 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "if",
+      "ln": "3",
+      "col_start": "8",
+      "col_end": "14",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "4",
+      "exit": "6",
+      "parent": "1",
+      "src": "    if true",
+      "next": "6"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return b"
+    },
+    "6": {
+      "method": "elif",
+      "ln": "6",
+      "col_start": "13",
+      "col_end": "10",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "equal",
+          "values": [
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 2
+            }
+          ]
+        }
+      ],
+      "enter": "7",
+      "exit": "9",
+      "parent": "1",
+      "src": "    else if 1 == 2",
+      "next": "9"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "6",
+      "src": "        c = 3",
+      "next": "8"
+    },
+    "8": {
+      "method": "return",
+      "ln": "8",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "c"
+          ]
+        }
+      ],
+      "parent": "6",
+      "src": "        return c"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var3.story
+++ b/tests/e2e/return_local_var3.story
@@ -1,0 +1,9 @@
+function foo returns int
+    a = 1
+    if true
+        b = 2
+        return b
+    else if 1 == 2
+        c = 3
+        return c
+    return a

--- a/tests/e2e/return_local_var4.json
+++ b/tests/e2e/return_local_var4.json
@@ -1,0 +1,150 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "if",
+      "ln": "3",
+      "col_start": "8",
+      "col_end": "9",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "4",
+      "exit": "6",
+      "parent": "1",
+      "src": "    if true",
+      "next": "6"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return b"
+    },
+    "6": {
+      "method": "else",
+      "ln": "6",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "7",
+      "exit": "9",
+      "parent": "1",
+      "src": "    else",
+      "next": "9"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "6",
+      "src": "        c = 3",
+      "next": "8"
+    },
+    "8": {
+      "method": "return",
+      "ln": "8",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "c"
+          ]
+        }
+      ],
+      "parent": "6",
+      "src": "        return c"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var4.story
+++ b/tests/e2e/return_local_var4.story
@@ -1,0 +1,9 @@
+function foo returns int
+    a = 1
+    if true
+        b = 2
+        return b
+    else
+        c = 3
+        return c
+    return a

--- a/tests/e2e/return_local_var5.json
+++ b/tests/e2e/return_local_var5.json
@@ -1,0 +1,190 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "if",
+      "ln": "3",
+      "col_start": "8",
+      "col_end": "14",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "4",
+      "exit": "6",
+      "parent": "1",
+      "src": "    if true",
+      "next": "6"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "b"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return a + b"
+    },
+    "6": {
+      "method": "elif",
+      "ln": "6",
+      "col_start": "13",
+      "col_end": "10",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "equal",
+          "values": [
+            {
+              "$OBJECT": "int",
+              "int": 1
+            },
+            {
+              "$OBJECT": "int",
+              "int": 2
+            }
+          ]
+        }
+      ],
+      "enter": "7",
+      "exit": "9",
+      "parent": "1",
+      "src": "    else if 1 == 2",
+      "next": "9"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "6",
+      "src": "        c = 3",
+      "next": "8"
+    },
+    "8": {
+      "method": "return",
+      "ln": "8",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "c"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "6",
+      "src": "        return a + c"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var5.story
+++ b/tests/e2e/return_local_var5.story
@@ -1,0 +1,9 @@
+function foo returns int
+    a = 1
+    if true
+        b = 2
+        return a + b
+    else if 1 == 2
+        c = 3
+        return a + c
+    return a

--- a/tests/e2e/return_local_var6.json
+++ b/tests/e2e/return_local_var6.json
@@ -1,0 +1,307 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "if",
+      "ln": "3",
+      "col_start": "8",
+      "col_end": "10",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "4",
+      "exit": "14",
+      "parent": "1",
+      "src": "    if true",
+      "next": "14"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "if",
+      "ln": "5",
+      "col_start": "12",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "6",
+      "exit": "8",
+      "parent": "3",
+      "src": "        if true",
+      "next": "8"
+    },
+    "6": {
+      "method": "expression",
+      "ln": "6",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "5",
+      "src": "            c = 3",
+      "next": "7"
+    },
+    "7": {
+      "method": "return",
+      "ln": "7",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "c"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "5",
+      "src": "            return c + b + a"
+    },
+    "8": {
+      "method": "elif",
+      "ln": "8",
+      "col_start": "17",
+      "col_end": "14",
+      "args": [
+        {
+          "$OBJECT": "boolean",
+          "boolean": true
+        }
+      ],
+      "enter": "9",
+      "exit": "11",
+      "parent": "3",
+      "src": "        else if true",
+      "next": "11"
+    },
+    "9": {
+      "method": "expression",
+      "ln": "9",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "d"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 4
+        }
+      ],
+      "parent": "8",
+      "src": "            d = 4",
+      "next": "10"
+    },
+    "10": {
+      "method": "return",
+      "ln": "10",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "d"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "8",
+      "src": "            return d + b + a"
+    },
+    "11": {
+      "method": "else",
+      "ln": "11",
+      "col_start": "9",
+      "col_end": "14",
+      "enter": "12",
+      "exit": "14",
+      "parent": "3",
+      "src": "        else"
+    },
+    "12": {
+      "method": "expression",
+      "ln": "12",
+      "col_start": "13",
+      "col_end": "16",
+      "name": [
+        "e"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 5
+        }
+      ],
+      "parent": "11",
+      "src": "            e = 5",
+      "next": "13"
+    },
+    "13": {
+      "method": "return",
+      "ln": "13",
+      "col_start": "13",
+      "col_end": "21",
+      "args": [
+        {
+          "$OBJECT": "expression",
+          "expression": "sum",
+          "values": [
+            {
+              "$OBJECT": "expression",
+              "expression": "sum",
+              "values": [
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "e"
+                  ]
+                },
+                {
+                  "$OBJECT": "path",
+                  "paths": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "parent": "11",
+      "src": "            return e + b + a"
+    },
+    "14": {
+      "method": "return",
+      "ln": "14",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var6.story
+++ b/tests/e2e/return_local_var6.story
@@ -1,0 +1,14 @@
+function foo returns int
+    a = 1
+    if true
+        b = 2
+        if true
+            c = 3
+            return c + b + a
+        else if true
+            d = 4
+            return d + b + a
+        else
+            e = 5
+            return e + b + a
+    return a

--- a/tests/e2e/return_local_var7.json
+++ b/tests/e2e/return_local_var7.json
@@ -1,0 +1,99 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "try",
+      "ln": "3",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "4",
+      "exit": "6",
+      "parent": "1",
+      "src": "    try",
+      "next": "6"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return b"
+    },
+    "6": {
+      "method": "return",
+      "ln": "6",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var7.story
+++ b/tests/e2e/return_local_var7.story
@@ -1,0 +1,6 @@
+function foo returns int
+    a = 1
+    try
+        b = 2
+        return b
+    return a

--- a/tests/e2e/return_local_var8.json
+++ b/tests/e2e/return_local_var8.json
@@ -1,0 +1,144 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "try",
+      "ln": "3",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "4",
+      "exit": "6",
+      "parent": "1",
+      "src": "    try",
+      "next": "6"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return b"
+    },
+    "6": {
+      "method": "catch",
+      "ln": "6",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "7",
+      "exit": "9",
+      "parent": "1",
+      "src": "    catch",
+      "next": "9"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "6",
+      "src": "        c = 3",
+      "next": "8"
+    },
+    "8": {
+      "method": "return",
+      "ln": "8",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "c"
+          ]
+        }
+      ],
+      "parent": "6",
+      "src": "        return c"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var8.story
+++ b/tests/e2e/return_local_var8.story
@@ -1,0 +1,9 @@
+function foo returns int
+    a = 1
+    try
+        b = 2
+        return b
+    catch
+        c = 3
+        return c
+    return a

--- a/tests/e2e/return_local_var9.json
+++ b/tests/e2e/return_local_var9.json
@@ -1,0 +1,144 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "6",
+      "output": [
+        "int"
+      ],
+      "function": "foo",
+      "enter": "2",
+      "src": "function foo returns int"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "8",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 1
+        }
+      ],
+      "parent": "1",
+      "src": "    a = 1",
+      "next": "3"
+    },
+    "3": {
+      "method": "try",
+      "ln": "3",
+      "col_start": "5",
+      "col_end": "12",
+      "enter": "4",
+      "exit": "6",
+      "parent": "1",
+      "src": "    try",
+      "next": "6"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 2
+        }
+      ],
+      "parent": "3",
+      "src": "        b = 2",
+      "next": "5"
+    },
+    "5": {
+      "method": "return",
+      "ln": "5",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b"
+          ]
+        }
+      ],
+      "parent": "3",
+      "src": "        return b"
+    },
+    "6": {
+      "method": "finally",
+      "ln": "6",
+      "col_start": "5",
+      "col_end": "10",
+      "enter": "7",
+      "exit": "9",
+      "parent": "1",
+      "src": "    finally",
+      "next": "9"
+    },
+    "7": {
+      "method": "expression",
+      "ln": "7",
+      "col_start": "9",
+      "col_end": "12",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 3
+        }
+      ],
+      "parent": "6",
+      "src": "        c = 3",
+      "next": "8"
+    },
+    "8": {
+      "method": "return",
+      "ln": "8",
+      "col_start": "9",
+      "col_end": "17",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "c"
+          ]
+        }
+      ],
+      "parent": "6",
+      "src": "        return c"
+    },
+    "9": {
+      "method": "return",
+      "ln": "9",
+      "col_start": "5",
+      "col_end": "13",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "a"
+          ]
+        }
+      ],
+      "parent": "1",
+      "src": "    return a"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/return_local_var9.story
+++ b/tests/e2e/return_local_var9.story
@@ -1,0 +1,9 @@
+function foo returns int
+    a = 1
+    try
+        b = 2
+        return b
+    finally
+        c = 3
+        return c
+    return a


### PR DESCRIPTION
This fixes the bugs relating to returning from functions where
the return statements with local variables errored out since
info about local variables defined inside a new scope inside of a
function scope was getting lost.
Example cases like below used to error out:
```
	function foo return int
            a = 1
            if true
                b = 1
                return b
            return a
```

Above used to error out saying `b` isn't defined. We start
supporting/fix the above use case.

Fixes: #1183 
Fixes: #1259 