### PR TITLE
chore(tests): fix test suite for the newest hub SDK

### DIFF
--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -11,25 +11,20 @@ from click import unstyle
 
 from pytest import fixture, mark
 
-from storyhub.sdk.ServiceWrapper import ServiceWrapper
-
 import storyscript.hub.Hub as StoryHub
 from storyscript.Api import Api
 from storyscript.App import _clean_dict
 
 from tests.e2e.utils.Features import parse_features
+from tests.e2e.utils.fixtures import hub, test_dir
 
-test_dir = path.dirname(path.realpath(__file__))
+
 # make the test_file paths relative, s.t. test paths are nice to read
 test_files = list(
     map(
         lambda e: path.relpath(e, test_dir),
         glob(path.join(test_dir, "**", "*.story"), recursive=True),
     )
-)
-
-hub_fixtures_file = path.join(
-    path.dirname(test_dir), "fixtures", "hub_fixture.json.fixed"
 )
 
 features = {"globals": True}
@@ -113,7 +108,6 @@ def run_test(story_path):
 
 @fixture
 def patched_storyhub(mocker, scope="module"):
-    hub = ServiceWrapper.from_json_file(hub_fixtures_file)
     mocker.patch.object(StoryHub, "StoryscriptHub", return_value=hub)
 
 

--- a/tests/e2e/utils/fixtures.py
+++ b/tests/e2e/utils/fixtures.py
@@ -1,0 +1,13 @@
+from os import path
+
+
+from storyhub.sdk.ServiceWrapper import ServiceWrapper
+
+
+test_dir = path.dirname(path.dirname(path.realpath(__file__)))
+
+
+fixture_dir = path.join(test_dir, "..", "fixtures")
+fixture_file = path.join(fixture_dir, "hub_fixture.json.fixed")
+
+hub = ServiceWrapper.from_json_file(fixture_file)

--- a/tests/integration/Api.py
+++ b/tests/integration/Api.py
@@ -39,7 +39,7 @@ def test_api_loads_with_hub():
     """
     Ensures Api.load functions return errors
     """
-    hub = ServiceWrapper(services=None)
+    hub = ServiceWrapper(services=[])
     story = Api.loads("http server", backend="semantic", hub=hub)
     e = story.errors()[0]
     assert (


### PR DESCRIPTION
Moving the fixture loading into a separate file isn't strictly necessary, but I thought it was loaded in another parts as well, so it's separated now.