### PR TITLE
fix(Types): make null and any interoperability work

### DIFF
--- a/storyscript/ErrorCodes.py
+++ b/storyscript/ErrorCodes.py
@@ -306,6 +306,10 @@ class ErrorCodes:
         'Event based action expected but action `{action}` of service '
         '`{service}` found.'
     )
+    path_index_no_null = (
+        'E0158',
+        'Cannot use `null` in index'
+    )
 
     @staticmethod
     def is_error(error_name):

--- a/storyscript/compiler/semantics/PathResolver.py
+++ b/storyscript/compiler/semantics/PathResolver.py
@@ -38,6 +38,8 @@ class PathResolver:
             child = fragment.child(0)
             kind = IndexKind.INDEX
             if isinstance(child, Tree):
+                child.expect(child.data != 'null',
+                             'path_index_no_null')
                 if child.data == 'string':
                     type_ = StringType.instance()
                     value = child.child(0).value

--- a/storyscript/compiler/semantics/symbols/Symbols.py
+++ b/storyscript/compiler/semantics/symbols/Symbols.py
@@ -3,7 +3,7 @@ from storyhub.sdk.service.Output import Output as ServiceOutput
 
 from storyscript.compiler.semantics.types.Indexing import IndexKind
 from storyscript.compiler.semantics.types.Types import BaseType, MapType, \
-    ObjectType
+    NullType, ObjectType
 from storyscript.hub.TypeMappings import TypeMappings
 
 
@@ -134,6 +134,11 @@ class Symbol:
             assert isinstance(type_, BaseType)
 
         cur_type = symbol.type()
+        tree.expect(type_ != NullType.instance(),
+                    'type_index_incompatible',
+                    left=cur_type,
+                    name=name,
+                    right=type_)
         new_type = cur_type.index(type_, kind)
         if isinstance(cur_type, ObjectType) and new_type is not None:
             obj = new_type

--- a/storyscript/compiler/semantics/symbols/Symbols.py
+++ b/storyscript/compiler/semantics/symbols/Symbols.py
@@ -3,7 +3,7 @@ from storyhub.sdk.service.Output import Output as ServiceOutput
 
 from storyscript.compiler.semantics.types.Indexing import IndexKind
 from storyscript.compiler.semantics.types.Types import BaseType, MapType, \
-    NullType, ObjectType
+    ObjectType
 from storyscript.hub.TypeMappings import TypeMappings
 
 
@@ -134,11 +134,6 @@ class Symbol:
             assert isinstance(type_, BaseType)
 
         cur_type = symbol.type()
-        tree.expect(type_ != NullType.instance(),
-                    'type_index_incompatible',
-                    left=cur_type,
-                    name=name,
-                    right=type_)
         new_type = cur_type.index(type_, kind)
         if isinstance(cur_type, ObjectType) and new_type is not None:
             obj = new_type

--- a/storyscript/compiler/semantics/types/Types.py
+++ b/storyscript/compiler/semantics/types/Types.py
@@ -677,6 +677,8 @@ class NullType(BaseType):
         return None
 
     def implicit_to(self, other):
+        if other == AnyType.instance():
+            return other
         return None
 
     def explicit_from(self, other):

--- a/tests/e2e/null_any.json
+++ b/tests/e2e/null_any.json
@@ -1,0 +1,96 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "10",
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "any"
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4",
+      "src": "function foo a:any",
+      "next": "4"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "10",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "parent": "1",
+      "src": "    b = 0"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "1",
+      "col_end": "9",
+      "name": [
+        "a"
+      ],
+      "args": [
+        null
+      ],
+      "src": "a = null",
+      "next": "5.1"
+    },
+    "5.1": {
+      "method": "call",
+      "ln": "5.1",
+      "col_start": "1",
+      "col_end": "7",
+      "name": [
+        "__p-5.1"
+      ],
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "path",
+            "paths": [
+              "a"
+            ]
+          }
+        }
+      ],
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-5.1"
+          ]
+        }
+      ],
+      "src": "foo(:a)"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/null_any.story
+++ b/tests/e2e/null_any.story
@@ -1,0 +1,5 @@
+function foo a:any
+    b = 0
+
+a = null
+foo(:a)

