### PR TITLE
chore(TypeResolver): ban foreach to iterate over AnyType

### DIFF
--- a/storyscript/compiler/semantics/TypeResolver.py
+++ b/storyscript/compiler/semantics/TypeResolver.py
@@ -145,9 +145,9 @@ class TypeResolver(ScopeSelectiveVisitor):
             stmt.expect(nr_children > 0, 'foreach_output_required')
 
             iterable_types = output_type.output(nr_children)
-            stmt.output.expect(iterable_types is not None,
-                               'foreach_iterable_required',
-                               target=output_type)
+            stmt.base_expression.expect(iterable_types is not None,
+                                        'foreach_iterable_required',
+                                        target=output_type)
             stmt.output.expect(nr_children <= 2,
                                'foreach_output_children')
 

--- a/storyscript/compiler/semantics/types/Types.py
+++ b/storyscript/compiler/semantics/types/Types.py
@@ -711,14 +711,6 @@ class AnyType(BaseType):
         """
         return AnyType()
 
-    def output(self, n):
-        """
-        Output types of the AnyType.
-        """
-        if n == 1:
-            return AnyType.instance(),
-        return AnyType.instance(), AnyType.instance()
-
     def has_boolean(self):
         return False
 

--- a/tests/e2e/semantics/foreach_invalid2.error
+++ b/tests/e2e/semantics/foreach_invalid2.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 3, column 18
+Error: syntax error in story at line 3, column 9
 
 3|    foreach "foo" as elem
-                       ^^^^
+              ^^^^^
 
 E0106: `foreach` requires an iterable type, but `string` is not

--- a/tests/e2e/semantics/foreach_invalid6.error
+++ b/tests/e2e/semantics/foreach_invalid6.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 6, column 5
+Error: syntax error in story at line 5, column 5
 
-6|        c = k
+5|        c = k
           ^^^^^
 
 E0100: Can't assign `any` to `int`

--- a/tests/e2e/semantics/foreach_invalid6.story
+++ b/tests/e2e/semantics/foreach_invalid6.story
@@ -1,5 +1,4 @@
-b = {} to Map[any,any]
-a = b[0]
+a = {} to Map[any,any]
 c = 0
 
 foreach a as k

--- a/tests/e2e/semantics/foreach_invalid7.error
+++ b/tests/e2e/semantics/foreach_invalid7.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 8, column 5
+Error: syntax error in story at line 7, column 5
 
-8|        d = v
+7|        d = v
           ^^^^^
 
 E0100: Can't assign `any` to `int`

--- a/tests/e2e/semantics/foreach_invalid7.story
+++ b/tests/e2e/semantics/foreach_invalid7.story
@@ -1,6 +1,5 @@
-b = {} to Map[any,any]
-a = b[0]
-c = b[0]
+a = {} to Map[any,any]
+c = a[0]
 d = 0
 
 foreach a as k, v

--- a/tests/e2e/semantics/foreach_no_any.error
+++ b/tests/e2e/semantics/foreach_no_any.error
@@ -1,0 +1,6 @@
+Error: syntax error in story at line 2, column 14
+
+2|    foreach a as e
+                   ^
+
+E0106: `foreach` requires an iterable type, but `any` is not

--- a/tests/e2e/semantics/foreach_no_any.error
+++ b/tests/e2e/semantics/foreach_no_any.error
@@ -1,6 +1,6 @@
-Error: syntax error in story at line 2, column 14
+Error: syntax error in story at line 2, column 9
 
 2|    foreach a as e
-                   ^
+              ^
 
 E0106: `foreach` requires an iterable type, but `any` is not

--- a/tests/e2e/semantics/foreach_no_any.story
+++ b/tests/e2e/semantics/foreach_no_any.story
@@ -1,0 +1,3 @@
+a = 1 to any
+foreach a as e
+    c = e


### PR DESCRIPTION
We ban foreach to iterate over AnyType. In fact we only allow
it to iterate over MapType or ListType for the moment.

Fixes: #1300 