### PR TITLE
feat(setup.py): dependencies are no longer hard pinned

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,11 @@ classifiers = [
 ]
 
 requirements = [
-    'bom-open==0.4.0',
-    'click==7.0',
+    'bom-open~=0.4.0',
+    'click~=7.0',
+    'click-aliases~=1.0',
     'lark-parser==0.7.2',
-    'click-aliases==1.0.1',
-    'story-hub==0.1.9'
+    'story-hub~=0.1.10',
 ]
 
 extras = [


### PR DESCRIPTION
This allows dependents of Storyscript more freedom. They should still pin the versions of all dependencies for a release, s.t. each release is predictable.