--- a/tests/e2e/null_list_any.json
+++ b/tests/e2e/null_list_any.json
@@ -1,0 +1,120 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "10",
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "List",
+            "values": [
+              {
+                "$OBJECT": "type",
+                "type": "any"
+              }
+            ]
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4",
+      "src": "function foo a:List[any]",
+      "next": "4"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "10",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "parent": "1",
+      "src": "    b = 0"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "1",
+      "col_end": "11",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            null
+          ]
+        }
+      ],
+      "src": "a = [null]",
+      "next": "5.1"
+    },
+    "5.1": {
+      "method": "call",
+      "ln": "5.1",
+      "col_start": "1",
+      "col_end": "7",
+      "name": [
+        "__p-5.1"
+      ],
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type_cast",
+            "type": {
+              "$OBJECT": "type",
+              "type": "List",
+              "values": [
+                {
+                  "$OBJECT": "type",
+                  "type": "any"
+                }
+              ]
+            },
+            "value": {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          }
+        }
+      ],
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-5.1"
+          ]
+        }
+      ],
+      "src": "foo(:a)"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/null_list_any.story
+++ b/tests/e2e/null_list_any.story
@@ -1,0 +1,5 @@
+function foo a:List[any]
+    b = 0
+
+a = [null]
+foo(:a)

--- a/tests/e2e/null_list_any2.json
+++ b/tests/e2e/null_list_any2.json
@@ -1,0 +1,137 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "10",
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "List",
+            "values": [
+              {
+                "$OBJECT": "type",
+                "type": "List",
+                "values": [
+                  {
+                    "$OBJECT": "type",
+                    "type": "any"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4",
+      "src": "function foo a:List[List[any]]",
+      "next": "4"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "10",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "parent": "1",
+      "src": "    b = 0"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "1",
+      "col_end": "13",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "list",
+          "items": [
+            {
+              "$OBJECT": "list",
+              "items": [
+                null
+              ]
+            }
+          ]
+        }
+      ],
+      "src": "a = [[null]]",
+      "next": "5.1"
+    },
+    "5.1": {
+      "method": "call",
+      "ln": "5.1",
+      "col_start": "1",
+      "col_end": "7",
+      "name": [
+        "__p-5.1"
+      ],
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type_cast",
+            "type": {
+              "$OBJECT": "type",
+              "type": "List",
+              "values": [
+                {
+                  "$OBJECT": "type",
+                  "type": "List",
+                  "values": [
+                    {
+                      "$OBJECT": "type",
+                      "type": "any"
+                    }
+                  ]
+                }
+              ]
+            },
+            "value": {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          }
+        }
+      ],
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-5.1"
+          ]
+        }
+      ],
+      "src": "foo(:a)"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/null_list_any2.story
+++ b/tests/e2e/null_list_any2.story
@@ -1,0 +1,5 @@
+function foo a:List[List[any]]
+    b = 0
+
+a = [[null]]
+foo(:a)

--- a/tests/e2e/null_list_any3.error
+++ b/tests/e2e/null_list_any3.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 4, column 5
+
+4|    c = b[a]
+          ^^^
+
+E0104: `List[any]` can't be indexed with `a` of type `any`

--- a/tests/e2e/null_list_any3.story
+++ b/tests/e2e/null_list_any3.story
@@ -1,0 +1,4 @@
+# a = null
+b = [] to List[any]
+a = 1 to any
+c = b[a]

--- a/tests/e2e/null_map.error
+++ b/tests/e2e/null_map.error
@@ -1,6 +1,0 @@
-Error: syntax error in story at line 3, column 5
-
-3|    c = b[a]
-          ^^^
-
-E0104: `Map[any,any]` can't be indexed with `a` of type `null`

--- a/tests/e2e/null_map.json
+++ b/tests/e2e/null_map.json
@@ -1,0 +1,77 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "9",
+      "name": [
+        "a"
+      ],
+      "args": [
+        null
+      ],
+      "src": "a = null",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "22",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "type_cast",
+          "type": {
+            "$OBJECT": "type",
+            "type": "Map",
+            "values": [
+              {
+                "$OBJECT": "type",
+                "type": "any"
+              },
+              {
+                "$OBJECT": "type",
+                "type": "any"
+              }
+            ]
+          },
+          "value": {
+            "$OBJECT": "dict",
+            "items": []
+          }
+        }
+      ],
+      "src": "b = {} to Map[any,any]",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "col_start": "1",
+      "col_end": "8",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b",
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "src": "c = b[a]"
+    }
+  },
+  "entrypoint": "1"
+}

