### PR TITLE
chore(packaging): Add LICENSE, tests, etc to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include README.md
+recursive-include docs *.rst
+# This includes *everything*
+# Be sure the sdist build env is clean
+graft tests


### PR DESCRIPTION
The sdist needs to have a LICENSE, and docs and tests
are used by packagers.
