### PR TITLE
feat(Types): prevent assigning null to objects

### DIFF
--- a/storyscript/compiler/semantics/types/Types.py
+++ b/storyscript/compiler/semantics/types/Types.py
@@ -622,6 +622,9 @@ class ObjectType(BaseType):
     def hashable(self):
         return False
 
+    def can_be_assigned(self, other):
+        return other.implicit_to(self)
+
     @singleton
     def instance():
         """

--- a/storyscript/compiler/semantics/types/Types.py
+++ b/storyscript/compiler/semantics/types/Types.py
@@ -115,8 +115,6 @@ class BaseType:
         return implicit_cast(self, other)
 
     def can_be_assigned(self, other):
-        if other == AnyType.instance():
-            return None
         if other == NullType.instance():
             return self
         return other.implicit_to(self)

--- a/tests/e2e/object_assign_any.error
+++ b/tests/e2e/object_assign_any.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 3, column 5
+
+3|        server = a
+          ^^^^^^^^^^
+
+E0100: Can't assign `any` to `Object`

--- a/tests/e2e/object_assign_any.story
+++ b/tests/e2e/object_assign_any.story
@@ -1,0 +1,3 @@
+a = 1 to any
+http server
+    server = a

--- a/tests/e2e/object_assign_boolean.error
+++ b/tests/e2e/object_assign_boolean.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = true
+          ^^^^^^^^^^^^^
+
+E0100: Can't assign `boolean` to `Object`

--- a/tests/e2e/object_assign_boolean.story
+++ b/tests/e2e/object_assign_boolean.story
@@ -1,0 +1,2 @@
+http server
+    server = true

--- a/tests/e2e/object_assign_float.error
+++ b/tests/e2e/object_assign_float.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = 1.5
+          ^^^^^^^^^^^^
+
+E0100: Can't assign `float` to `Object`

--- a/tests/e2e/object_assign_float.story
+++ b/tests/e2e/object_assign_float.story
@@ -1,0 +1,2 @@
+http server
+    server = 1.5

--- a/tests/e2e/object_assign_int.error
+++ b/tests/e2e/object_assign_int.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = 1
+          ^^^^^^^^^^
+
+E0100: Can't assign `int` to `Object`

--- a/tests/e2e/object_assign_int.story
+++ b/tests/e2e/object_assign_int.story
@@ -1,0 +1,2 @@
+http server
+    server = 1

--- a/tests/e2e/object_assign_list.error
+++ b/tests/e2e/object_assign_list.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = [1]
+          ^^^^^^^^^^^^
+
+E0100: Can't assign `List[int]` to `Object`

--- a/tests/e2e/object_assign_list.story
+++ b/tests/e2e/object_assign_list.story
@@ -1,0 +1,2 @@
+http server
+    server = [1]

--- a/tests/e2e/object_assign_map.error
+++ b/tests/e2e/object_assign_map.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = {"a": "b"}
+          ^^^^^^^^^^^^^^^^^^
+
+E0100: Can't assign `Map[string,string]` to `Object`

--- a/tests/e2e/object_assign_map.story
+++ b/tests/e2e/object_assign_map.story
@@ -1,0 +1,2 @@
+http server
+    server = {"a": "b"}

--- a/tests/e2e/object_assign_null.error
+++ b/tests/e2e/object_assign_null.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = null
+          ^^^^^^^^^^^^^
+
+E0100: Can't assign `null` to `Object`

--- a/tests/e2e/object_assign_null.story
+++ b/tests/e2e/object_assign_null.story
@@ -1,0 +1,2 @@
+http server
+    server = null

--- a/tests/e2e/object_assign_null2.error
+++ b/tests/e2e/object_assign_null2.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 3, column 9
+
+3|            r = null
+              ^^^^^^^^
+
+E0100: Can't assign `null` to `Object`

--- a/tests/e2e/object_assign_null2.story
+++ b/tests/e2e/object_assign_null2.story
@@ -1,0 +1,3 @@
+http server as server
+    when server listen path: "/" as r
+        r = null

--- a/tests/e2e/object_assign_null3.error
+++ b/tests/e2e/object_assign_null3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        a = null
+          ^^^^^^^^
+
+E0100: Can't assign `null` to `Object`

--- a/tests/e2e/object_assign_null3.story
+++ b/tests/e2e/object_assign_null3.story
@@ -1,0 +1,4 @@
+function foo a: object
+    a = null
+
+foo(a: app)

--- a/tests/e2e/object_assign_null4.error
+++ b/tests/e2e/object_assign_null4.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        a = null
+          ^^^^^^^^
+
+E0100: Can't assign `null` to `Object`

--- a/tests/e2e/object_assign_null4.story
+++ b/tests/e2e/object_assign_null4.story
@@ -1,0 +1,4 @@
+function foo a: object
+    a = null
+
+foo(a: (gmaps geocode address: "foobar"))

--- a/tests/e2e/object_assign_regexp.error
+++ b/tests/e2e/object_assign_regexp.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = /re/
+          ^^^^^^^^^^^^^
+
+E0100: Can't assign `regexp` to `Object`

--- a/tests/e2e/object_assign_regexp.story
+++ b/tests/e2e/object_assign_regexp.story
@@ -1,0 +1,2 @@
+http server
+    server = /re/

--- a/tests/e2e/object_assign_string.error
+++ b/tests/e2e/object_assign_string.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = "foo"
+          ^^^^^^^^^^^^^^
+
+E0100: Can't assign `string` to `Object`

--- a/tests/e2e/object_assign_string.story
+++ b/tests/e2e/object_assign_string.story
@@ -1,0 +1,2 @@
+http server
+    server = "foo"

--- a/tests/e2e/object_assign_time.error
+++ b/tests/e2e/object_assign_time.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 5
+
+2|        server = 1s
+          ^^^^^^^^^^^
+
+E0100: Can't assign `time` to `Object`

--- a/tests/e2e/object_assign_time.story
+++ b/tests/e2e/object_assign_time.story
@@ -1,0 +1,2 @@
+http server
+    server = 1s


### PR DESCRIPTION
First commit:
chore(Types): remove special case for AnyType
    
    We can remove this since we migrated AnyType to behave like
    unknown and hence any can no longer be assigned to anything
    but any. Therefore AnyType.can_be_assigned will always return
    None which the special case was added to do before the migration
    of AnyType to behave like unknown.

Second commit:

feat(Types): prevent assigning null to objects

This one just adds the restriction with a few e2e tests.

Fixes: #1257 