--- a/tests/e2e/null_map_any.json
+++ b/tests/e2e/null_map_any.json
@@ -1,0 +1,134 @@
+{
+  "tree": {
+    "1": {
+      "method": "function",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "10",
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type",
+            "type": "Map",
+            "values": [
+              {
+                "$OBJECT": "type",
+                "type": "any"
+              },
+              {
+                "$OBJECT": "type",
+                "type": "any"
+              }
+            ]
+          }
+        }
+      ],
+      "enter": "2",
+      "exit": "4",
+      "src": "function foo a:Map[any,any]",
+      "next": "4"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "5",
+      "col_end": "10",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "int",
+          "int": 0
+        }
+      ],
+      "parent": "1",
+      "src": "    b = 0"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "1",
+      "col_end": "15",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "dict",
+          "items": [
+            [
+              {
+                "$OBJECT": "string",
+                "string": "a"
+              },
+              null
+            ]
+          ]
+        }
+      ],
+      "src": "a = {\"a\": null}",
+      "next": "5.1"
+    },
+    "5.1": {
+      "method": "call",
+      "ln": "5.1",
+      "col_start": "1",
+      "col_end": "7",
+      "name": [
+        "__p-5.1"
+      ],
+      "function": "foo",
+      "args": [
+        {
+          "$OBJECT": "arg",
+          "name": "a",
+          "arg": {
+            "$OBJECT": "type_cast",
+            "type": {
+              "$OBJECT": "type",
+              "type": "Map",
+              "values": [
+                {
+                  "$OBJECT": "type",
+                  "type": "any"
+                },
+                {
+                  "$OBJECT": "type",
+                  "type": "any"
+                }
+              ]
+            },
+            "value": {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          }
+        }
+      ],
+      "next": "5"
+    },
+    "5": {
+      "method": "expression",
+      "ln": "5",
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "__p-5.1"
+          ]
+        }
+      ],
+      "src": "foo(:a)"
+    }
+  },
+  "entrypoint": "1",
+  "functions": {
+    "foo": "1"
+  }
+}

--- a/tests/e2e/null_map_any.story
+++ b/tests/e2e/null_map_any.story
@@ -1,0 +1,5 @@
+function foo a:Map[any,any]
+    b = 0
+
+a = {"a": null}
+foo(:a)

--- a/tests/e2e/null_map_any2.json
+++ b/tests/e2e/null_map_any2.json
@@ -1,0 +1,94 @@
+{
+  "tree": {
+    "1": {
+      "method": "expression",
+      "ln": "1",
+      "col_start": "1",
+      "col_end": "9",
+      "name": [
+        "a"
+      ],
+      "args": [
+        null
+      ],
+      "src": "a = null",
+      "next": "2"
+    },
+    "2": {
+      "method": "expression",
+      "ln": "2",
+      "col_start": "1",
+      "col_end": "22",
+      "name": [
+        "b"
+      ],
+      "args": [
+        {
+          "$OBJECT": "type_cast",
+          "type": {
+            "$OBJECT": "type",
+            "type": "Map",
+            "values": [
+              {
+                "$OBJECT": "type",
+                "type": "any"
+              },
+              {
+                "$OBJECT": "type",
+                "type": "any"
+              }
+            ]
+          },
+          "value": {
+            "$OBJECT": "dict",
+            "items": []
+          }
+        }
+      ],
+      "src": "b = {} to Map[any,any]",
+      "next": "3"
+    },
+    "3": {
+      "method": "expression",
+      "ln": "3",
+      "col_start": "1",
+      "col_end": "10",
+      "name": [
+        "a"
+      ],
+      "args": [
+        {
+          "$OBJECT": "string",
+          "string": "foo"
+        }
+      ],
+      "src": "a = \"foo\"",
+      "next": "4"
+    },
+    "4": {
+      "method": "expression",
+      "ln": "4",
+      "col_start": "1",
+      "col_end": "8",
+      "name": [
+        "c"
+      ],
+      "args": [
+        {
+          "$OBJECT": "path",
+          "paths": [
+            "b",
+            {
+              "$OBJECT": "path",
+              "paths": [
+                "a"
+              ]
+            }
+          ]
+        }
+      ],
+      "src": "c = b[a]"
+    }
+  },
+  "entrypoint": "1"
+}

--- a/tests/e2e/null_map_any2.story
+++ b/tests/e2e/null_map_any2.story
@@ -1,0 +1,4 @@
+a = null
+b = {} to Map[any,any]
+a = "foo"
+c = b[a]

--- a/tests/e2e/path_index_no_null.error
+++ b/tests/e2e/path_index_no_null.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 7
+
+2|    c = b[null]
+            ^^^^
+
+E0158: Cannot use `null` in index

--- a/tests/e2e/path_index_no_null.story
+++ b/tests/e2e/path_index_no_null.story
@@ -1,0 +1,2 @@
+b = {"foo": "bar"}
+c = b[null]


### PR DESCRIPTION
We make sure that `null` could be implicitly converted to `any`
so that it can be passed around in function arguments accepting
`any` as parameter.
Also I added another commit which prevents `null` being used in indexs. I believe we need this.
It stops things like
```
a = [1, 2]
a[null]
```

Fixes: #1276 