### PR TITLE
chore(setup): bump minimal version of Python to 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
 executors:
   python-default:
     docker:
-      - image: circleci/python:3.6.8
+      - image: circleci/python:3.7
 jobs:
     build:
         executor: python-default

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={"docs": extras, "stylecheck": ["black==19.10b0"],},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points={"console_scripts": ["storyscript=storyscript.Cli:Cli.main"]},
     use_scm_version=True,
     setup_requires=["setuptools_scm~=3.3",],


### PR DESCRIPTION
- Python 3.8 is out
- Storyscript is only intended to be used via the Studio and the runtime only supports >=3.7